### PR TITLE
Add additional users to kubernetes-incubator

### DIFF
--- a/config/kubernetes-incubator/org.yaml
+++ b/config/kubernetes-incubator/org.yaml
@@ -37,6 +37,7 @@ members:
 - carolynvs
 - cdrage
 - chadswen
+- chenopis
 - childsb
 - chrislovecnm
 - cofyc
@@ -81,6 +82,7 @@ members:
 - k82cn
 - kadel
 - kawych
+- kbarnard10
 - kibbles-n-bytes
 - kikisdeliveryservice
 - krancour
@@ -121,6 +123,7 @@ members:
 - procrypt
 - pwittrock
 - Raffo
+- Rajakavitha1
 - Random-Liu
 - redbaron
 - rhatdan
@@ -162,5 +165,6 @@ members:
 - yliaog
 - yujuhong
 - zacharysarah
+- zhangxiaoyu-zidif
 - zmerlynn
 - zparnold


### PR DESCRIPTION
There were some users in kubernetes/org#16 that didn't end up getting PR'd and didn't accept their invite right away. This adds them to the config so they don't get deleted as soon as they accept their invite.