### PR TITLE
sig-pm: Update `enhancements-maintainers` team

### DIFF
--- a/config/kubernetes/sig-pm/teams.yaml
+++ b/config/kubernetes/sig-pm/teams.yaml
@@ -1,47 +1,11 @@
 teams:
   enhancements-maintainers:
-    description: People who can be assigned to drive issues and approve docs in k/enhancements
+    description: Contributors with write access to k/enhancements
     maintainers:
+    - calebamiles
     - idvoretskyi
+    - jdumars
     - justaugustus
-    - spiffxp
-    members:
-    - aronchick
-    - bgrant0607
-    - bprashanth
-    - caseydavenport
-    - claurence
-    - davidopp
-    - dchen1107
-    - deads2k
-    - ecordell
-    - erictune
-    - errordeveloper
-    - euank
-    - grodrigues3
-    - hongchaodeng
-    - jbeda
-    - jszczepkowski
-    - lukemarsden
-    - madhusudancs
-    - matchstick
-    - mdelio
-    - mike-saparov
-    - nikhiljindal
-    - philips
-    - pweil-
-    - pwittrock
-    - quinton-hoole
-    - quinton-hoole-2
-    - saad-ali
-    - sarahnovotny
-    - smarterclayton
-    - soltysh
-    - sttts
-    - tallclair
-    - timstclair
-    - yifan-gu
-    - yujuhong
     privacy: closed
     previously:
     - features-maintainers


### PR DESCRIPTION
This cleans up the enhancements-maintainers team to only include SIG PM maintainers.
Ref: https://github.com/kubernetes/enhancements/issues/590#issuecomment-464413261

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @calebamiles @idvoretskyi @jdumars 