### PR TITLE
Move structured-merge-diff and yaml teams to api-machinery dir

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -616,20 +616,6 @@ teams:
     - msau42
     - saad-ali
     privacy: closed
-  structured-merge-diff-admins:
-    description: admin access to structured-merge-diff
-    maintainers:
-    - apelisse
-    - lavalamp
-    privacy: closed
-  structured-merge-diff-maintainers:
-    description: write access to structured-merge-diff
-    maintainers:
-    - apelisse
-    - lavalamp
-    members:
-    - jennybuckley
-    privacy: closed
   testing_frameworks-admins:
     description: admin access for testing_frameworks
     maintainers:
@@ -675,20 +661,4 @@ teams:
     - PatrickLang
     members:
     - adelina-t
-    privacy: closed
-  yaml-admins:
-    description: ""
-    maintainers:
-    - deads2k
-    - dims
-    - lavalamp
-    - liggitt
-    privacy: closed
-  yaml-maintainers:
-    description: ""
-    maintainers:
-    - deads2k
-    - dims
-    - lavalamp
-    - liggitt
     privacy: closed

--- a/config/kubernetes-sigs/sig-api-machinery/teams.yaml
+++ b/config/kubernetes-sigs/sig-api-machinery/teams.yaml
@@ -114,3 +114,33 @@ teams:
         - deads2k
         - lavalamp
         privacy: closed
+  structured-merge-diff-admins:
+    description: admin access to structured-merge-diff
+    maintainers:
+      - apelisse
+      - lavalamp
+    privacy: closed
+  structured-merge-diff-maintainers:
+    description: write access to structured-merge-diff
+    maintainers:
+      - apelisse
+      - lavalamp
+    members:
+      - jennybuckley
+    privacy: closed
+  yaml-admins:
+    description: ""
+    maintainers:
+      - deads2k
+      - dims
+      - lavalamp
+      - liggitt
+    privacy: closed
+  yaml-maintainers:
+    description: ""
+    maintainers:
+      - deads2k
+      - dims
+      - lavalamp
+      - liggitt
+    privacy: closed


### PR DESCRIPTION
Follow up of #505 

https://github.com/kubernetes-sigs/structured-merge-diff and https://github.com/kubernetes-sigs/yaml are apimachinery subprojects.

Ref: https://github.com/kubernetes/community/tree/master/sig-api-machinery#subprojects