### PR TITLE
Add k82cn to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -54,6 +54,7 @@ members:
 - jeremyrickard
 - jsafrane
 - justinsb
+- k82cn
 - kow3ns
 - krmayankk
 - krzyzacy


### PR DESCRIPTION
Currently a member of the
kubernetes-incubator/admins-kube-arbitrator team

Planning to move kubernetes-incubator/kube-arbitrator repo over
to kuberentes-sigs

ref: #112