### PR TITLE
Update SIG Azure teams

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -264,16 +264,6 @@ teams:
     - ingvagabund
     - timothysc
     privacy: closed
-  cluster-api-provider-azure-admins:
-    description: ""
-    maintainers:
-    - justaugustus
-    privacy: closed
-  cluster-api-provider-azure-maintainers:
-    description: ""
-    maintainers:
-    - justaugustus
-    privacy: closed
   cluster-api-provider-digitalocean-admins:
     description: ""
     maintainers:

--- a/config/kubernetes-sigs/sig-azure/OWNERS
+++ b/config/kubernetes-sigs/sig-azure/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - sig-azure-leads
+approvers:
+  - sig-azure-leads
+labels:
+  - sig/azure

--- a/config/kubernetes-sigs/sig-azure/teams.yaml
+++ b/config/kubernetes-sigs/sig-azure/teams.yaml
@@ -1,0 +1,14 @@
+teams:
+  cluster-api-provider-azure-admins:
+    description: ""
+    maintainers:
+    - justaugustus
+    privacy: closed
+  cluster-api-provider-azure-maintainers:
+    description: ""
+    maintainers:
+    - justaugustus
+    members:
+    - soggiest
+    - tariq1890
+    privacy: closed

--- a/config/kubernetes/sig-azure/teams.yaml
+++ b/config/kubernetes/sig-azure/teams.yaml
@@ -2,11 +2,14 @@ teams:
   sig-azure:
     description: General discussion for SIG Azure
     maintainers:
+    - dstrebel
+    - feiskyer
     - justaugustus
     - khenidak
-    - shubheksha
     members:
     - andyzhangx
-    - feiskyer
     - karataliu
+    - lachie83
+    - soggiest
+    - tariq1890
     privacy: closed


### PR DESCRIPTION
Fixes: kubernetes-sigs/cluster-api-provider-azure#48

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @cblecker @dstrebel @khenidak @feiskyer 

For visibility:
/cc @lachie83 @tariq1890 @soggiest 