### PR TITLE
Add sig docs it teams and update fr teams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *~
 /bazel-*
 .DS_Store
+.idea/

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -102,7 +102,6 @@ teams:
     - ClaudiaJKang
     - ianychoi
     privacy: closed
-    teams:
   sig-docs-ko-reviews:
     description: Reviews for Korean docs PRs
     maintainers:

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -36,6 +36,7 @@ teams:
     - awkif
     - jygastaud
     - lledru
+    - oussemos
     - perriea
     - rbenzair
     - rekcah78
@@ -50,6 +51,7 @@ teams:
     - awkif
     - jygastaud
     - lledru
+    - oussemos
     - perriea
     - rbenzair
     - rekcah78

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -55,6 +55,22 @@ teams:
     - smana
     - yastij
     privacy: closed
+  sig-docs-it-owners:
+    description: Owners for Italian content
+    maintainers:
+    - rlenferink
+    members:
+    - lledru
+    - micheleberardi
+    privacy: closed
+  sig-docs-it-reviews:
+    description: Review PRs for Italian content
+    maintainers:
+    - rlenferink
+    members:
+    - lledru
+    - micheleberardi
+    privacy: closed
   sig-docs-ja-owners:
     description: sig-docs-ja-owners
     maintainers:

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -29,8 +29,8 @@ teams:
     - xiangpengzhao
     - zhangxiaoyu-zidif
     privacy: closed
-  sig-docs-fr-reviews:
-    description: Review PRs for French content
+  sig-docs-fr-owners:
+    description: Owners for French content
     members:
     - awkif
     - jygastaud
@@ -42,8 +42,8 @@ teams:
     - smana
     - yastij
     privacy: closed
-  sig-docs-fr-owners:
-    description: Owners for French content
+  sig-docs-fr-reviews:
+    description: Review PRs for French content
     members:
     - awkif
     - jygastaud

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -101,14 +101,14 @@ teams:
     - ianychoi
     privacy: closed
     teams:
-      sig-docs-ko-reviews:
-        description: Reviews for Korean docs PRs
-        maintainers:
-        - ClaudiaJKang
-        - gochist
-        members:
-        - ianychoi
-        privacy: closed
+  sig-docs-ko-reviews:
+    description: Reviews for Korean docs PRs
+    maintainers:
+    - ClaudiaJKang
+    - gochist
+    members:
+    - ianychoi
+    privacy: closed
   sig-docs-l10n-admins:
     description: Admins for l10n projects
     maintainers:

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -61,19 +61,17 @@ teams:
     privacy: closed
   sig-docs-it-owners:
     description: Owners for Italian content
-    maintainers:
-    - rlenferink
     members:
     - lledru
     - micheleberardi
+    - rlenferink
     privacy: closed
   sig-docs-it-reviews:
     description: Review PRs for Italian content
-    maintainers:
-    - rlenferink
     members:
     - lledru
     - micheleberardi
+    - rlenferink
     privacy: closed
   sig-docs-ja-owners:
     description: sig-docs-ja-owners

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -32,6 +32,7 @@ teams:
   sig-docs-fr-owners:
     description: Owners for French content
     members:
+    - abuisine
     - awkif
     - jygastaud
     - lledru
@@ -45,6 +46,7 @@ teams:
   sig-docs-fr-reviews:
     description: Review PRs for French content
     members:
+    - abuisine
     - awkif
     - jygastaud
     - lledru


### PR DESCRIPTION
PR is adding the Italian localization teams. The members are already in the appropriate OWNERS files => [kubernetes/website/OWNERS_ALIASES](https://github.com/kubernetes/website/blob/12036aa614ff0e4ac5bdfce102642b7e5e4cb2b5/OWNERS_ALIASES#L166)

Next to that some small improvements
- Ignoring `.idea` files when opening the project with a Jetbrains editor
- Swapped `sig-docs-fr-reviews` and `sig-docs-fr-owners` to follow the rest of the file: first owners, then review teams
- Fixed indentation for `sig-docs-ko-reviews`