### PR TITLE
Update meta org

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,152 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
-
 aliases:
+  sig-api-machinery-leads:
+    - lavalamp
+    - deads2k
+  sig-apps-leads:
+    - mattfarina
+    - prydonius
+    - kow3ns
+  sig-architecture-leads:
+    - bgrant0607
+    - jdumars
+  sig-auth-leads:
+    - ericchiang
+    - liggitt
+    - tallclair
+  sig-autoscaling-leads:
+    - mwielgus
+    - directxman12
+  sig-aws-leads:
+    - justinsb
+    - kris-nova
+    - countspongebob
+  sig-azure-leads:
+    - justaugustus
+    - shubheksha
+    - khenidak
+    - colemickens
+  sig-big-data-leads:
+    - foxish
+    - erikerlandson
+    - liyinan926
+  sig-cli-leads:
+    - soltysh
+    - pwittrock
+    - AdoHe
+  sig-cloud-provider-leads:
+    - andrewsykim
+    - hogepodge
+    - jagosan
+  sig-cluster-lifecycle-leads:
+    - lukemarsden
+    - roberthbailey
+    - luxas
+    - timothysc
+  sig-cluster-ops-leads:
+    - zehicle
+    - jdumars
+  sig-contributor-experience-leads:
+    - Phillels
+    - parispittman
+    - grodrigues3
+    - cblecker
+  sig-docs-leads:
+    - zacharysarah
+    - chenopis
+    - jaredbhatti
+  sig-gcp-leads:
+    - abgworrall
+  sig-ibmcloud-leads:
+    - khahmed
+    - rtheis
+    - spzala
+  sig-instrumentation-leads:
+    - piosz
+    - brancz
+  sig-multicluster-leads:
+    - csbell
+    - quinton-hoole
+  sig-network-leads:
+    - thockin
+    - dcbw
+    - caseydavenport
+  sig-node-leads:
+    - dchen1107
+    - derekwaynecarr
+  sig-openstack-leads:
+    - hogepodge
+    - dklyle
+    - rjmorse
+  sig-pm-leads:
+    - apsinha
+    - idvoretskyi
+    - calebamiles
+  sig-release-leads:
+    - jdumars
+    - calebamiles
+  sig-scalability-leads:
+    - wojtek-t
+    - countspongebob
+  sig-scheduling-leads:
+    - bsalamat
+    - k82cn
+  sig-service-catalog-leads:
+    - pmorie
+    - arschles
+    - vaikas-google
+    - duglin
+  sig-storage-leads:
+    - saad-ali
+    - childsb
+  sig-testing-leads:
+    - spiffxp
+    - fejta
+    - stevekuznetsov
+    - timothysc
+  sig-ui-leads:
+    - danielromlein
+    - floreks
+  sig-vmware-leads:
+    - frapposelli
+    - cantbewong
+  sig-windows-leads:
+    - michmike
+    - patricklang
+  wg-app-def-leads:
+    - ant31
+    - bryanl
+    - garethr
+  wg-apply-leads:
+    - lavalamp
+  wg-cluster-api-leads:
+    - kris-nova
+    - roberthbailey
+  wg-container-identity-leads:
+    - smarterclayton
+    - destijl
+  wg-iot-edge-leads:
+    - dejanb
+  wg-kubeadm-adoption-leads:
+    - luxas
+    - justinsb
+  wg-machine-learning-leads:
+    - vishh
+    - kow3ns
+    - balajismaniam
+    - ConnorDoyle
+  wg-multitenancy-leads:
+    - davidopp
+    - jessfraz
+  wg-policy-leads:
+    - hannibalhuang
+    - tsandall
+    - davidopp
+    - smarterclayton
+    - xuanjia
+  wg-resource-management-leads:
+    - vishh
+    - derekwaynecarr
+## BEGIN CUSTOM CONTENT
   steering-committee:
     - bgrant0607
     - brendanburns
@@ -15,3 +161,4 @@ aliases:
     - spiffxp
     - thockin
     - timothysc
+## END CUSTOM CONTENT

--- a/kubernetes/org.yaml
+++ b/kubernetes/org.yaml
@@ -88,6 +88,7 @@ members:
 - BaluDontu
 - bboreham
 - bdbauer
+- bencer
 - benjigoldberg
 - BenTheElder
 - bgrant0607-cc
@@ -177,6 +178,7 @@ members:
 - dougm
 - drinktee
 - dshulyak
+- DStorck
 - dubstack
 - duglin
 - ecordell
@@ -209,11 +211,13 @@ members:
 - font
 - foxish
 - fraenkel
+- frapposelli
 - freehan
 - Frostman
 - G-Harmon
 - gabrtv
 - gambol99
+- GaneshSPatil
 - geojaz
 - ghodss
 - gianrubio
@@ -343,13 +347,8 @@ members:
 - k8s-mirror-auth-pr-reviews
 - k8s-mirror-auth-proposals
 - k8s-mirror-auth-test-failures
-- k8s-mirror-azure-api-reviews
-- k8s-mirror-azure-bugs
-- k8s-mirror-azure-feature-requests
 - k8s-mirror-azure-misc
 - k8s-mirror-azure-pr-reviews
-- k8s-mirror-azure-proposals
-- k8s-mirror-azure-test-failures
 - k8s-mirror-cli-api-reviews
 - k8s-mirror-cli-bugs
 - k8s-mirror-cli-feature-requests
@@ -471,10 +470,12 @@ members:
 - maisem
 - marcoceppi
 - markturansky
+- marpaia
 - marun
 - mattf
 - mattfarina
 - matthiasr
+- matthyx
 - mattmoyer
 - mattthias
 - mbohlool
@@ -508,6 +509,7 @@ members:
 - mkumatag
 - mlmhl
 - mml
+- mohammedzee1000
 - monadic
 - monopole
 - mqliang
@@ -524,6 +526,7 @@ members:
 - nckturner
 - nebril
 - neolit123
+- nestorsalceda
 - ngtuna
 - nhlfr
 - nickchase
@@ -533,6 +536,7 @@ members:
 - nikhita
 - OddBloke
 - olekzabl
+- onyiny-ang
 - oomichi
 - p0lyn0mial
 - parispittman
@@ -610,6 +614,7 @@ members:
 - seanknox
 - seans3
 - SebastianM
+- sebastienvas
 - sebgoa
 - sethpollack
 - sgoings

--- a/kubernetes/sig-contributor-experience/OWNERS
+++ b/kubernetes/sig-contributor-experience/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - sig-contributor-experience-leads
+approvers:
+  - sig-contributor-experience-leads
+labels:
+  - sig/contributor-experience

--- a/kubernetes/sig-contributor-experience/org.yaml
+++ b/kubernetes/sig-contributor-experience/org.yaml
@@ -1,0 +1,68 @@
+teams:
+  sig-contributor-experience-bugs:
+    description: Bugs relating to contributor-experience infrastructure, such as the
+      PR bot, mungegithub.
+    maintainers:
+    - cblecker
+    - grodrigues3
+    members:
+    - rmmh
+    privacy: closed
+  sig-contributor-experience-feature-requests:
+    description: Requests for features in contributor-experience infrastructure, such
+      as the PR bot, mungegithub.
+    maintainers:
+    - idvoretskyi
+    - cblecker
+    - grodrigues3
+    members:
+    - rmmh
+    privacy: closed
+  sig-contributor-experience-misc-use-only-as-a-last-resort:
+    description: Improve contributor productivity
+    maintainers:
+    - philips
+    - idvoretskyi
+    - lavalamp
+    - cblecker
+    - grodrigues3
+    - thockin
+    - pwittrock
+    - eparis
+    members:
+    - dims
+    - rmmh
+    - Kashomon
+    - pigmej
+    - foxish
+    - hongchaodeng
+    - jessfraz
+    - monopole
+    - xiang90
+    privacy: closed
+  sig-contributor-experience-pr-reviews:
+    description: PR reviews for contributor-experience infrastructure, such as the
+      PR bot, mungegithub.
+    maintainers:
+    - idvoretskyi
+    - cblecker
+    - grodrigues3
+    members:
+    - rmmh
+    privacy: closed
+  sig-contributor-experience-proposals:
+    description: Design proposals for new contributor-experience infrastructure, such
+      as bots, monitoring dashboards, portals, etc.
+    maintainers:
+    - cblecker
+    - grodrigues3
+    members:
+    - rmmh
+    privacy: closed
+  sig-contributor-experience-test-failures:
+    description: List to triage test failures for contributor-experience infrastructure,
+      such as the PR bot, mungegithub.
+    maintainers:
+    - cblecker
+    - grodrigues3
+    privacy: closed


### PR DESCRIPTION
This updates the meta org as follows:
- Pull a copy of the OWNERS_ALIASES from k/community
- Updates membership as of 7/16
- Adds a folder of team members for sig-contributor-experience. Example of what it would look like to have sig-responsible teams.