### PR TITLE
Setup teams and org membership for k8s-container-image-promoter

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -84,6 +84,7 @@ members:
 - gyuho
 - hardikdr
 - hello2mao
+- hh
 - hoegaarden
 - iamemilio
 - ibzib

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -118,6 +118,7 @@ members:
 - lichuqiang
 - liggitt
 - Lion-Wei
+- listx
 - Liujingfang1
 - liyinan926
 - liztio

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -190,6 +190,7 @@ members:
 - tizhou86
 - tomassedovic
 - totherme
+- tpepper
 - umohnani8
 - verult
 - vincepri

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -1,0 +1,17 @@
+teams:
+  k8s-container-image-promoter-admins:
+    description: "admin access to k8s-container-image-promoter"
+    members:
+    - dims
+    - hh
+    - listx
+    - tpepper
+    privacy: closed
+  k8s-container-image-promoter-maintainers:
+    description: "write access to k8s-container-image-promoter"
+    members:
+    - dims
+    - hh
+    - listx
+    - tpepper
+    privacy: closed


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/551

All members I'm adding to kubernetes-sigs to satisfy the repo migration request are already members of kubernetes, so I opted to handle in this PR instead of asking for issues to be filed