### PR TITLE
Add smourapina (CI Signal 1.14) as milestone maintainer

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -80,6 +80,7 @@ teams:
     - saad-ali # Storage
     - seans3 # CLI
     - shyamjvs # Scalability
+    - smourapina # 1.14 CI Signal
     - soltysh # CLI
     - spzala # IBM Cloud
     - stevekuznetsov # Testing


### PR DESCRIPTION
As CI Signal team member, I need to have the ability to assign issues created to the 1.14 release milestone, and so will need to be added as milestone maintainer.

cc @mariantalla 
