### PR TITLE
Update the repo-create template with more questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/repo-create.md
+++ b/.github/ISSUE_TEMPLATE/repo-create.md
@@ -4,7 +4,7 @@ about: Create or migrate a repository into a Kubernetes Org
 
 ---
 
-### New Repo, or migrate existing
+### New Repo, Staging Repo, or migrate existing
 e.g. new repository
 
 ### Requested name for new repository
@@ -13,15 +13,36 @@ e.g. cloud-provider-foo
 ### Which Organization should it reside
 e.g. kubernetes-sigs
 
-### Who should be provided access to this repository
-e.g (at)example_user should have write access
+### If not a staging repo, who should have admin access
+e.g. alice, bob
+
+### If not a staging repo, who should have write access
+e.g. chris, dianne
+
+### If a new repo, who should be listed as approvers in OWNERS
+e.g. alice, bob
+
+### If a new repo, who should be listed in SECURITY_CONTACTS
+e.g. alice, bob
+
+### What should the repo description be
+by default we will set it to "created due to (link to this issue)"
+
+### What SIG and subproject does this fall under in sigs.yaml
+e.g. this is a new subproject for sig-foo called bar-baz
+e.g. this is part of the sparkles subproject for sig-awesome
 
 ### Approvals
-Please detail out the approval process for the new repo
-Requirements are listed here: https://git.k8s.io/community/github-management/kubernetes-repositories.md
-If this is a core repository, then sig-architecture must approve
-If this is a SIG repository, then the SIG Technical Leads must approve
-Please include links to the approvals (meeting minutes, e-mail thread, etc)
+Please prove you have followed the appropriate approval process for this new
+repo by including links to the relevant approvals (meeting minutes, e-mail
+thread, etc.)
+
+Authoritative requirements are here: https://git.k8s.io/community/github-management/kubernetes-repositories.md
+
+tl;dr (but really you should read the linked doc, this may be stale)
+- If this is a core repository, then sig-architecture must approve
+- If this is a SIG repository, then this must follow the procedure spelled out
+  in that SIG's charter
 
 ### Additional context for request
 Any additional information or context to describe the request.


### PR DESCRIPTION
These are questions I find myself guessing the answer to or
having to ask as followup requests to the initial create

I'm also adding "staging" as an option since we tend to
create a bunch of those and they have slightly different
requirements from new or migrated repos

/cc @cblecker @calebamiles
Since you've also handled repo creation in the past