### PR TITLE
Add members to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -88,6 +88,7 @@ members:
 - justinsb
 - k82cn
 - kow3ns
+- kris-nova
 - krmayankk
 - krzyzacy
 - lavalamp

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -90,6 +90,7 @@ members:
 - kow3ns
 - kris-nova
 - krmayankk
+- krousey
 - krzyzacy
 - lavalamp
 - leakingtapan

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -14,6 +14,7 @@ admins:
 - spiffxp
 - thelinuxfoundation
 members:
+- adelina-t
 - ainmosni
 - akutz
 - alvaroaleman


### PR DESCRIPTION
- Add @adelina-t to kubernetes-sigs so she can be given permissions to kubernetes-sigs/windows-testing.
- Add @krousey and @kris-nova to kubernetes-sigs so they can be given permissions to kubernetes-sigs/cluster-api via a group (as opposed to outside collab access)

All three are members of @kubernetes.