### PR TITLE
Correct jichenjc membership

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -94,7 +94,6 @@ members:
 - jeffwan
 - jennybuckley
 - jeremyrickard
-- jichenjc
 - jingxu97
 - jinzhejz
 - jsafrane

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -350,6 +350,7 @@ members:
 - jiangyaoguo
 - jianhuiz
 - jiayingz
+- jichenjc
 - jimangel
 - jimmidyson
 - jimmycuadra


### PR DESCRIPTION
I incorrect added @jichenjc to the @kubernetes-sigs org instead of @kubernetes org in PR #400.

This PR reverts the commit: https://github.com/kubernetes/org/pull/400/commits/492582a6d75a4442a0c4e71218f6141686bdeed1 and correctly adds @jichenjc to the @kubernetes org. 

I double checked that the other membership requests in that PR were processed correctly. 

ref: https://github.com/kubernetes/org/issues/389#issuecomment-463019923

Sorry about that @jichenjc :( 