### PR TITLE
Add members to cncf-conformance-wg

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -925,6 +925,8 @@ teams:
     - bradtopol
     - mgdevstack
     - deepak-vij
+    - bgrant0607
+    - johnbelamaric
     privacy: closed
   cncf-wg:
     description: The cncf working group


### PR DESCRIPTION
Aaron added these two members to the team yesterday. This syncs the config for them.

/assign @spiffxp 
/approve 