### PR TITLE
Add publishing-bot-reviewers team

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -179,3 +179,13 @@ teams:
         - justaugustus
         - tpepper
         privacy: closed
+  publishing-bot-reviewers:
+    description: Reviews for publishing-bot
+    maintainers:
+    - nikhita
+    members:
+    - caesarxuchao
+    - dims
+    - mfojtik
+    - sttts
+    privacy: closed


### PR DESCRIPTION
Adds a team so that we can use it to cc folks for reviews/issues related to the publishing-bot.

Ref: https://github.com/kubernetes/publishing-bot/blob/master/OWNERS

/cc @sttts @dims @mfojtik @caesarxuchao 