### PR TITLE
Add Katharine to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -99,6 +99,7 @@ members:
 - justaugustus
 - justinsb
 - k82cn
+- Katharine
 - kow3ns
 - kris-nova
 - krmayankk


### PR DESCRIPTION
I'm already a member of the Kubernetes org.

It would be handy to be able to express opinions in e.g. kubernetes-sigs/kind without the bot [yelling at everyone involved](https://github.com/kubernetes-sigs/kind/pull/285).

/area github-membership