### PR TITLE
Add k8s-github-robot alongside k8s-ci-robot in all orgs

### DIFF
--- a/config/kubernetes-client/org.yaml
+++ b/config/kubernetes-client/org.yaml
@@ -10,6 +10,7 @@ admins:
 - fejta
 - idvoretskyi
 - k8s-ci-robot
+- k8s-github-robot
 - nikhita
 - spiffxp
 - thelinuxfoundation

--- a/config/kubernetes-csi/org.yaml
+++ b/config/kubernetes-csi/org.yaml
@@ -10,6 +10,7 @@ admins:
 - fejta
 - idvoretskyi
 - k8s-ci-robot
+- k8s-github-robot
 - nikhita
 - spiffxp
 - thelinuxfoundation

--- a/config/kubernetes-incubator/org.yaml
+++ b/config/kubernetes-incubator/org.yaml
@@ -10,6 +10,7 @@ admins:
 - fejta
 - idvoretskyi
 - k8s-ci-robot
+- k8s-github-robot
 - nikhita
 - spiffxp
 - thelinuxfoundation

--- a/config/kubernetes-retired/org.yaml
+++ b/config/kubernetes-retired/org.yaml
@@ -10,6 +10,7 @@ admins:
 - fejta
 - idvoretskyi
 - k8s-ci-robot
+- k8s-github-robot
 - nikhita
 - spiffxp
 - thelinuxfoundation

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -10,6 +10,7 @@ admins:
 - fejta
 - idvoretskyi
 - k8s-ci-robot
+- k8s-github-robot
 - nikhita
 - spiffxp
 - thelinuxfoundation
@@ -257,6 +258,7 @@ teams:
     description: Bot Service Accounts in the Kubernetes-SIGs org
     maintainers:
     - k8s-ci-robot
+    - k8s-github-robot
     - thelinuxfoundation
     privacy: closed
   cluster-api-admins:

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -10,7 +10,7 @@ admins:
 - fejta
 - idvoretskyi
 - k8s-ci-robot
-- k8s-merge-robot
+- k8s-github-robot
 - nikhita
 - spiffxp
 - thelinuxfoundation
@@ -864,7 +864,7 @@ teams:
     description: Bot Service Accounts in the Kubernetes org
     maintainers:
     - k8s-ci-robot
-    - k8s-merge-robot
+    - k8s-github-robot
     - thelinuxfoundation
     members:
     - k8s-publishing-bot


### PR DESCRIPTION
The bot formerly known as k8s-merge-robot is going to do more things in more orgs

ref: https://github.com/kubernetes/test-infra/issues/11402