### PR TITLE
Add nikhita to community-maintainers team

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -964,28 +964,6 @@ teams:
     - eparis
     - sttts
     privacy: closed
-  community-admins:
-    description: ""
-    maintainers:
-    - calebamiles
-    - cblecker
-    - grodrigues3
-    - idvoretskyi
-    members:
-    - bgrant0607
-    - castrojo
-    - jdumars
-    - parispittman
-    - Phillels
-    - sarahnovotny
-    - thockin
-    privacy: closed
-  community-maintainers:
-    description: ""
-    members:
-    - Phillels
-    - thockin
-    privacy: closed
   contrib-maintainers:
     description: Those who maintain (have write access to) contrib.
     maintainers:

--- a/config/kubernetes/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes/sig-contributor-experience/teams.yaml
@@ -98,6 +98,7 @@ teams:
   community-maintainers:
     description: ""
     members:
+    - nikhita
     - Phillels
     - thockin
     privacy: closed

--- a/config/kubernetes/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes/sig-contributor-experience/teams.yaml
@@ -79,3 +79,25 @@ teams:
     - idealhack
     - nikhita
     privacy: closed
+  community-admins:
+    description: ""
+    maintainers:
+    - calebamiles
+    - cblecker
+    - grodrigues3
+    - idvoretskyi
+    members:
+    - bgrant0607
+    - castrojo
+    - jdumars
+    - parispittman
+    - Phillels
+    - sarahnovotny
+    - thockin
+    privacy: closed
+  community-maintainers:
+    description: ""
+    members:
+    - Phillels
+    - thockin
+    privacy: closed


### PR DESCRIPTION
This PR also moves the `community-maintainers` and `community-admins` team from `org.yaml` to `sig-contributor-experience/teams.yaml`.

I wish to be added to this team so that I can help manage the [contribex project board](https://github.com/orgs/kubernetes/projects/1). I am a technical lead for sig-contribex.

/cc @cblecker @parispittman @Phillels 
/assign @cblecker 