### PR TITLE
Add a test to check if team members are org members

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -989,6 +989,7 @@
     "k8s.io/test-infra/prow/cmd/peribolos",
     "k8s.io/test-infra/prow/config",
     "k8s.io/test-infra/prow/config/org",
+    "k8s.io/test-infra/prow/github",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/test-infra/prow/config:go_default_library",
         "//vendor/k8s.io/test-infra/prow/config/org:go_default_library",
+        "//vendor/k8s.io/test-infra/prow/github:go_default_library",
     ],
 )
 

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -24,7 +24,7 @@ members:
 - animeshsingh
 - ant31
 - apelisse
-- atoms
+- Atoms
 - balajismaniam
 - BenTheElder
 - bertinatto

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -67,7 +67,7 @@ members:
 - ash2k
 - ashcrow
 - asultan001
-- atoms
+- Atoms
 - austbot
 - aveshagarwal
 - awly


### PR DESCRIPTION
This would be useful to fail early if someone who is added as a team maintainer or member is not an org member. See https://github.com/kubernetes/org/pull/346#pullrequestreview-191923294 for an example.

This PR also validates:

- a user is not mentioned as both an org admin and org member
- a user is not mentioned as both a team maintainer and member
- no duplicates exist in the list of team maintainers and members

/assign @cblecker @fejta 