### PR TITLE
Add code-of-conduct-committee team

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -988,6 +988,15 @@ teams:
     - eparis
     - sttts
     privacy: closed
+  code-of-conduct-committee:
+    description: Kubernetes Code of Conduct Committee
+    members:
+    - Bradamant3
+    - carolynvs
+    - eparis
+    - jdumars
+    - parispittman
+    privacy: closed
   contrib-maintainers:
     description: Those who maintain (have write access to) contrib.
     maintainers:


### PR DESCRIPTION
I wanted to explictly at-mention the code of conduct committee in https://github.com/kubernetes/community/pull/3194 but found that there was no such team.

We already have a team for the steering committee (which is pretty useful for at-mentioning). I think it'd be useful to have this team as well.

Members of the team are the members of the CoC mentioned here: https://github.com/kubernetes/community/tree/master/committee-code-of-conduct

/cc @Bradamant3 @carolynvs @eparis @jdumars @parispittman 