### PR TITLE
Update GitHub template metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-support.md
+++ b/.github/ISSUE_TEMPLATE/general-support.md
@@ -1,6 +1,9 @@
 ---
 name: General Support
 about: Permissions issues, repository issues, etc
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/integrations.md
+++ b/.github/ISSUE_TEMPLATE/integrations.md
@@ -1,6 +1,9 @@
 ---
 name: Integrations
 about: Third-party integrations, webhooks, or GitHub Apps
+title: ''
+labels: area/github-integration
+assignees: ''
 
 ---
 
@@ -18,6 +21,3 @@ A clear and concise description of what is trying to be accomplished with this i
 
 ### Additional context for request
 Any additional information or context to describe the use case.
-
-<!-- DO NOT EDIT BELOW THIS LINE -->
-/area github-integration

--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -1,6 +1,9 @@
 ---
 name: Organization Membership Request
 about: Request membership in a Kubernetes Org
+title: 'REQUEST: New membership for <your-GH-handle>'
+labels: area/github-membership
+assignees: ''
 
 ---
 
@@ -26,6 +29,3 @@ e.g. (at)kubernetes
 - PRs reviewed / authored
 - Issues responded to
 - SIG projects I am involved with
-
-<!-- DO NOT EDIT BELOW THIS LINE -->
-/area github-membership

--- a/.github/ISSUE_TEMPLATE/repo-archive.md
+++ b/.github/ISSUE_TEMPLATE/repo-archive.md
@@ -1,6 +1,9 @@
 ---
 name: Repository archival
 about: Retire and archive a Kubernetes repository
+title: ''
+labels: area/github-repo
+assignees: ''
 
 ---
 
@@ -15,6 +18,3 @@ e.g. Anytime.
 
 ### Additional context for request
 Any additional information or context to describe the request.
-
-<!-- DO NOT EDIT BELOW THIS LINE -->
-/area github-repo

--- a/.github/ISSUE_TEMPLATE/repo-create.md
+++ b/.github/ISSUE_TEMPLATE/repo-create.md
@@ -1,6 +1,9 @@
 ---
 name: Repository creation/migration
 about: Create or migrate a repository into a Kubernetes Org
+title: ''
+labels: area/github-repo
+assignees: ''
 
 ---
 
@@ -46,6 +49,3 @@ tl;dr (but really you should read the linked doc, this may be stale)
 
 ### Additional context for request
 Any additional information or context to describe the request.
-
-<!-- DO NOT EDIT BELOW THIS LINE -->
-/area github-repo


### PR DESCRIPTION
GitHub now allows you to specify titles and labels by default as a part of the template. Update our templates to use this.

ref: https://help.github.com/articles/creating-issue-templates-for-your-repository/