### PR TITLE
config/kubernetes: Add mxinden to sig-instrumentation

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -2770,6 +2770,7 @@ teams:
     - loburm
     - fgrzadkowski
     - danielqsj
+    - mxinden
     privacy: closed
   sig-instrumentation-bugs:
     description: ""
@@ -2785,6 +2786,7 @@ teams:
     - loburm
     - fgrzadkowski
     - danielqsj
+    - mxinden
     privacy: closed
   sig-instrumentation-feature-requests:
     description: ""
@@ -2799,6 +2801,7 @@ teams:
     - loburm
     - fgrzadkowski
     - danielqsj
+    - mxinden
     privacy: closed
   sig-instrumentation-misc:
     description: ""
@@ -2813,6 +2816,7 @@ teams:
     - loburm
     - fgrzadkowski
     - danielqsj
+    - mxinden
     privacy: closed
   sig-instrumentation-pr-reviews:
     description: ""
@@ -2828,6 +2832,7 @@ teams:
     - loburm
     - fgrzadkowski
     - danielqsj
+    - mxinden
     privacy: closed
   sig-instrumentation-proposals:
     description: ""
@@ -2842,6 +2847,7 @@ teams:
     - loburm
     - fgrzadkowski
     - danielqsj
+    - mxinden
     privacy: closed
   sig-instrumentation-test-failures:
     description: ""
@@ -2856,6 +2862,7 @@ teams:
     - loburm
     - fgrzadkowski
     - danielqsj
+    - mxinden
     privacy: closed
   sig-multicluster-api-reviews:
     description: ""


### PR DESCRIPTION
Following https://github.com/kubernetes/org/pull/353 as an example, I would like to help in sig-instrumentation. Hence being added here would be great.

Let me know if this is the wrong way to approach this.

//CC @brancz 

