### PR TITLE
ISSUE_TEMPLATE/membership: fix markdown rendering

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -23,9 +23,6 @@ e.g. (at)kubernetes
 - (at)sponsor-2
 
 ### List of contributions to the Kubernetes project
-- <PR reviewed / authored>
-- <PR reviewed / authored>
-- <Issue responded to>
-- <Issue responded to>
-- <SIG project I am involved with>
-- <SIG project I am involved with>
+- PRs reviewed / authored
+- Issues responded to
+- SIG projects I am involved with


### PR DESCRIPTION
In the current issue template for membership, the last few points are not displayed in "List of contributions": https://github.com/kubernetes/org/blob/master/.github/ISSUE_TEMPLATE/membership.md#list-of-contributions-to-the-kubernetes-project. I think it's because the points are listed in angle brackets (`<Issues responded to>`), which markdown treats as html.

/assign cblecker 