### PR TITLE
Update SIG-UI (Dashboard) groups 

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1004,25 +1004,29 @@ teams:
     - saad-ali
     privacy: closed
   dashboard-admins:
-    description: ""
+    description: Admins of the Dashboard repository
     members:
     - bryk
     - floreks
+    - jeefy
     - konryd
+    - maciaszczykm
     privacy: closed
   dashboard-maintainers:
     description: The Dashboard UI team
-    maintainers:
-    - bryk
     members:
+    - bryk
     - cheld
     - cupofcat
     - danielromlein
     - floreks
     - ianlewis
+    - jeefy
     - konryd
     - maciaszczykm
     - mhenc
+    - olekzabl
+    - pewu
     - rf232
     privacy: closed
   dashboard-reviewers:


### PR DESCRIPTION
Updating groups to reflect our [OWNER_ALIASES](https://github.com/kubernetes/dashboard/blob/master/OWNERS_ALIASES) accurately and the [sigs.yaml ](https://github.com/kubernetes/community/blob/master/sigs.yaml#L1989) changes. 

Let me know if I did something wrong. :) 

/sig ui