### PR TITLE
Migrate team maintainers to members

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -108,6 +108,11 @@ func testTeamMembers(teams map[string]org.Team, admins sets.String, orgMembers s
 		teamMaintainers = normalize(teamMaintainers)
 		teamMembers = normalize(teamMembers)
 
+		// check for non-admins in maintainers list
+		if nonAdminMaintainers := teamMaintainers.Difference(admins); len(nonAdminMaintainers) > 0 {
+			errs = append(errs, fmt.Errorf("The team %s in org %s has non-admins listed as maintainers; these users should be in the members list instead: %s", teamName, orgName, strings.Join(nonAdminMaintainers.List(), ",")))
+		}
+
 		// check for users in both maintainers and members
 		if both := teamMaintainers.Intersection(teamMembers); len(both) > 0 {
 			errs = append(errs, fmt.Errorf("The team %s in org %s has users in both maintainer admin and member roles: %s", teamName, orgName, strings.Join(both.List(), ", ")))
@@ -122,9 +127,6 @@ func testTeamMembers(teams map[string]org.Team, admins sets.String, orgMembers s
 		}
 
 		// check if all are org members
-		if missing := teamMaintainers.Difference(orgMembers); len(missing) > 0 {
-			errs = append(errs, fmt.Errorf("The following maintainers of team %s are not %s org members: %s", teamName, orgName, strings.Join(missing.List(), ", ")))
-		}
 		if missing := teamMembers.Difference(orgMembers); len(missing) > 0 {
 			errs = append(errs, fmt.Errorf("The following members of team %s are not %s org members: %s", teamName, orgName, strings.Join(missing.List(), ", ")))
 		}

--- a/config/kubernetes-client/org.yaml
+++ b/config/kubernetes-client/org.yaml
@@ -58,57 +58,49 @@ teams:
     privacy: secret
   csharp-admins:
     description: admin access to csharp
-    maintainers:
-    - krabhishek8260
     members:
     - brendandburns
+    - krabhishek8260
     privacy: closed
   gen-admins:
     description: admin access to gen
-    maintainers:
-    - mbohlool
     members:
     - brendandburns
+    - mbohlool
     privacy: closed
   haskell-admins:
     description: admin access to haskell
-    maintainers:
-    - mbohlool
     members:
     - brendandburns
+    - mbohlool
     privacy: closed
   java-admins:
     description: admin access to java
-    maintainers:
-    - mbohlool
     members:
     - brendandburns
+    - mbohlool
     privacy: closed
   javascript-admins:
     description: admin access to javascript
-    maintainers:
-    - mbohlool
     members:
     - brendandburns
+    - mbohlool
     privacy: closed
   python-admins:
     description: admin access to python
-    maintainers:
-    - mbohlool
     members:
+    - mbohlool
     - yliaog
     privacy: closed
   python-base-admins:
     description: ""
-    maintainers:
-    - mbohlool
     members:
+    - mbohlool
     - yliaog
     privacy: closed
   ruby-admins:
     description: admin access to ruby
-    maintainers:
-    - mbohlool
     members:
     - brendandburns
+    - mbohlool
     privacy: closed

--- a/config/kubernetes-csi/org.yaml
+++ b/config/kubernetes-csi/org.yaml
@@ -43,190 +43,186 @@ members:
 teams:
   cluster-driver-registrar-admins:
     description: admin access to cluster-driver-registrar
-    maintainers:
+    members:
     - lpabon
     - saad-ali
     privacy: closed
   cluster-driver-registrar-maintainers:
     description: write access to cluster-driver-registrar
-    maintainers:
+    members:
     - lpabon
     - saad-ali
     privacy: closed
   csi-driver-fibre-channel-admins:
     description: admin access to csi-driver-fibre-channel
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-driver-fibre-channel-maintainers:
     description: write access to csi-driver-fibre-channel
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-driver-flex-admins:
     description: admin access to csi-driver-flex
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-driver-flex-maintainers:
     description: write access to csi-driver-flex
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-driver-host-path-admins:
     description: admin access to csi-driver-host-path
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-driver-host-path-maintainers:
     description: write access to csi-driver-host-path
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-driver-image-populator-admins:
     description: admin access to csi-driver-image-populator
-    maintainers:
+    members:
       - msau42
       - saad-ali
     privacy: closed
   csi-driver-image-populator-maintainers:
     description: write access to csi-driver-image-populator
-    maintainers:
+    members:
       - msau42
       - saad-ali
     privacy: closed
   csi-driver-iscsi-admins:
     description: admin access to csi-driver-iscsi
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-driver-iscsi-maintainers:
     description: write access to csi-driver-iscsi
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-driver-nfs-admins:
     description: admin access to csi-driver-nfs
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-driver-nfs-maintainers:
     description: write access to csi-driver-nfs
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-lib-common-admins:
     description: admin access to csi-lib-common
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-lib-common-maintainers:
     description: write access to csi-lib-common
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-lib-fc-admins:
     description: admin access to csi-lib-fc
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-lib-fc-maintainers:
     description: write access to csi-lib-fc
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-lib-iscsi-admins:
     description: admin access to csi-lib-iscsi
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-lib-iscsi-maintainers:
     description: write access to csi-lib-iscsi
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   csi-lib-utils-admins:
     description: admin access to csi-lib-utils
-    maintainers:
+    members:
     - saad-ali
     privacy: closed
   csi-lib-utils-maintainers:
     description: write access to csi-lib-utils
-    maintainers:
+    members:
     - saad-ali
     privacy: closed
   csi-misc:
     description: Miscellaneous Discussions for Kubernetes CSI Working Group
-    maintainers:
-    - childsb
-    - msau42
-    - saad-ali
     members:
     - chakri-nelluri
+    - childsb
     - davidz627
     - gnufied
     - jsafrane
     - lpabon
+    - msau42
     - pohly
     - rootfs
+    - saad-ali
     - sbezverk
     - vladimirvivien
     - xing-yang
     privacy: closed
   csi-release-tools-admins:
     description: admin access to csi-release-tools
-    maintainers:
+    members:
     - msau42
     - saad-ali
     privacy: closed
   csi-release-tools-maintainers:
     description: write access to csi-release-tools
-    maintainers:
+    members:
     - msau42
     - saad-ali
     privacy: closed
   csi-test-admins:
     description: admin access to csi-test
-    maintainers:
-    - childsb
-    - saad-ali
     members:
+    - childsb
     - davidz627
     - lpabon
+    - saad-ali
     privacy: closed
   csi-test-maintainers:
     description: write access to csi-test
-    maintainers:
+    members:
     - childsb
     - saad-ali
-    members:
     - sbezverk
     privacy: closed
   developers:
     description: ""
-    maintainers:
-    - lpabon
     members:
     - chakri-nelluri
     - childsb
     - davidz627
     - jsafrane
+    - lpabon
     - rootfs
     - saad-ali
     - sbezverk
@@ -234,146 +230,138 @@ teams:
     privacy: closed
   docs-admins:
     description: admin access to docs
-    maintainers:
-    - childsb
-    - saad-ali
     members:
+    - childsb
     - lpabon
+    - saad-ali
     privacy: closed
   docs-maintainers:
     description: write access to docs
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   driver-registrar-admins:
     description: admin access to driver-registrar
-    maintainers:
-    - childsb
-    - saad-ali
     members:
+    - childsb
     - davidz627
     - lpabon
+    - saad-ali
     privacy: closed
   driver-registrar-maintainers:
     description: write access to driver-registrar
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   drivers-admins:
     description: admin access to drivers
-    maintainers:
-    - childsb
-    - saad-ali
     members:
     - chakri-nelluri
+    - childsb
     - lpabon
+    - saad-ali
     privacy: closed
   drivers-maintainers:
     description: write access to drivers
-    maintainers:
+    members:
     - childsb
     - saad-ali
-    members:
     - sbezverk
     privacy: closed
   external-attacher-admins:
     description: admin access to external-attacher
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   external-attacher-maintainers:
     description: write access to external-attacher
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   external-provisioner-admins:
     description: admin access to external-provisioner
-    maintainers:
-    - childsb
-    - saad-ali
     members:
+    - childsb
     - davidz627
     - lpabon
+    - saad-ali
     privacy: closed
   external-provisioner-maintainers:
     description: write access to external-provisioner
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   external-resizer-admins:
     description: admin access to external-resizer
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   external-resizer-maintainers:
     description: write access to external-resizer
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   external-snapshotter-admins:
     description: admin access to external-snapshotter
-    maintainers:
-    - childsb
-    - saad-ali
     members:
+    - childsb
     - lpabon
+    - saad-ali
     privacy: closed
   external-snapshotter-maintainers:
     description: write access to external-snapshotter
-    maintainers:
+    members:
     - childsb
     - saad-ali
     privacy: closed
   kubernetes-csi-github-io-admins:
     description: admin access to kubernetes-csi.github.io
-    maintainers:
+    members:
     - lpabon
     - saad-ali
     privacy: closed
   kubernetes-csi-migration-library-admins:
     description: admin access to kubernetes-csi-migration-library
-    maintainers:
+    members:
     - davidz627
     - saad-ali
     privacy: closed
   kubernetes-csi-migration-library-maintainers:
     description: write access to kubernetes-csi-migration-library
-    maintainers:
+    members:
     - davidz627
     - saad-ali
     privacy: closed
   livenessprobe-admins:
     description: admin access to livenessprobe
-    maintainers:
-    - childsb
-    - saad-ali
     members:
+    - childsb
     - lpabon
+    - saad-ali
     privacy: closed
   livenessprobe-maintainers:
     description: write access to livenessprobe
-    maintainers:
+    members:
     - childsb
     - saad-ali
-    members:
     - sbezverk
     privacy: closed
   node-driver-registrar-admins:
     description: admnin access to node-driver-registrar
-    maintainers:
+    members:
     - lpabon
     - saad-ali
     privacy: closed
   node-driver-registrar-maintainers:
     description: write access to node-driver-registrar
-    maintainers:
+    members:
     - lpabon
     - saad-ali
     privacy: closed

--- a/config/kubernetes-incubator/org.yaml
+++ b/config/kubernetes-incubator/org.yaml
@@ -181,9 +181,8 @@ members:
 teams:
   admin-bootkube:
     description: ""
-    maintainers:
-    - aaronlevy
     members:
+    - aaronlevy
     - philips
     privacy: closed
   admin-cluster-capacity:
@@ -203,9 +202,8 @@ teams:
     privacy: closed
   admin-custom-metrics-apiserver:
     description: Admins for the custom-metrics-apiserver repo
-    maintainers:
-    - DirectXMan12
     members:
+    - DirectXMan12
     - luxas
     - piosz
     privacy: closed
@@ -217,14 +215,13 @@ teams:
     privacy: closed
   admin-reference-docs:
     description: adminstration of reference-docs repo
-    maintainers:
-    - pwittrock
     members:
+    - pwittrock
     - sarahnovotny
     privacy: closed
   admins-apiserver-builder:
     description: maintainers of the apiserver-builder repository with admin access
-    maintainers:
+    members:
     - DirectXMan12
     - pwittrock
     - yue9944882
@@ -233,15 +230,14 @@ teams:
     description: administrators of the application-images repository
     maintainers:
     - calebamiles
-    - zmerlynn
     members:
     - mattf
+    - zmerlynn
     privacy: closed
   admins-client-python:
     description: admins of the client-python project
-    maintainers:
-    - mbohlool
     members:
+    - mbohlool
     - sarahnovotny
     - smarterclayton
     - yliaog
@@ -249,35 +245,34 @@ teams:
   admins-cluster-proportional-autoscaler:
     description: administers of  the cluster-proportional-autoscaler repository
     maintainers:
-    - bowei
     - calebamiles
-    - MrHohn
     members:
+    - bowei
+    - MrHohn
     - philips
     privacy: closed
   admins-external-dns:
     description: ""
     maintainers:
     - calebamiles
-    - justinsb
     members:
+    - justinsb
     - sarahnovotny
     privacy: closed
   admins-ip-masq-agent:
     description: ""
-    maintainers:
+    members:
     - dnardo
+    - MrHohn
     - mtaufen
     - thockin
-    members:
-    - MrHohn
     privacy: closed
   admins-kargo:
     description: ""
     maintainers:
-    - ant31
     - calebamiles
     members:
+    - ant31
     - bogdando
     - mattymo
     - sarahnovotny
@@ -285,14 +280,13 @@ teams:
     privacy: closed
   admins-kompose:
     description: Admins for kompose
-    maintainers:
-    - sebgoa
     members:
     - bgrant0607
     - cdrage
     - janetkuo
     - kadel
     - ngtuna
+    - sebgoa
     privacy: closed
   admins-kops:
     description: administrators of the kops repository
@@ -303,8 +297,8 @@ teams:
     description: kube-aws repository administrators
     maintainers:
     - calebamiles
-    - colhom
     members:
+    - colhom
     - mumoshu
     - philips
     privacy: closed
@@ -312,9 +306,9 @@ teams:
     description: administrators of the kube2consul repository
     maintainers:
     - calebamiles
-    - elg0nz
     members:
     - bgrant0607
+    - elg0nz
     privacy: closed
   admins-metrics-server:
     description: ""
@@ -324,9 +318,8 @@ teams:
     privacy: closed
   admins-node-feature-discovery:
     description: Administrators of node-feature-discovery
-    maintainers:
-    - balajismaniam
     members:
+    - balajismaniam
     - ConnorDoyle
     - davidopp
     - philips
@@ -335,51 +328,48 @@ teams:
     description: administrators of the rktlet repository
     maintainers:
     - calebamiles
-    - euank
-    - yifan-gu
     members:
     - dchen1107
+    - euank
+    - yifan-gu
     privacy: closed
   admins-service-catalog:
     description: administrators for the service catalog project
-    maintainers:
+    members:
     - carolynvs
     - duglin
-    - pmorie
-    members:
     - kibbles-n-bytes
+    - pmorie
     - sarahnovotny
     privacy: closed
   descheduler-admins:
     description: Admin permission for descheduler repo
-    maintainers:
+    members:
     - aveshagarwal
     privacy: closed
   descheduler-maintainers:
     description: Write permission for descheduler repo
-    maintainers:
+    members:
     - aveshagarwal
     privacy: closed
   descheduler-reviewers:
     description: Read permission for descheduler repo
-    maintainers:
+    members:
     - aveshagarwal
     privacy: closed
   design-reviewer-kube-arbitrator:
     description: The design reviewer of kube-arbitrator
-    maintainers:
-    - k82cn
     members:
     - bsalamat
     - davidopp
     - foxish
+    - k82cn
     - timothysc
     privacy: closed
   external-storage-community:
     description: the extended external storage community
-    maintainers:
-    - childsb
     members:
+    - childsb
     - ianchakeres
     - jsafrane
     - msau42
@@ -395,17 +385,16 @@ teams:
     privacy: closed
   kompose-contributors:
     description: Contributors to kompose repo (read access)
-    maintainers:
-    - sebgoa
     members:
     - bgrant0607
     - cdrage
     - ngtuna
     - procrypt
+    - sebgoa
     privacy: closed
   maintainers-apiserver-builder:
     description: maintainers of apiserver-builder with write access on the repository
-    maintainers:
+    members:
     - DirectXMan12
     - pwittrock
     - yue9944882
@@ -414,9 +403,9 @@ teams:
     description: contributors to the application-images repository
     maintainers:
     - calebamiles
-    - zmerlynn
     members:
     - mattf
+    - zmerlynn
     privacy: closed
   maintainers-bootkube:
     description: ""
@@ -428,12 +417,11 @@ teams:
     privacy: closed
   maintainers-client-python:
     description: maintainers of the client-python project
-    maintainers:
-    - mbohlool
     members:
     - caesarxuchao
     - dims
     - lavalamp
+    - mbohlool
     - sarahnovotny
     - yliaog
     privacy: closed
@@ -449,8 +437,8 @@ teams:
     description: contributors to the cluster-proportional-autoscaler repository
     maintainers:
     - calebamiles
-    - MrHohn
     members:
+    - MrHohn
     - philips
     privacy: closed
   maintainers-cluster-proportional-vertical-autoscaler:
@@ -461,24 +449,22 @@ teams:
     privacy: closed
   maintainers-cri-containerd:
     description: maintainers of cri-containerd repo
-    maintainers:
-    - Random-Liu
     members:
     - abhi
     - dchen1107
     - mikebrow
+    - Random-Liu
     - sarahnovotny
     - yujuhong
     privacy: closed
   maintainers-external-dns:
     description: ""
-    maintainers:
-    - justinsb
     members:
     - chrislovecnm
     - hjacobs
     - ideahitme
     - iterion
+    - justinsb
     - kris-nova
     - linki
     - njuettner
@@ -508,23 +494,22 @@ teams:
   maintainers-kargo:
     description: ""
     maintainers:
-    - ant31
     - calebamiles
     members:
+    - ant31
     - bogdando
     - mattymo
     - rsmitty
     privacy: closed
   maintainers-kompose:
     description: Write access for kompose
-    maintainers:
-    - sebgoa
     members:
     - bgrant0607
     - cab105
     - cdrage
     - janetkuo
     - kadel
+    - sebgoa
     - surajssd
     privacy: closed
   maintainers-kops:
@@ -536,8 +521,8 @@ teams:
     description: maintainers for kube-aws
     maintainers:
     - calebamiles
-    - colhom
     members:
+    - colhom
     - mumoshu
     - pbx0
     - philips
@@ -547,9 +532,9 @@ teams:
     description: contributors to the kube2consul repository
     maintainers:
     - calebamiles
-    - elg0nz
     members:
     - bgrant0607
+    - elg0nz
     privacy: closed
   maintainers-metrics-server:
     description: ""
@@ -567,9 +552,8 @@ teams:
     privacy: closed
   maintainers-node-feature-discovery:
     description: Maintainers of the node-feature-discovery repo.
-    maintainers:
-    - balajismaniam
     members:
+    - balajismaniam
     - ConnorDoyle
     - davidopp
     - flyingcougar
@@ -578,29 +562,26 @@ teams:
     privacy: closed
   maintainers-reference-docs:
     description: maintainers of the reference-docs repo
-    maintainers:
-    - pwittrock
     members:
+    - pwittrock
     - sarahnovotny
     privacy: closed
   maintainers-rktlet:
     description: contributors to the rktlet repository
     maintainers:
     - calebamiles
-    - euank
-    - yifan-gu
     members:
     - dchen1107
+    - euank
+    - yifan-gu
     privacy: closed
   maintainers-service-catalog:
     description: maintainers of the service catalog project
-    maintainers:
-    - carolynvs
-    - duglin
-    - pmorie
     members:
     - arschles
     - bgrant0607
+    - carolynvs
+    - duglin
     - eriknelson
     - jberkhahn
     - jboyd01
@@ -612,6 +593,7 @@ teams:
     - MHBauer
     - n3wscott
     - nilebox
+    - pmorie
     - service-catalog-jenkins
     - slack
     - staebler
@@ -619,10 +601,9 @@ teams:
     privacy: closed
   maintainers-spartakus:
     description: People who maintain spartakus
-    maintainers:
-    - grodrigues3
     members:
     - aronchick
+    - grodrigues3
     - squat
     - thockin
     privacy: closed
@@ -647,12 +628,11 @@ teams:
     privacy: closed
   reviewers-cri-containerd:
     description: reviewers of cri-containerd repo
-    maintainers:
-    - Random-Liu
     members:
     - abhi
     - miaoyq
     - mikebrow
+    - Random-Liu
     - yanxuean
     privacy: closed
   temporary-admin-transfers:

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -211,55 +211,52 @@ members:
 teams:
   application-admins:
     description: admin access to application
-    maintainers:
-    - kow3ns
     members:
+    - kow3ns
     - mattfarina
     - prydonius
     privacy: closed
   architecture-tracking-admins:
     description: admin permission for architecture-tracking
-    maintainers:
+    members:
     - bgrant0607
     - jdumars
     privacy: closed
   architecture-tracking-maintainers:
     description: write permission for architecture-tracking
     maintainers:
-    - bgrant0607
-    - jdumars
     - spiffxp
     members:
+    - bgrant0607
     - dims
+    - jdumars
     - liggitt
     - mattfarina
     - timothysc
     privacy: closed
   aws-ebs-csi-driver-admins:
     description: ""
-    maintainers:
-    - d-nishi
     members:
+    - d-nishi
     - leakingtapan
     privacy: closed
   aws-ebs-csi-driver-maintainers:
     description: ""
-    maintainers:
-    - d-nishi
     members:
     - bertinatto
+    - d-nishi
     - jsafrane
     - leakingtapan
     privacy: closed
   aws-encryption-provider-admins:
     description: admin access to aws_encryption-provider repo
-    maintainers:
+    members:
     - justinsb
     - robinpercy
     privacy: closed
   aws-encryption-provider-maintainers:
     description: write access to aws_encryption-provider
-    maintainers:
+    members:
     - justinsb
     - robinpercy
     privacy: closed
@@ -272,35 +269,32 @@ teams:
     privacy: closed
   cluster-api-admins:
     description: ""
-    maintainers:
-    - timothysc
     members:
     - kris-nova
     - krousey
     - roberthbailey
+    - timothysc
     privacy: closed
   cluster-api-maintainers:
     description: ""
-    maintainers:
-    - timothysc
     members:
     - davidewatson
     - detiber
     - ncdc
+    - timothysc
     - vincepri
     privacy: closed
   cluster-api-provider-aws-admins:
     description: admin access to cluster-api-provider-aws
-    maintainers:
+    members:
     - detiber
     privacy: closed
   cluster-api-provider-aws-maintainers:
     description: write access to cluster-api-provider-aws
-    maintainers:
-    - detiber
     members:
     - chuckha
     - davidewatson
+    - detiber
     - ingvagabund
     - ncdc
     - timothysc
@@ -308,7 +302,7 @@ teams:
     privacy: closed
   cluster-api-provider-digitalocean-admins:
     description: ""
-    maintainers:
+    members:
     - roberthbailey
     - timothysc
     - xmudrii
@@ -316,37 +310,35 @@ teams:
   cluster-api-provider-digitalocean-maintainers:
     description: ""
     maintainers:
-    - alvaroaleman
     - nikhita
+    members:
+    - alvaroaleman
     - roberthbailey
     - timothysc
     - xmudrii
     privacy: closed
   cluster-api-provider-gcp-admins:
     description: admin access to cluster-api-provider-gcp
-    maintainers:
+    members:
     - roberthbailey
     privacy: closed
   cluster-api-provider-gcp-maintainers:
     description: write access to cluster-api-provider-gcp-maintainers
-    maintainers:
-    - roberthbailey
     members:
     - justinsb
+    - roberthbailey
     privacy: closed
   cluster-api-provider-openstack-admins:
     description: admin access to cluster-api-provider-openstack
-    maintainers:
-    - dims
     members:
     - chaosaffe
+    - dims
     privacy: closed
   cluster-api-provider-openstack-maintainers:
     description: write access to cluster-api-provider-openstack
-    maintainers:
-    - dims
     members:
     - chaosaffe
+    - dims
     privacy: closed
   cluster-api-provider-vsphere-admins:
     description: admin access to cluster-api-provider-vsphere-admins
@@ -364,56 +356,50 @@ teams:
     privacy: closed
   contributor-site-admins:
     description: admin access to contributor-site
-    maintainers:
-    - castrojo
     members:
+    - castrojo
     - mrbobbytables
     privacy: closed
   contributor-site-maintainers:
     description: write access to contributor-site
-    maintainers:
-    - castrojo
     members:
+    - castrojo
     - mrbobbytables
     privacy: closed
   cri-o-admins:
     description: admin access to cri-o
-    maintainers:
-    - mrunalp
     members:
+    - mrunalp
     - runcom
     privacy: closed
   cri-o-maintainers:
     description: write access to cri-o
-    maintainers:
-    - mrunalp
     members:
     - giuseppe
+    - mrunalp
     - rhatdan
     - runcom
     - sboeuf
     privacy: closed
   cri-tools-admins:
     description: admin access to cri-tools
-    maintainers:
+    members:
     - feiskyer
     - mrunalp
-    members:
     - Random-Liu
     - yujuhong
     privacy: closed
   cri-tools-maintainers:
     description: write access to cri-tools
-    maintainers:
+    members:
     - feiskyer
     - mrunalp
-    members:
     - Random-Liu
     - yujuhong
     privacy: closed
   dashboard-metrics-scraper-admins:
     description: admin access to dashboard-metrics-scraper
-    maintainers:
+    members:
     - bryk
     - floreks
     - jeefy
@@ -421,7 +407,7 @@ teams:
     privacy: closed
   dashboard-metrics-scraper-maintainers:
     description: write access to dashboard-metrics-scraper
-    maintainers:
+    members:
     - bryk
     - floreks
     - jeefy
@@ -429,13 +415,13 @@ teams:
     privacy: closed
   etcdadm-admins:
     description: admin access to etcdadm
-    maintainers:
+    members:
     - dlipovetsky
     - justinsb
     privacy: closed
   etcdadm-maintainers:
     description: write access to etcdadm
-    maintainers:
+    members:
     - dlipovetsky
     - justinsb
     privacy: closed
@@ -452,21 +438,19 @@ teams:
     privacy: closed
   federation-v2-maintainers:
     description: write access to the fededation-v2 repo
-    maintainers:
-    - marun
     members:
     - font
     - irfanurrehman
+    - marun
     - shashidharatd
     privacy: closed
   federation-wg:
     description: Individuals who are part of sig-multicluster and working as federation
       workgroup.
-    maintainers:
-    - irfanurrehman
     members:
     - font
     - gyliu513
+    - irfanurrehman
     - marun
     - onyiny-ang
     - pmorie
@@ -476,28 +460,26 @@ teams:
     privacy: closed
   gcp-filestore-csi-driver-admins:
     description: ""
-    maintainers:
+    members:
     - msau42
     - saad-ali
     privacy: closed
   gcp-filestore-csi-driver-maintainers:
     description: ""
-    maintainers:
+    members:
     - msau42
     - saad-ali
     privacy: closed
   kind-admins:
     description: ""
-    maintainers:
-    - BenTheElder
     members:
+    - BenTheElder
     - munnerz
     privacy: closed
   kind-maintainers:
     description: ""
-    maintainers:
-    - BenTheElder
     members:
+    - BenTheElder
     - munnerz
     privacy: closed
   kube-batch-admins:
@@ -541,17 +523,15 @@ teams:
     privacy: closed
   kubespray-admins:
     description: ""
-    maintainers:
-    - ant31
     members:
+    - ant31
     - chadswen
     - mattymo
     privacy: closed
   kubespray-maintainers:
     description: ""
-    maintainers:
-    - ant31
     members:
+    - ant31
     - Atoms
     - chadswen
     - mattymo
@@ -605,77 +585,69 @@ teams:
     privacy: closed
   sig-storage-lib-external-provisioner-admins:
     description: admin access to sig-storage-lib-external-provisioner
-    maintainers:
-    - wongma7
     members:
     - childsb
     - jsafrane
+    - wongma7
     privacy: closed
   sig-storage-lib-external-provisioner-maintainers:
     description: write access to sig-storage-lib-external-provisioner
-    maintainers:
-    - wongma7
     members:
     - childsb
     - jsafrane
+    - wongma7
     privacy: closed
   sig-storage-local-static-provisioner-admins:
     description: ""
-    maintainers:
+    members:
     - jsafrane
     - msau42
     - saad-ali
     privacy: closed
   sig-storage-local-static-provisioner-maintainers:
     description: ""
-    maintainers:
+    members:
     - jsafrane
     - msau42
     - saad-ali
     privacy: closed
   testing_frameworks-admins:
     description: admin access for testing_frameworks
-    maintainers:
-    - hoegaarden
     members:
+    - hoegaarden
     - totherme
     privacy: closed
   testing_frameworks-maintainers:
     description: write access to testing_frameworks
-    maintainers:
-    - liztio
     members:
+    - liztio
     - marun
     privacy: closed
   website-metadata-admins:
     description: ""
-    maintainers:
-    - Bradamant3
-    - zacharysarah
     members:
+    - Bradamant3
     - chenopis
+    - zacharysarah
     privacy: closed
   website-metadata-maintainers:
     description: ""
-    maintainers:
-    - Bradamant3
-    - zacharysarah
     members:
+    - Bradamant3
     - chenopis
+    - zacharysarah
     privacy: closed
   windows-testing-admins:
     description: ""
-    maintainers:
-    - michmike
-    - PatrickLang
     members:
     - adelina-t
+    - michmike
+    - PatrickLang
     privacy: closed
   windows-testing-maintainers:
     description: ""
-    maintainers:
-    - michmike
-    - PatrickLang
     members:
     - adelina-t
+    - michmike
+    - PatrickLang
     privacy: closed

--- a/config/kubernetes-sigs/sig-api-machinery/teams.yaml
+++ b/config/kubernetes-sigs/sig-api-machinery/teams.yaml
@@ -66,11 +66,13 @@ teams:
   kubebuilder-declarative-pattern-admins:
     description: admin access to kubebuilder-declarative-pattern
     members:
+    - johnsonj
     - justinsb
     privacy: closed
   kubebuilder-declarative-pattern-maintainers:
     description: write access to kubebuilder-declarative-pattern
     members:
+    - johnsonj
     - justinsb
     privacy: closed
   kubebuilder-maintainers:

--- a/config/kubernetes-sigs/sig-api-machinery/teams.yaml
+++ b/config/kubernetes-sigs/sig-api-machinery/teams.yaml
@@ -1,20 +1,20 @@
 teams:
   controller-runtime-admins:
-    description: "admin access to controller-runtime"
+    description: admin access to controller-runtime
     members:
     - DirectXMan12
     - droot
     - pwittrock
     privacy: closed
   controller-runtime-contributors:
-    description: "read access to controller-runtime"
+    description: read access to controller-runtime
     members:
     - fanzhangio
     - lichuqiang
     - pwittrock
     privacy: closed
   controller-runtime-maintainers:
-    description: "write access to controller-runtime"
+    description: write access to controller-runtime
     members:
     - Liujingfang1
     - mengqiy
@@ -22,7 +22,7 @@ teams:
     - seans3
     privacy: closed
   controller-tools-admins:
-    description: "admin access to controller-tools"
+    description: admin access to controller-tools
     members:
     - DirectXMan12
     - droot
@@ -30,13 +30,13 @@ teams:
     - seans3
     privacy: closed
   controller-tools-contributors:
-    description: "read access to controller-tools"
+    description: read access to controller-tools
     members:
     - Birdrock
     - pwittrock
     privacy: closed
   controller-tools-maintainers:
-    description: "write access to controller-tools"
+    description: write access to controller-tools
     members:
     - droot
     - mengqiy
@@ -44,12 +44,11 @@ teams:
     - seans3
     privacy: closed
   kubebuilder-admins:
-    description: "admin access to kubebuilder"
-    maintainers:
-    - grodrigues3
+    description: admin access to kubebuilder
     members:
     - DirectXMan12
     - droot
+    - grodrigues3
     - Liujingfang1
     - mengqiy
     - monopole
@@ -57,15 +56,25 @@ teams:
     - pwittrock
     privacy: closed
   kubebuilder-contributors:
-    description: "read access to kubebuilder"
+    description: read access to kubebuilder
     members:
     - DirectXMan12
     - fanzhangio
     - lichuqiang
     - pwittrock
     privacy: closed
+  kubebuilder-declarative-pattern-admins:
+    description: admin access to kubebuilder-declarative-pattern
+    members:
+    - justinsb
+    privacy: closed
+  kubebuilder-declarative-pattern-maintainers:
+    description: write access to kubebuilder-declarative-pattern
+    members:
+    - justinsb
+    privacy: closed
   kubebuilder-maintainers:
-    description: "write access to kubebuilder"
+    description: write access to kubebuilder
     members:
     - apelisse
     - DirectXMan12
@@ -75,18 +84,6 @@ teams:
     - pmorie
     - pwittrock
     - seans3
-    privacy: closed
-  kubebuilder-declarative-pattern-admins:
-    description: "admin access to kubebuilder-declarative-pattern"
-    members:
-    # - johnsonj # TODO: uncomment once johnsonj is a member, ref: https://github.com/kubernetes/org/issues/418#issuecomment-465357261
-    - justinsb
-    privacy: closed
-  kubebuilder-declarative-pattern-maintainers:
-    description: "write access to kubebuilder-declarative-pattern"
-    members:
-    # - johnsonj # TODO: uncomment once johnsonj is a member, ref: https://github.com/kubernetes/org/issues/418#issuecomment-465357261
-    - justinsb
     privacy: closed
   kubernetes/sig-api-machinery:
     description: Parent team for all SIG API Machinery subteams (approvers, reviewers,
@@ -116,31 +113,30 @@ teams:
         privacy: closed
   structured-merge-diff-admins:
     description: admin access to structured-merge-diff
-    maintainers:
-      - apelisse
-      - lavalamp
+    members:
+    - apelisse
+    - lavalamp
     privacy: closed
   structured-merge-diff-maintainers:
     description: write access to structured-merge-diff
-    maintainers:
-      - apelisse
-      - lavalamp
     members:
-      - jennybuckley
+    - apelisse
+    - jennybuckley
+    - lavalamp
     privacy: closed
   yaml-admins:
     description: ""
-    maintainers:
-      - deads2k
-      - dims
-      - lavalamp
-      - liggitt
+    members:
+    - deads2k
+    - dims
+    - lavalamp
+    - liggitt
     privacy: closed
   yaml-maintainers:
     description: ""
-    maintainers:
-      - deads2k
-      - dims
-      - lavalamp
-      - liggitt
+    members:
+    - deads2k
+    - dims
+    - lavalamp
+    - liggitt
     privacy: closed

--- a/config/kubernetes-sigs/sig-azure/teams.yaml
+++ b/config/kubernetes-sigs/sig-azure/teams.yaml
@@ -1,14 +1,13 @@
 teams:
   cluster-api-provider-azure-admins:
     description: ""
-    maintainers:
+    members:
     - justaugustus
     privacy: closed
   cluster-api-provider-azure-maintainers:
     description: ""
-    maintainers:
-    - justaugustus
     members:
+    - justaugustus
     - soggiest
     - tariq1890
     privacy: closed

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -807,19 +807,16 @@ teams:
   api-approvers:
     description: Approve changes to stable Kubernetes APIs and addition of new beta/stable
       APIs
-    maintainers:
-    - liggitt
     members:
     - bgrant0607
     - erictune
     - lavalamp
+    - liggitt
     - smarterclayton
     - thockin
     privacy: closed
   api-reviewers:
     description: See also api-approvers.
-    maintainers:
-    - pwittrock
     members:
     - davidopp
     - deads2k
@@ -828,33 +825,30 @@ teams:
     - lavalamp
     - liggitt
     - mikedanese
+    - pwittrock
     - smarterclayton
     - thockin
     - vishh
     privacy: closed
   autoscaler-admins:
     description: ""
-    maintainers:
-    - mwielgus
     members:
     - MaciekPytel
+    - mwielgus
     privacy: closed
   autoscaler-maintainers:
     description: ""
-    maintainers:
-    - mwielgus
     members:
     - aleksandra-malinowska
     - bskiba
     - DirectXMan12
     - losipiuk
     - MaciekPytel
+    - mwielgus
     - piosz
     privacy: closed
   autoscaler-reviewers:
     description: ""
-    maintainers:
-    - mwielgus
     members:
     - aleksandra-malinowska
     - bskiba
@@ -862,6 +856,7 @@ teams:
     - feiskyer
     - jszczepkowski
     - MaciekPytel
+    - mwielgus
     - piosz
     privacy: closed
   bash-firefighters:
@@ -903,43 +898,41 @@ teams:
   cloud-provider-gcp-admins:
     description: admin access to cloud-provider-gcp
     maintainers:
-    - awly
     - calebamiles
     members:
+    - awly
     - mikedanese
     privacy: closed
   cloud-provider-gcp-maintainers:
     description: write access to cloud-provider-gcp
     maintainers:
-    - awly
     - calebamiles
     members:
+    - awly
     - mikedanese
     privacy: closed
   cloud-provider-openstack-admins:
     description: Admin access to cloud-provider-openstack repo
-    maintainers:
-    - dklyle
-    - hogepodge
     members:
     - dims
+    - dklyle
+    - hogepodge
     privacy: closed
   cloud-provider-openstack-maintainers:
     description: Write access to the cloud-provider-openstack repo
-    maintainers:
-    - dklyle
-    - hogepodge
     members:
     - dims
+    - dklyle
+    - hogepodge
     privacy: closed
   cloud-provider-openstack-members:
     description: ""
-    maintainers:
+    members:
     - dims
     privacy: closed
   cloud-provider-vsphere-admins:
     description: admin access to cloud-provider-vsphere repository
-    maintainers:
+    members:
     - abrarshivani
     - BaluDontu
     - divyenpatel
@@ -950,7 +943,7 @@ teams:
     privacy: closed
   cloud-provider-vsphere-maintainers:
     description: write access to the cloud-provider-vsphere repo
-    maintainers:
+    members:
     - abrarshivani
     - BaluDontu
     - divyenpatel
@@ -961,36 +954,32 @@ teams:
     privacy: closed
   cluster-registry-admins:
     description: Admin access to cluster-registry repo
-    maintainers:
+    members:
+    - font
     - madhusudancs
     - perotinus
     - pmorie
-    members:
-    - font
     privacy: closed
   cluster-registry-maintainers:
     description: Write access to the cluster-registry repo.
-    maintainers:
-    - perotinus
-    - pmorie
     members:
     - font
     - madhusudancs
+    - perotinus
+    - pmorie
     privacy: closed
   cluster-registry-reviewers:
     description: cluster-registry reviewers. Read access to the cluster-registry repository.
-    maintainers:
+    members:
+    - font
     - madhusudancs
     - perotinus
     - pmorie
-    members:
-    - font
     privacy: closed
   cncf-conformance-wg:
     description: ""
     maintainers:
     - spiffxp
-    - timothysc
     members:
     - bgrant0607
     - bradtopol
@@ -1004,6 +993,7 @@ teams:
     - mgdevstack
     - rjbez17
     - smarterclayton
+    - timothysc
     - WilliamDenniss
     privacy: closed
   cncf-wg:
@@ -1017,17 +1007,15 @@ teams:
     privacy: closed
   code-generator-admins:
     description: ""
-    maintainers:
-    - deads2k
-    - sttts
     members:
+    - deads2k
     - eparis
+    - sttts
     privacy: closed
   code-generator-maintainers:
     description: ""
-    maintainers:
-    - deads2k
     members:
+    - deads2k
     - eparis
     - sttts
     privacy: closed
@@ -1050,12 +1038,12 @@ teams:
     privacy: closed
   csi-api-admins:
     description: admin access to csi-api
-    maintainers:
+    members:
     - saad-ali
     privacy: closed
   csi-api-maintainers:
     description: write access to csi-api
-    maintainers:
+    members:
     - saad-ali
     privacy: closed
   dashboard-admins:
@@ -1098,10 +1086,9 @@ teams:
     privacy: closed
   dns-maintainers:
     description: Maintainers of the DNS repository (can write to the repo)
-    maintainers:
+    members:
     - bowei
     - MrHohn
-    members:
     - thockin
     privacy: closed
   dns-reviewers:
@@ -1129,56 +1116,53 @@ teams:
     description: Admin privileges for the examples repo
     maintainers:
     - idvoretskyi
+    members:
     - sebgoa
     privacy: closed
   examples-maintainers:
     description: Write access to the examples repository
     maintainers:
     - idvoretskyi
-    - sebgoa
     members:
     - ahmetb
+    - sebgoa
     privacy: closed
   examples-reviewers:
     description: Read access to the examples repository
-    maintainers:
+    members:
     - sebgoa
     privacy: closed
   federation-admins:
     description: Admin permission to federation repo
-    maintainers:
-    - madhusudancs
     members:
     - csbell
     - irfanurrehman
+    - madhusudancs
     privacy: closed
   federation-maintainers:
     description: Contributors with write access to kubernetes/federation repo
-    maintainers:
-    - madhusudancs
     members:
     - csbell
     - irfanurrehman
+    - madhusudancs
     privacy: closed
   federation-reviewers:
     description: Contributors with read access to kubernetes/federation repo
-    maintainers:
-    - madhusudancs
     members:
     - csbell
     - irfanurrehman
+    - madhusudancs
     privacy: closed
   frakti-admins:
     description: ""
-    maintainers:
-    - feiskyer
-    - resouer
     members:
     - dchen1107
+    - feiskyer
+    - resouer
     privacy: closed
   frakti-maintainers:
     description: ""
-    maintainers:
+    members:
     - feiskyer
     privacy: closed
   gengo-admins:
@@ -1221,14 +1205,13 @@ teams:
     privacy: closed
   goog-gke:
     description: Google Kubernetes Engine
-    maintainers:
-    - alex-mohr
-    - fabioy
     members:
     - ajitak
+    - alex-mohr
     - bdbauer
     - cjcullen
     - destijl
+    - fabioy
     - ihmccreery
     - jcbsmpsn
     - jessicaochen
@@ -1241,13 +1224,12 @@ teams:
     privacy: closed
   goog-image:
     description: ""
-    maintainers:
-    - yinghan
     members:
     - adityakali
     - Amey-D
     - dchen1107
     - wonderfly
+    - yinghan
     privacy: closed
   ingress-gce-admins:
     description: ""
@@ -1279,18 +1261,16 @@ teams:
     privacy: closed
   ingress-nginx-admins:
     description: ""
-    maintainers:
-    - aledbf
     members:
+    - aledbf
     - bowei
     - bprashanth
     privacy: closed
   ingress-nginx-maintainers:
     description: Maintainers of the ingress repo
-    maintainers:
-    - bprashanth
     members:
     - aledbf
+    - bprashanth
     - justinsb
     - nicksardo
     privacy: closed
@@ -1302,11 +1282,10 @@ teams:
     privacy: closed
   intel:
     description: ""
-    maintainers:
-    - ConnorDoyle
     members:
     - balajismaniam
     - bart0sh
+    - ConnorDoyle
     - davidopp
     - kad
     privacy: closed
@@ -1314,16 +1293,16 @@ teams:
     description: ""
     maintainers:
     - cblecker
-    - dims
     - idvoretskyi
     - spiffxp
-    - thockin
     members:
     - amwat
     - BenTheElder
     - brendandburns
+    - dims
     - ixdy
     - shyamjvs
+    - thockin
     privacy: closed
   k8s.io-maintainers:
     description: People who run k8s.io
@@ -1336,52 +1315,48 @@ teams:
     privacy: closed
   klog-admins:
     description: ""
-    maintainers:
+    members:
     - dims
     - thockin
     privacy: closed
   klog-maintainers:
     description: ""
-    maintainers:
-    - dims
-    - thockin
     members:
+    - dims
     - erictune
     - justinsb
     - lavalamp
     - tallclair
+    - thockin
     privacy: closed
   kompose-admins:
     description: administrators for kompose repo
-    maintainers:
-    - sebgoa
     members:
     - cdrage
     - janetkuo
     - kadel
     - ngtuna
     - sarahnovotny
+    - sebgoa
     privacy: closed
   kompose-contributors:
     description: contributors to the kompose repo
-    maintainers:
-    - sebgoa
     members:
     - cdrage
     - ngtuna
     - procrypt
     - sarahnovotny
+    - sebgoa
     privacy: closed
   kompose-maintainers:
     description: maintainers for kompose
-    maintainers:
-    - cdrage
-    - sebgoa
     members:
     - cab105
+    - cdrage
     - janetkuo
     - kadel
     - sarahnovotny
+    - sebgoa
     - surajssd
     privacy: closed
   kops-admins:
@@ -1393,11 +1368,10 @@ teams:
     privacy: closed
   kops-maintainers:
     description: ""
-    maintainers:
-    - justinsb
     members:
     - chrislovecnm
     - geojaz
+    - justinsb
     - kris-nova
     - mikedanese
     - mikesplain
@@ -1410,24 +1384,21 @@ teams:
     privacy: closed
   kube-deploy-admins:
     description: ""
-    maintainers:
-    - justinsb
     members:
+    - justinsb
     - kris-nova
     privacy: closed
   kube-deploy-maintainers:
     description: ""
-    maintainers:
-    - justinsb
     members:
+    - justinsb
     - kris-nova
     privacy: closed
   kube-state-metrics-admins:
     description: Admin for kube-state-metrics
-    maintainers:
-    - ghodss
     members:
     - fabxc
+    - ghodss
     privacy: closed
   kube-state-metrics-maintainers:
     description: ""
@@ -1448,10 +1419,6 @@ teams:
     privacy: closed
   kubeadm-maintainers:
     description: Maintainers of kubeadm
-    maintainers:
-    - luxas
-    - roberthbailey
-    - timothysc
     members:
     - chuckha
     - detiber
@@ -1461,46 +1428,43 @@ teams:
     - jbeda
     - liztio
     - lukemarsden
+    - luxas
     - medinatiger
     - neolit123
     - pipejakob
+    - roberthbailey
     - stealthybox
+    - timothysc
     privacy: closed
   kubeadm-reviewers:
     description: Collaborators for kubeadm
-    maintainers:
-    - errordeveloper
-    - jbeda
-    - lukemarsden
-    - luxas
     members:
     - chuckha
     - detiber
     - dixudx
+    - errordeveloper
     - fabriziopandini
     - jamiehannaford
+    - jbeda
     - liztio
+    - lukemarsden
+    - luxas
     - medinatiger
     - stealthybox
     privacy: closed
   kubectl-admins:
     description: Administrators of the kubectl repo
-    maintainers:
-    - pwittrock
-    - seans3
-    - soltysh
     members:
     - adohe
     - fabianofranz
     - juanvallejo
     - monopole
-    privacy: closed
-  kubectl-maintainers:
-    description: Maintainers of the kubectl repo
-    maintainers:
     - pwittrock
     - seans3
     - soltysh
+    privacy: closed
+  kubectl-maintainers:
+    description: Maintainers of the kubectl repo
     members:
     - adohe
     - apelisse
@@ -1508,22 +1472,24 @@ teams:
     - juanvallejo
     - mengqiy
     - monopole
+    - pwittrock
+    - seans3
     - shiywang
+    - soltysh
     - yue9944882
     privacy: closed
   kubectl-reviewers:
     description: Code reviewers for the kubectl repo
-    maintainers:
-    - pwittrock
-    - seans3
-    - soltysh
     members:
     - adohe
     - fabianofranz
     - juanvallejo
     - mengqiy
     - monopole
+    - pwittrock
+    - seans3
     - shiywang
+    - soltysh
     privacy: closed
   kubernetes-admins:
     description: 'Do not add new people to this group.  Add build-cops to kubernetes-build-cops  and
@@ -1538,32 +1504,30 @@ teams:
     privacy: closed
   kubernetes-anywhere-admins:
     description: ""
-    maintainers:
+    members:
     - luxas
     - neolit123
     - timothysc
     privacy: closed
   kubernetes-anywhere-maintainers:
     description: Maintainers of the kubernetes-anywhere repository
-    maintainers:
-    - luxas
-    - neolit123
-    - timothysc
     members:
     - errordeveloper
     - fabriziopandini
     - kerneltime
+    - luxas
     - monadic
+    - neolit123
+    - timothysc
     privacy: closed
   kubernetes-blog-maintainers:
     description: Maintaining the Kubernetes blog on kubernetes.io
-    maintainers:
-    - zacharysarah
     members:
     - bobsky
     - kbarnard10
     - natekartchner
     - SarahKConway
+    - zacharysarah
     privacy: closed
   kubernetes-maintainers:
     description: Write access to kubernetes repo. Follow the process in https://github.com/kubernetes/community/blob/master/community-membership.md
@@ -1746,29 +1710,27 @@ teams:
   kubernetes-staging-publish-cops:
     description: will be notified if the robot fails to publish the staging folder
       to repos
-    maintainers:
-    - caesarxuchao
     members:
+    - caesarxuchao
     - deads2k
     - lavalamp
     - sttts
     privacy: closed
   kubernetes-website-admins:
     description: Admins of kubernetes/website repo
-    maintainers:
-    - chenopis
-    - jaredbhatti
-    - pwittrock
-    - sebgoa
-    - steveperry-53
-    - zacharysarah
     members:
     - Bradamant3
+    - chenopis
+    - jaredbhatti
     - Kashomon
     - lavalamp
     - mistyhacks
+    - pwittrock
+    - sebgoa
+    - steveperry-53
     - tfogo
     - thockin
+    - zacharysarah
     - zparnold
     privacy: closed
   maintainer-test-exemptions:
@@ -1820,26 +1782,23 @@ teams:
     privacy: closed
   node-problem-detector-admins:
     description: Maintainers of node problem detector
-    maintainers:
-    - Random-Liu
     members:
     - dchen1107
+    - Random-Liu
     privacy: closed
   node-problem-detector-maintainers:
     description: ""
-    maintainers:
-    - Random-Liu
     members:
     - andyxning
     - dchen1107
+    - Random-Liu
     - wangzhen127
     privacy: closed
   node-problem-detector-reviewers:
     description: ""
-    maintainers:
-    - Random-Liu
     members:
     - andyxning
+    - Random-Liu
     - wangzhen127
     privacy: closed
   owners:
@@ -1854,25 +1813,23 @@ teams:
     privacy: closed
   perf-tests-admins:
     description: ""
-    maintainers:
-    - gmarek
-    - wojtek-t
     members:
     - bowei
+    - gmarek
+    - wojtek-t
     privacy: closed
   perf-tests-maintainers:
     description: ""
-    maintainers:
-    - gmarek
-    - wojtek-t
     members:
     - bowei
+    - gmarek
     - shyamjvs
     - timothysc
+    - wojtek-t
     privacy: closed
   perf-tests-reviewers:
     description: ""
-    maintainers:
+    members:
     - gmarek
     - wojtek-t
     privacy: closed
@@ -1884,9 +1841,9 @@ teams:
     - liggitt
     - philips
     - tallclair
-    privacy: closed
     previously:
     - product-security-team
+    privacy: closed
   repo-infra-maintainers:
     description: ""
     members:
@@ -1913,15 +1870,15 @@ teams:
   steering-committee:
     description: Kubernetes Steering Committee
     maintainers:
-    - brendandburns
-    - jbeda
-    - philips
     - spiffxp
     members:
     - bgrant0607
+    - brendandburns
     - derekwaynecarr
     - dims
+    - jbeda
     - michelleN
+    - philips
     - pwittrock
     - sarahnovotny
     - smarterclayton
@@ -1939,10 +1896,9 @@ teams:
     privacy: closed
   utils-admins:
     description: ""
-    maintainers:
+    members:
     - apelisse
     - dims
-    members:
     - mengqiy
     - monopole
     - pwittrock
@@ -1950,10 +1906,9 @@ teams:
     privacy: closed
   utils-maintainers:
     description: ""
-    maintainers:
+    members:
     - apelisse
     - dims
-    members:
     - mengqiy
     - monopole
     - pwittrock
@@ -1961,10 +1916,9 @@ teams:
     privacy: closed
   utils-reviewers:
     description: ""
-    maintainers:
+    members:
     - apelisse
     - dims
-    members:
     - mengqiy
     - monopole
     - pwittrock

--- a/config/kubernetes/sig-api-machinery/teams.yaml
+++ b/config/kubernetes/sig-api-machinery/teams.yaml
@@ -18,9 +18,8 @@ teams:
     privacy: closed
   sig-api-machinery-misc:
     description: Use only if you can't figure out a better category
-    maintainers:
-    - deads2k
     members:
+    - deads2k
     - derekwaynecarr
     - enj
     - ironcladlou
@@ -34,9 +33,8 @@ teams:
     privacy: closed
   sig-api-machinery-pr-reviews:
     description: ""
-    maintainers:
-    - deads2k
     members:
+    - deads2k
     - lavalamp
     - liggitt
     - smarterclayton

--- a/config/kubernetes/sig-apps/teams.yaml
+++ b/config/kubernetes/sig-apps/teams.yaml
@@ -1,127 +1,120 @@
 teams:
   sig-apps-api-reviews:
     description: ""
-    maintainers:
-    - enisoc
-    - foxish
-    - janetkuo
-    - mattfarina
-    - soltysh
     members:
     - davidopp
     - dhilipkumars
     - dixudx
+    - enisoc
+    - foxish
+    - janetkuo
     - kow3ns
     - lukaszo
+    - mattfarina
     - mfojtik
     - smarterclayton
+    - soltysh
     - tnozicka
     - zouyee
     privacy: closed
   sig-apps-bugs:
     description: ""
-    maintainers:
+    members:
+    - davidopp
     - enisoc
     - foxish
     - janetkuo
-    - mattfarina
-    - soltysh
-    members:
-    - davidopp
     - kow3ns
     - lukaszo
+    - mattfarina
     - mfojtik
     - resouer
     - smarterclayton
+    - soltysh
     - tnozicka
     - wanghaoran1988
     privacy: closed
   sig-apps-feature-requests:
     description: ""
-    maintainers:
+    members:
+    - ant31
+    - davidopp
     - enisoc
     - foxish
     - janetkuo
     - kow3ns
-    - mattfarina
-    - soltysh
-    members:
-    - ant31
-    - davidopp
     - lukaszo
+    - mattfarina
     - mfojtik
     - prydonius
     - resouer
     - smarterclayton
+    - soltysh
     - tnozicka
     privacy: closed
   sig-apps-misc:
     description: Use only if you can't figure out a better category
-    maintainers:
+    members:
+    - davidopp
     - enisoc
     - foxish
     - janetkuo
-    - mattfarina
-    - soltysh
-    members:
-    - davidopp
     - kow3ns
     - lukaszo
+    - mattfarina
     - mfojtik
     - prydonius
     - resouer
     - smarterclayton
+    - soltysh
     - tnozicka
     privacy: closed
   sig-apps-pr-reviews:
     description: ""
-    maintainers:
-    - enisoc
-    - foxish
-    - janetkuo
-    - mattfarina
-    - soltysh
     members:
     - davidopp
     - dhilipkumars
+    - enisoc
+    - foxish
+    - janetkuo
     - kow3ns
     - lukaszo
+    - mattfarina
     - mfojtik
     - resouer
     - smarterclayton
+    - soltysh
     - tnozicka
     privacy: closed
   sig-apps-proposals:
     description: ""
-    maintainers:
+    members:
+    - davidopp
     - enisoc
     - foxish
     - janetkuo
-    - mattfarina
-    - soltysh
-    members:
-    - davidopp
     - kow3ns
     - lukaszo
+    - mattfarina
     - mfojtik
     - prydonius
     - smarterclayton
+    - soltysh
     - tnozicka
     privacy: closed
   sig-apps-test-failures:
     description: ""
-    maintainers:
+    members:
+    - davidopp
     - enisoc
     - foxish
     - janetkuo
-    - mattfarina
-    - soltysh
-    members:
-    - davidopp
     - kow3ns
     - lukaszo
+    - mattfarina
     - mfojtik
     - prydonius
     - smarterclayton
+    - soltysh
     - tnozicka
     privacy: closed

--- a/config/kubernetes/sig-architecture/teams.yaml
+++ b/config/kubernetes/sig-architecture/teams.yaml
@@ -1,10 +1,9 @@
 teams:
   sig-architecture-api-reviews:
     description: SIG Architecture API review notifications
-    maintainers:
-    - liggitt
     members:
     - bgrant0607
+    - liggitt
     - smarterclayton
     privacy: closed
   sig-architecture-bugs:
@@ -16,9 +15,9 @@ teams:
     description: SIG Architecture feature request notifications
     maintainers:
     - idvoretskyi
-    - liggitt
     members:
     - bgrant0607
+    - liggitt
     - smarterclayton
     privacy: closed
   sig-architecture-misc-use-only-as-a-last-resort:
@@ -30,11 +29,10 @@ teams:
     privacy: closed
   sig-architecture-pr-reviews:
     description: SIG Architecture PR review notifications
-    maintainers:
-    - liggitt
     members:
     - bgrant0607
     - jbeda
+    - liggitt
     - smarterclayton
     - timothysc
     privacy: closed

--- a/config/kubernetes/sig-auth/teams.yaml
+++ b/config/kubernetes/sig-auth/teams.yaml
@@ -1,48 +1,41 @@
 teams:
   sig-auth-api-reviews:
     description: ""
-    maintainers:
-    - liggitt
-    - tallclair
     members:
     - davidopp
     - deads2k
     - enj
+    - liggitt
     - mattmoyer
     - mikedanese
+    - tallclair
     privacy: closed
   sig-auth-bugs:
     description: ""
-    maintainers:
-    - liggitt
-    - tallclair
     members:
     - davidopp
     - deads2k
     - enj
+    - liggitt
     - mattmoyer
     - mikedanese
+    - tallclair
     privacy: closed
   sig-auth-feature-requests:
     description: ""
-    maintainers:
-    - deads2k
-    - liggitt
-    - tallclair
     members:
     - davidopp
+    - deads2k
     - destijl
     - enj
+    - liggitt
     - mattmoyer
     - mikedanese
     - smarterclayton
+    - tallclair
     privacy: closed
   sig-auth-misc:
     description: ""
-    maintainers:
-    - erictune
-    - liggitt
-    - tallclair
     members:
     - alex-mohr
     - cjcullen
@@ -50,48 +43,48 @@ teams:
     - deads2k
     - destijl
     - enj
+    - erictune
     - gtank
+    - liggitt
     - mattmoyer
     - mikedanese
     - pmorie
     - smarterclayton
+    - tallclair
     - timstclair
     privacy: closed
   sig-auth-pr-reviews:
     description: ""
-    maintainers:
-    - liggitt
-    - tallclair
     members:
     - davidopp
     - deads2k
     - enj
+    - liggitt
     - mattmoyer
     - mikedanese
+    - tallclair
     privacy: closed
   sig-auth-proposals:
     description: ""
-    maintainers:
-    - liggitt
-    - tallclair
     members:
     - davidopp
     - deads2k
     - destijl
     - enj
+    - liggitt
     - mattmoyer
     - mikedanese
     - smarterclayton
+    - tallclair
     privacy: closed
   sig-auth-test-failures:
     description: ""
-    maintainers:
-    - liggitt
-    - tallclair
     members:
     - davidopp
     - deads2k
     - enj
+    - liggitt
     - mattmoyer
     - mikedanese
+    - tallclair
     privacy: closed

--- a/config/kubernetes/sig-autoscaling/teams.yaml
+++ b/config/kubernetes/sig-autoscaling/teams.yaml
@@ -1,78 +1,71 @@
 teams:
   sig-autoscaling-api-reviews:
     description: ""
-    maintainers:
-    - DirectXMan12
-    - mwielgus
     members:
     - aleksandra-malinowska
     - bskiba
     - davidopp
+    - DirectXMan12
     - MaciekPytel
+    - mwielgus
     privacy: closed
   sig-autoscaling-bugs:
     description: ""
-    maintainers:
-    - DirectXMan12
-    - mwielgus
     members:
     - aleksandra-malinowska
     - bskiba
     - davidopp
+    - DirectXMan12
     - MaciekPytel
+    - mwielgus
     privacy: closed
   sig-autoscaling-feature-requests:
     description: ""
-    maintainers:
-    - DirectXMan12
-    - mwielgus
     members:
     - aleksandra-malinowska
     - bskiba
     - davidopp
+    - DirectXMan12
     - MaciekPytel
+    - mwielgus
     privacy: closed
   sig-autoscaling-misc:
     description: ""
-    maintainers:
-    - DirectXMan12
-    - mwielgus
     members:
     - aleksandra-malinowska
     - bskiba
     - davidopp
+    - DirectXMan12
     - MaciekPytel
+    - mwielgus
     privacy: closed
   sig-autoscaling-pr-reviews:
     description: ""
-    maintainers:
-    - DirectXMan12
-    - mwielgus
     members:
     - aleksandra-malinowska
     - bskiba
     - davidopp
+    - DirectXMan12
     - MaciekPytel
+    - mwielgus
     privacy: closed
   sig-autoscaling-proposals:
     description: ""
-    maintainers:
-    - mwielgus
     members:
     - aleksandra-malinowska
     - bskiba
     - davidopp
     - DirectXMan12
     - MaciekPytel
+    - mwielgus
     privacy: closed
   sig-autoscaling-test-failures:
     description: ""
-    maintainers:
-    - DirectXMan12
-    - mwielgus
     members:
     - aleksandra-malinowska
     - bskiba
     - davidopp
+    - DirectXMan12
     - MaciekPytel
+    - mwielgus
     privacy: closed

--- a/config/kubernetes/sig-aws/teams.yaml
+++ b/config/kubernetes/sig-aws/teams.yaml
@@ -1,11 +1,10 @@
 teams:
   sig-aws-misc:
     description: ""
-    maintainers:
-    - kris-nova
     members:
     - d-nishi
     - jsafrane
+    - kris-nova
     - leakingtapan
     - mcrute
     - micahhausler

--- a/config/kubernetes/sig-azure/teams.yaml
+++ b/config/kubernetes/sig-azure/teams.yaml
@@ -1,16 +1,15 @@
 teams:
   sig-azure:
     description: General discussion for SIG Azure
-    maintainers:
-    - dstrebel
-    - feiskyer
-    - justaugustus
-    - khenidak
     members:
     - andyzhangx
     - brendandburns
     - craiglpeters
+    - dstrebel
+    - feiskyer
+    - justaugustus
     - karataliu
+    - khenidak
     - lachie83
     - ritazh
     - soggiest

--- a/config/kubernetes/sig-big-data/teams.yaml
+++ b/config/kubernetes/sig-big-data/teams.yaml
@@ -1,36 +1,36 @@
 teams:
   sig-big-data-api-reviews:
     description: ""
-    maintainers:
+    members:
     - foxish
     privacy: closed
   sig-big-data-bugs:
     description: ""
-    maintainers:
+    members:
     - foxish
     privacy: closed
   sig-big-data-feature-requests:
     description: ""
-    maintainers:
+    members:
     - foxish
     privacy: closed
   sig-big-data-misc:
     description: ""
-    maintainers:
+    members:
     - foxish
     privacy: closed
   sig-big-data-pr-reviews:
     description: ""
-    maintainers:
+    members:
     - foxish
     privacy: closed
   sig-big-data-proposals:
     description: ""
-    maintainers:
+    members:
     - foxish
     privacy: closed
   sig-big-data-test-failures:
     description: ""
-    maintainers:
+    members:
     - foxish
     privacy: closed

--- a/config/kubernetes/sig-cli/teams.yaml
+++ b/config/kubernetes/sig-cli/teams.yaml
@@ -1,66 +1,58 @@
 teams:
   sig-cli-api-reviews:
     description: ""
-    maintainers:
-    - pwittrock
-    - seans3
-    - soltysh
     members:
     - adohe
     - fabianofranz
     - janetkuo
-    privacy: closed
-  sig-cli-bugs:
-    description: ""
-    maintainers:
     - pwittrock
     - seans3
     - soltysh
+    privacy: closed
+  sig-cli-bugs:
+    description: ""
     members:
     - adohe
     - dixudx
     - fabianofranz
     - janetkuo
     - mengqiy
+    - pwittrock
+    - seans3
     - shiywang
+    - soltysh
     - wanghaoran1988
     privacy: closed
   sig-cli-feature-requests:
     description: ""
-    maintainers:
-    - pwittrock
-    - seans3
-    - soltysh
     members:
     - adohe
     - davidopp
     - fabianofranz
     - janetkuo
     - mengqiy
+    - pwittrock
+    - seans3
     - shiywang
     - smarterclayton
+    - soltysh
     - wanghaoran1988
     privacy: closed
   sig-cli-maintainers:
     description: ""
-    maintainers:
-    - liggitt
-    - pwittrock
-    - seans3
-    - soltysh
     members:
     - adohe
     - fabianofranz
     - janetkuo
+    - liggitt
     - mengqiy
     - monopole
-    privacy: closed
-  sig-cli-misc:
-    description: Use only if you can't figure out a better category
-    maintainers:
     - pwittrock
     - seans3
     - soltysh
+    privacy: closed
+  sig-cli-misc:
+    description: Use only if you can't figure out a better category
     members:
     - adohe
     - brendandburns
@@ -70,17 +62,16 @@ teams:
     - fabianofranz
     - janetkuo
     - mengqiy
+    - pwittrock
+    - seans3
     - shiywang
     - smarterclayton
+    - soltysh
     - sttts
     - wanghaoran1988
     privacy: closed
   sig-cli-pr-reviews:
     description: ""
-    maintainers:
-    - pwittrock
-    - seans3
-    - soltysh
     members:
     - adohe
     - deads2k
@@ -94,19 +85,18 @@ teams:
     - janetkuo
     - liggitt
     - mengqiy
+    - pwittrock
     - rootfs
+    - seans3
     - shiywang
     - smarterclayton
+    - soltysh
     - sttts
     - wanghaoran1988
     - yue9944882
     privacy: closed
   sig-cli-proposals:
     description: ""
-    maintainers:
-    - pwittrock
-    - seans3
-    - soltysh
     members:
     - adohe
     - brendandburns
@@ -116,16 +106,18 @@ teams:
     - janetkuo
     - liggitt
     - mengqiy
+    - pwittrock
+    - seans3
     - shiywang
     - smarterclayton
+    - soltysh
     privacy: closed
   sig-cli-test-failures:
     description: ""
-    maintainers:
-    - pwittrock
-    - seans3
-    - soltysh
     members:
     - adohe
     - fabianofranz
+    - pwittrock
+    - seans3
+    - soltysh
     privacy: closed

--- a/config/kubernetes/sig-cloud-provider/teams.yaml
+++ b/config/kubernetes/sig-cloud-provider/teams.yaml
@@ -2,12 +2,12 @@ teams:
   sig-cloud-provider:
     description: Parent Team for SIG Cloud Provider
     maintainers:
-    - andrewsykim
     - calebamiles
+    members:
+    - andrewsykim
+    - cheftako
     - hogepodge
     - jagosan
-    members:
-    - cheftako
     - jhorwit2
     - justaugustus
     - mcrute
@@ -19,88 +19,97 @@ teams:
       cloud-provider-sample-admins:
         description: ""
         maintainers:
-        - andrewsykim
         - calebamiles
+        members:
+        - andrewsykim
         - cheftako
         - mcrute
         privacy: closed
       cloud-provider-sample-maintainers:
         description: ""
         maintainers:
-        - andrewsykim
         - calebamiles
+        members:
+        - andrewsykim
         - cheftako
         - mcrute
+        privacy: closed
+      sig-cloud-provider-alibaba-admins:
+        description: ""
+        members:
+        - aoxn
+        - cheyang
+        - xlgao-zju
         privacy: closed
       sig-cloud-provider-api-reviews:
         description: ""
         maintainers:
-        - andrewsykim
         - calebamiles
+        members:
+        - andrewsykim
         - hogepodge
         - jagosan
         privacy: closed
       sig-cloud-provider-bugs:
         description: ""
         maintainers:
-        - andrewsykim
         - calebamiles
+        members:
+        - andrewsykim
         - hogepodge
         - jagosan
         privacy: closed
       sig-cloud-provider-feature-requests:
         description: ""
         maintainers:
-        - andrewsykim
         - calebamiles
+        members:
+        - andrewsykim
         - hogepodge
         - jagosan
         privacy: closed
       sig-cloud-provider-misc:
         description: ""
         maintainers:
-        - andrewsykim
         - calebamiles
+        members:
+        - andrewsykim
         - hogepodge
         - jagosan
         privacy: closed
       sig-cloud-provider-pr-reviews:
         description: ""
         maintainers:
-        - andrewsykim
         - calebamiles
+        members:
+        - andrewsykim
         - hogepodge
         - jagosan
-        members:
         - nckturner
         - Rajakavitha1
         privacy: closed
       sig-cloud-provider-proposals:
         description: ""
         maintainers:
-        - andrewsykim
         - calebamiles
+        members:
+        - andrewsykim
         - hogepodge
         - jagosan
         privacy: closed
       sig-cloud-provider-test-failures:
         description: ""
         maintainers:
-        - andrewsykim
         - calebamiles
+        members:
+        - andrewsykim
         - hogepodge
         - jagosan
-        privacy: closed
-      sig-cloud-provider-alibaba-admins:
-        description: ""
-        maintainers:
-        - aoxn
-        - cheyang
-        - xlgao-zju
         privacy: closed
   sig-cloud-provider-admins:
     description: ""
     maintainers:
-    - andrewsykim
     - calebamiles
+    members:
+    - andrewsykim
     privacy: closed

--- a/config/kubernetes/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes/sig-cluster-lifecycle/teams.yaml
@@ -1,10 +1,6 @@
 teams:
   sig-cluster-lifecycle:
     description: Use only if you can't figure out a better category
-    maintainers:
-    - luxas
-    - roberthbailey
-    - timothysc
     members:
     - chuckha
     - detiber
@@ -15,20 +11,19 @@ teams:
     - karan
     - krousey
     - liztio
+    - luxas
     - medinatiger
     - neolit123
     - pipejakob
+    - roberthbailey
     - rosti
     - stealthybox
+    - timothysc
     - xiangpengzhao
     - yagonobre
     privacy: closed
   sig-cluster-lifecycle-pr-reviews:
     description: ""
-    maintainers:
-    - luxas
-    - roberthbailey
-    - timothysc
     members:
     - chuckha
     - detiber
@@ -39,11 +34,14 @@ teams:
     - karan
     - krousey
     - liztio
+    - luxas
     - medinatiger
     - neolit123
     - pipejakob
+    - roberthbailey
     - rosti
     - stealthybox
+    - timothysc
     - xiangpengzhao
     - yagonobre
     - zouyee

--- a/config/kubernetes/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes/sig-contributor-experience/teams.yaml
@@ -1,4 +1,31 @@
 teams:
+  community-admins:
+    description: ""
+    maintainers:
+    - calebamiles
+    - cblecker
+    - idvoretskyi
+    - nikhita
+    members:
+    - bgrant0607
+    - castrojo
+    - grodrigues3
+    - jdumars
+    - parispittman
+    - Phillels
+    - sarahnovotny
+    - thockin
+    privacy: closed
+  community-maintainers:
+    description: ""
+    maintainers:
+    - cblecker
+    - nikhita
+    members:
+    - parispittman
+    - Phillels
+    - thockin
+    privacy: closed
   sig-contributor-experience-bugs:
     description: Bugs relating to contributor-experience infrastructure, such as the
       PR bot, etc.
@@ -47,8 +74,8 @@ teams:
     - xiang90
     privacy: closed
   sig-contributor-experience-pr-reviews:
-    description: PR reviews for contributor-experience infrastructure, such
-      as the PR bot, etc.
+    description: PR reviews for contributor-experience infrastructure, such as the
+      PR bot, etc.
     maintainers:
     - cblecker
     - idvoretskyi
@@ -77,31 +104,4 @@ teams:
     members:
     - grodrigues3
     - idealhack
-    privacy: closed
-  community-admins:
-    description: ""
-    maintainers:
-    - calebamiles
-    - cblecker
-    - idvoretskyi
-    - nikhita
-    members:
-    - bgrant0607
-    - castrojo
-    - grodrigues3
-    - jdumars
-    - parispittman
-    - Phillels
-    - sarahnovotny
-    - thockin
-    privacy: closed
-  community-maintainers:
-    description: ""
-    maintainers:
-    - cblecker
-    - nikhita
-    - parispittman
-    - Phillels
-    members:
-    - thockin
     privacy: closed

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -1,12 +1,10 @@
 teams:
   sig-docs-en-owners:
     description: ""
-    maintainers:
-    - Bradamant3
-    - chenopis
-    - zacharysarah
     members:
+    - Bradamant3
     - bradtopol
+    - chenopis
     - cody-clark
     - jaredbhatti
     - kbarnard10
@@ -16,17 +14,17 @@ teams:
     - stewart-yu
     - tengqm
     - tfogo
+    - zacharysarah
     - zparnold
     privacy: closed
   sig-docs-en-reviews:
     description: Review PRs for English content
-    maintainers:
-    - zacharysarah
     members:
     - jimangel
     - Rajakavitha1
     - stewart-yu
     - xiangpengzhao
+    - zacharysarah
     - zhangxiaoyu-zidif
     privacy: closed
   sig-docs-fr-owners:
@@ -75,10 +73,9 @@ teams:
     privacy: closed
   sig-docs-ja-owners:
     description: sig-docs-ja-owners
-    maintainers:
-    - cstoku
     members:
     - chenopis
+    - cstoku
     - makocchi-git
     - MasayaAoyama
     - nasa9084
@@ -86,74 +83,67 @@ teams:
     privacy: closed
   sig-docs-ja-reviews:
     description: ""
-    maintainers:
-    - cstoku
-    - nasa9084
-    - tnir
     members:
+    - cstoku
     - makocchi-git
     - MasayaAoyama
+    - nasa9084
+    - tnir
     privacy: closed
   sig-docs-ko-owners:
     description: sig-docs-ko-owners
-    maintainers:
-    - gochist
     members:
     - ClaudiaJKang
+    - gochist
     - ianychoi
     privacy: closed
   sig-docs-ko-reviews:
     description: Reviews for Korean docs PRs
-    maintainers:
+    members:
     - ClaudiaJKang
     - gochist
-    members:
     - ianychoi
     privacy: closed
   sig-docs-l10n-admins:
     description: Admins for l10n projects
-    maintainers:
+    members:
     - Bradamant3
     - chenopis
-    - zacharysarah
-    members:
     - ClaudiaJKang
     - cstoku
     - gochist
     - hanjiayao
     - markthink
     - tnir
+    - zacharysarah
     - zhangxiaoyu-zidif
     privacy: closed
   sig-docs-maintainers:
     description: Docs maintainers team.
-    maintainers:
-    - chenopis
-    - jaredbhatti
-    - pwittrock
-    - steveperry-53
-    - zacharysarah
     members:
     - Bradamant3
     - bradtopol
+    - chenopis
+    - jaredbhatti
     - jimangel
     - kbarnard10
     - mistyhacks
+    - pwittrock
     - ryanmcginnis
+    - steveperry-53
     - tengqm
     - tfogo
     - xiangpengzhao
+    - zacharysarah
     - zhangxiaoyu-zidif
     - zparnold
     privacy: closed
   sig-docs-pr-reviews:
     description: Users authorized to review docs PRs
-    maintainers:
-    - Bradamant3
-    - chenopis
-    - zacharysarah
     members:
+    - Bradamant3
     - bradtopol
+    - chenopis
     - cody-clark
     - jaredbhatti
     - jimangel
@@ -166,26 +156,25 @@ teams:
     - tengqm
     - tfogo
     - xiangpengzhao
+    - zacharysarah
     - zhangxiaoyu-zidif
     - zparnold
     privacy: closed
   sig-docs-zh-owners:
     description: ""
-    maintainers:
+    members:
     - hanjiayao
     - tengqm
-    members:
     - xiangpengzhao
     - zhangxiaoyu-zidif
     privacy: closed
   sig-docs-zh-reviews:
     description: Reviews for Chinese docs PRs
-    maintainers:
-    - tengqm
-    - xiangpengzhao
-    - zhangxiaoyu-zidif
     members:
     - chenrui333
     - idealhack
     - pigletfly
+    - tengqm
+    - xiangpengzhao
+    - zhangxiaoyu-zidif
     privacy: closed

--- a/config/kubernetes/sig-gcp/teams.yaml
+++ b/config/kubernetes/sig-gcp/teams.yaml
@@ -1,36 +1,36 @@
 teams:
   sig-gcp-api-reviews:
     description: ""
-    maintainers:
+    members:
     - abgworrall
     privacy: closed
   sig-gcp-bugs:
     description: ""
-    maintainers:
+    members:
     - abgworrall
     privacy: closed
   sig-gcp-feature-requests:
     description: ""
-    maintainers:
+    members:
     - abgworrall
     privacy: closed
   sig-gcp-misc:
     description: ""
-    maintainers:
+    members:
     - abgworrall
     privacy: closed
   sig-gcp-pr-reviews:
     description: ""
-    maintainers:
+    members:
     - abgworrall
     privacy: closed
   sig-gcp-proposals:
     description: ""
-    maintainers:
+    members:
     - abgworrall
     privacy: closed
   sig-gcp-test-failures:
     description: ""
-    maintainers:
+    members:
     - abgworrall
     privacy: closed

--- a/config/kubernetes/sig-instrumentation/teams.yaml
+++ b/config/kubernetes/sig-instrumentation/teams.yaml
@@ -1,109 +1,102 @@
 teams:
   sig-instrumentation-api-reviews:
     description: ""
-    maintainers:
-    - fabxc
-    - piosz
     members:
     - brancz
     - danielqsj
     - DirectXMan12
+    - fabxc
     - fgrzadkowski
     - kawych
     - loburm
     - mxinden
+    - piosz
     - x13n
     - zouyee
     privacy: closed
   sig-instrumentation-bugs:
     description: ""
-    maintainers:
-    - fabxc
-    - piosz
     members:
     - brancz
     - danielqsj
     - DirectXMan12
+    - fabxc
     - fgrzadkowski
     - kawych
     - loburm
     - mxinden
+    - piosz
     - x13n
     - zouyee
     privacy: closed
   sig-instrumentation-feature-requests:
     description: ""
-    maintainers:
-    - fabxc
-    - piosz
     members:
     - brancz
     - danielqsj
     - DirectXMan12
+    - fabxc
     - fgrzadkowski
     - kawych
     - loburm
     - mxinden
+    - piosz
     - x13n
     privacy: closed
   sig-instrumentation-misc:
     description: ""
-    maintainers:
-    - fabxc
-    - piosz
     members:
     - brancz
     - danielqsj
     - DirectXMan12
+    - fabxc
     - fgrzadkowski
     - kawych
     - loburm
     - mxinden
+    - piosz
     - x13n
     privacy: closed
   sig-instrumentation-pr-reviews:
     description: ""
-    maintainers:
-    - fabxc
-    - piosz
     members:
     - brancz
     - danielqsj
     - DirectXMan12
+    - fabxc
     - fgrzadkowski
     - kawych
     - loburm
     - mxinden
+    - piosz
     - x13n
     - zouyee
     privacy: closed
   sig-instrumentation-proposals:
     description: ""
-    maintainers:
-    - fabxc
-    - piosz
     members:
     - brancz
     - danielqsj
     - DirectXMan12
+    - fabxc
     - fgrzadkowski
     - kawych
     - loburm
     - mxinden
+    - piosz
     - x13n
     privacy: closed
   sig-instrumentation-test-failures:
     description: ""
-    maintainers:
-    - fabxc
-    - piosz
     members:
     - brancz
     - danielqsj
     - DirectXMan12
+    - fabxc
     - fgrzadkowski
     - kawych
     - loburm
     - mxinden
+    - piosz
     - x13n
     privacy: closed

--- a/config/kubernetes/sig-multicluster/teams.yaml
+++ b/config/kubernetes/sig-multicluster/teams.yaml
@@ -1,9 +1,8 @@
 teams:
   sig-multicluster-api-reviews:
     description: ""
-    maintainers:
-    - csbell
     members:
+    - csbell
     - davidopp
     - jianhuiz
     - madhusudancs
@@ -15,24 +14,22 @@ teams:
     privacy: closed
   sig-multicluster-bugs:
     description: ""
-    maintainers:
-    - csbell
-    - nikhiljindal
-    - quinton-hoole
     members:
+    - csbell
     - irfanurrehman
     - jianhuiz
     - madhusudancs
     - marun
     - mwielgus
+    - nikhiljindal
+    - quinton-hoole
     - quinton-hoole-2
     - shashidharatd
     privacy: closed
   sig-multicluster-feature-requests:
     description: ""
-    maintainers:
-    - csbell
     members:
+    - csbell
     - davidopp
     - derekwaynecarr
     - jianhuiz
@@ -46,30 +43,28 @@ teams:
     privacy: closed
   sig-multicluster-misc:
     description: 'SIG for multi cluster: https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster'
-    maintainers:
-    - csbell
-    - madhusudancs
-    - nikhiljindal
-    - quinton-hoole
     members:
     - alfred-huangjian
+    - csbell
     - davidopp
     - derekwaynecarr
     - huangyuqi
     - irfanurrehman
     - jianhuiz
     - liggitt
+    - madhusudancs
     - marun
     - mwielgus
+    - nikhiljindal
+    - quinton-hoole
     - quinton-hoole-2
     - shashidharatd
     - smarterclayton
     privacy: closed
   sig-multicluster-pr-reviews:
     description: ""
-    maintainers:
-    - csbell
     members:
+    - csbell
     - jianhuiz
     - madhusudancs
     - marun
@@ -81,11 +76,8 @@ teams:
     privacy: closed
   sig-multicluster-proposals:
     description: ""
-    maintainers:
-    - csbell
-    - quinton-hoole
-    - quinton-hoole-2
     members:
+    - csbell
     - davidopp
     - derekwaynecarr
     - jianhuiz
@@ -94,6 +86,8 @@ teams:
     - marun
     - mwielgus
     - nikhiljindal
+    - quinton-hoole
+    - quinton-hoole-2
     - shashidharatd
     - smarterclayton
     previously:
@@ -101,9 +95,8 @@ teams:
     privacy: closed
   sig-multicluster-test-failures:
     description: ""
-    maintainers:
-    - csbell
     members:
+    - csbell
     - irfanurrehman
     - jianhuiz
     - madhusudancs

--- a/config/kubernetes/sig-network/teams.yaml
+++ b/config/kubernetes/sig-network/teams.yaml
@@ -24,8 +24,6 @@ teams:
     privacy: closed
   sig-network-misc:
     description: Network SIG
-    maintainers:
-    - dcbw
     members:
     - aanm
     - bowei
@@ -33,6 +31,7 @@ teams:
     - caseydavenport
     - danwinship
     - davidopp
+    - dcbw
     - dnardo
     - eghobo
     - eparis

--- a/config/kubernetes/sig-openstack/teams.yaml
+++ b/config/kubernetes/sig-openstack/teams.yaml
@@ -3,15 +3,16 @@ teams:
     description: ""
     maintainers:
     - idvoretskyi
+    members:
     - xsgordon
     privacy: closed
   sig-openstack-bugs:
     description: ""
     maintainers:
     - idvoretskyi
-    - xsgordon
     members:
     - NickrenREN
+    - xsgordon
     privacy: closed
   sig-openstack-feature-requests:
     description: ""
@@ -24,7 +25,6 @@ teams:
     description: OpenStack Special Interest Group
     maintainers:
     - idvoretskyi
-    - xsgordon
     members:
     - anguslees
     - codevulture
@@ -42,24 +42,27 @@ teams:
     - rootfs
     - russellb
     - stevemcquaid
+    - xsgordon
     privacy: closed
   sig-openstack-pr-reviews:
     description: ""
     maintainers:
     - idvoretskyi
-    - xsgordon
     members:
     - NickrenREN
+    - xsgordon
     privacy: closed
   sig-openstack-proposals:
     description: ""
     maintainers:
     - idvoretskyi
+    members:
     - xsgordon
     privacy: closed
   sig-openstack-test-failures:
     description: ""
     maintainers:
     - idvoretskyi
+    members:
     - xsgordon
     privacy: closed

--- a/config/kubernetes/sig-pm/teams.yaml
+++ b/config/kubernetes/sig-pm/teams.yaml
@@ -4,25 +4,27 @@ teams:
     maintainers:
     - calebamiles
     - idvoretskyi
+    members:
     - jdumars
     - justaugustus
-    privacy: closed
     previously:
     - features-maintainers
+    privacy: closed
   kep-maintainers:
     description: KEP Process Owners
     maintainers:
     - calebamiles
+    members:
     - jdumars
     - justaugustus
-    privacy: closed
     previously:
     - enhancement-maintainers
+    privacy: closed
   project-board-maintainers:
     description: Contributors with access to groom issues on org-level project boards.
-      Groups can opt-in to assistance with grooming by adding this team to their
-       project board with admin permissions.
-    maintainers:
+      Groups can opt-in to assistance with grooming by adding this team to their project
+      board with admin permissions.
+    members:
     - jdumars
     - justaugustus
     privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -2,16 +2,14 @@ teams:
   kubernetes-milestone-maintainers:
     description: Contributors who can use `/milestone` or `/status` commands on issues/PRs.
       This team also grants write access to the kubernetes/enhancements repo to allow
-       editing of descriptions for Enhancement tracking issues.
+      editing of descriptions for Enhancement tracking issues.
     maintainers:
     - calebamiles # Release / PM
     - cblecker # ContribEx
     - fejta # Testing
     - idvoretskyi # PM
-    - justaugustus # Azure / PM / Release
     - nikhita # ContribEx
     - spiffxp # 1.14 RT Lead / Testing
-    - tpepper # Release
     members:
     - abgworrall # GCP
     - alejandrox1 # 1.14 CI Signal
@@ -50,6 +48,7 @@ teams:
     - jagosan # Cloud Provider
     - jdumars # Architecture
     - jimangel # 1.14 Docs
+    - justaugustus # Azure / PM / Release
     - justinsb # AWS
     - k82cn # Scheduling
     - kacole2 # 1.14 CI Signal
@@ -88,6 +87,7 @@ teams:
     - tallclair # Auth
     - thockin # Network
     - timothysc # Cluster Lifecycle / Testing
+    - tpepper # Release
     - wojtek-t # Scalability
     - zacharysarah # Docs
     privacy: closed
@@ -98,26 +98,24 @@ teams:
       management is needed. Remove users who are not actively doing this job.
     maintainers:
     - calebamiles
-    - justaugustus
     - spiffxp # 1.14 RT Lead
-    - tpepper # 1.13 PRM
     members:
     - aleksandra-malinowska # 1.13 PRM
     - BenTheElder # 1.14 RT Lead Shadow
     - feiskyer # 1.12 PRM
     - foxish # 1.11 PRM
     - hoegaarden # 1.14 Branch Manager
+    - justaugustus
     - k8s-release-robot
     - maciekpytel # 1.10 PRM
     - marpaia # 1.14 RT Lead Shadow
+    - tpepper # 1.13 PRM
     privacy: closed
   sig-release:
     description: SIG Release Members
     maintainers:
     - calebamiles
-    - justaugustus
     - spiffxp
-    - tpepper
     members:
     - abgworrall
     - AishSundar
@@ -146,6 +144,7 @@ teams:
     - jdumars
     - jimangel
     - jpbetz
+    - justaugustus
     - kacole2
     - kbarnard10
     - krzyzacy
@@ -167,6 +166,7 @@ teams:
     - shyamjvs
     - steveperry-53
     - tfogo
+    - tpepper
     - wojtek-t
     - zacharysarah
     - zparnold
@@ -176,6 +176,7 @@ teams:
         description: Admins for SIG Release repositories
         maintainers:
         - calebamiles
+        members:
         - justaugustus
         - tpepper
         privacy: closed

--- a/config/kubernetes/sig-scalability/teams.yaml
+++ b/config/kubernetes/sig-scalability/teams.yaml
@@ -2,44 +2,44 @@ teams:
   sig-scalability-api-reviews:
     description: ""
     maintainers:
-    - countspongebob
-    - jbeda
     - spiffxp
     members:
+    - countspongebob
+    - jbeda
     - lavalamp
     - shyamjvs
     privacy: closed
   sig-scalability-bugs:
     description: ""
     maintainers:
+    - spiffxp
+    members:
     - countspongebob
     - jbeda
-    - spiffxp
-    - timothysc
-    members:
     - lavalamp
     - shyamjvs
+    - timothysc
     privacy: closed
   sig-scalability-feature-requests:
     description: ""
     maintainers:
+    - spiffxp
+    members:
     - countspongebob
     - jbeda
-    - spiffxp
-    - timothysc
-    members:
     - lavalamp
     - shyamjvs
     - smarterclayton
+    - timothysc
     privacy: closed
   sig-scalability-misc:
     description: ""
     maintainers:
-    - countspongebob
-    - jbeda
     - spiffxp
     members:
+    - countspongebob
     - feiskyer
+    - jbeda
     - jeremyeder
     - lavalamp
     - rrati
@@ -49,20 +49,20 @@ teams:
   sig-scalability-pr-reviews:
     description: ""
     maintainers:
-    - countspongebob
-    - jbeda
     - spiffxp
     members:
+    - countspongebob
+    - jbeda
     - lavalamp
     - shyamjvs
     privacy: closed
   sig-scalability-proprosals:
     description: ""
     maintainers:
-    - countspongebob
-    - jbeda
     - spiffxp
     members:
+    - countspongebob
+    - jbeda
     - lavalamp
     - shyamjvs
     - smarterclayton
@@ -70,9 +70,9 @@ teams:
   sig-scalability-test-failures:
     description: ""
     maintainers:
-    - countspongebob
-    - jbeda
     - spiffxp
     members:
+    - countspongebob
+    - jbeda
     - lavalamp
     privacy: closed

--- a/config/kubernetes/sig-scheduling/teams.yaml
+++ b/config/kubernetes/sig-scheduling/teams.yaml
@@ -1,8 +1,6 @@
 teams:
   sig-scheduling-api-reviews:
     description: ""
-    maintainers:
-    - timothysc
     members:
     - aveshagarwal
     - balajismaniam
@@ -23,13 +21,12 @@ teams:
     - resouer
     - rrati
     - SrinivasChilveri
+    - timothysc
     - vishh
     - xiang90
     privacy: closed
   sig-scheduling-bugs:
     description: ""
-    maintainers:
-    - timothysc
     members:
     - aveshagarwal
     - balajismaniam
@@ -52,6 +49,7 @@ teams:
     - resouer
     - rrati
     - SrinivasChilveri
+    - timothysc
     - vikaschoudhary16
     - vishh
     - wanghaoran1988
@@ -59,8 +57,6 @@ teams:
     privacy: closed
   sig-scheduling-feature-requests:
     description: ""
-    maintainers:
-    - timothysc
     members:
     - aveshagarwal
     - balajismaniam
@@ -84,6 +80,7 @@ teams:
     - rrati
     - smarterclayton
     - SrinivasChilveri
+    - timothysc
     - vikaschoudhary16
     - vishh
     - xiang90
@@ -93,8 +90,6 @@ teams:
     description: Scheduling algorithms, scheduling/scheduler architecture and extensibility,
       rescheduling/continuous re-optimization, cluster-level resource allocation and
       resource management
-    maintainers:
-    - timothysc
     members:
     - aveshagarwal
     - balajismaniam
@@ -118,13 +113,12 @@ teams:
     - rrati
     - smarterclayton
     - SrinivasChilveri
+    - timothysc
     - wanghaoran1988
     - xiang90
     privacy: closed
   sig-scheduling-pr-reviews:
     description: ""
-    maintainers:
-    - timothysc
     members:
     - aveshagarwal
     - balajismaniam
@@ -147,6 +141,7 @@ teams:
     - resouer
     - rrati
     - SrinivasChilveri
+    - timothysc
     - vikaschoudhary16
     - vishh
     - wanghaoran1988
@@ -155,8 +150,6 @@ teams:
     privacy: closed
   sig-scheduling-proposals:
     description: ""
-    maintainers:
-    - timothysc
     members:
     - aveshagarwal
     - balajismaniam
@@ -179,14 +172,13 @@ teams:
     - rrati
     - smarterclayton
     - SrinivasChilveri
+    - timothysc
     - vikaschoudhary16
     - vishh
     - xiang90
     privacy: closed
   sig-scheduling-test-failures:
     description: ""
-    maintainers:
-    - timothysc
     members:
     - aveshagarwal
     - balajismaniam
@@ -209,5 +201,6 @@ teams:
     - resouer
     - rrati
     - SrinivasChilveri
+    - timothysc
     - xiang90
     privacy: closed

--- a/config/kubernetes/sig-service-catalog/teams.yaml
+++ b/config/kubernetes/sig-service-catalog/teams.yaml
@@ -1,61 +1,54 @@
 teams:
   sig-service-catalog-api-reviews:
     description: API review notifications for SIG service catalog
-    maintainers:
-    - pmorie
     members:
     - jessfraz
+    - pmorie
     - pwittrock
     privacy: closed
   sig-service-catalog-bugs:
     description: Bug notifications for SIG service-catalog
-    maintainers:
-    - pmorie
     members:
     - jessfraz
+    - pmorie
     - pwittrock
     privacy: closed
   sig-service-catalog-feature-requests:
     description: Feature request notifications for SIG service-catalog
-    maintainers:
-    - pmorie
     members:
     - jessfraz
+    - pmorie
     - pwittrock
     - smarterclayton
     privacy: closed
   sig-service-catalog-misc:
     description: Miscellaneous notifications for SIG service-catalog
-    maintainers:
-    - pmorie
     members:
     - bmelville
     - jessfraz
+    - pmorie
     - pwittrock
     - smarterclayton
     privacy: closed
   sig-service-catalog-pr-reviews:
     description: PR review notifications for SIG service-catalog
-    maintainers:
-    - pmorie
     members:
     - jessfraz
+    - pmorie
     - pwittrock
     privacy: closed
   sig-service-catalog-proposals:
     description: Proposal notifications for SIG service-catalog
-    maintainers:
-    - pmorie
     members:
     - jessfraz
+    - pmorie
     - pwittrock
     - smarterclayton
     privacy: closed
   sig-service-catalog-test-failures:
     description: For reporting test failures to SIG service-catalog
-    maintainers:
-    - pmorie
     members:
     - jessfraz
+    - pmorie
     - pwittrock
     privacy: closed

--- a/config/kubernetes/sig-storage/teams.yaml
+++ b/config/kubernetes/sig-storage/teams.yaml
@@ -1,8 +1,6 @@
 teams:
   sig-storage-api-reviews:
     description: API Reviews for Kubernetes Storage Special-Interest-Group
-    maintainers:
-    - saad-ali
     members:
     - childsb
     - davidopp
@@ -10,13 +8,12 @@ teams:
     - matchstick
     - msau42
     - rootfs
+    - saad-ali
     - thockin
     - wattsteve
     privacy: closed
   sig-storage-bugs:
     description: Bugs for Kubernetes Storage Special-Interest-Group
-    maintainers:
-    - saad-ali
     members:
     - childsb
     - gnufied
@@ -28,12 +25,11 @@ teams:
     - msau42
     - NickrenREN
     - rootfs
+    - saad-ali
     - wattsteve
     privacy: closed
   sig-storage-feature-requests:
     description: Feature Requests for Kubernetes Storage Special-Interest-Group
-    maintainers:
-    - saad-ali
     members:
     - childsb
     - davidopp
@@ -45,6 +41,7 @@ teams:
     - msau42
     - NickrenREN
     - rootfs
+    - saad-ali
     - smarterclayton
     - thockin
     - wattsteve
@@ -54,8 +51,6 @@ teams:
       Ideally @kubernetes/sig-storage-misc should be seldom used, in lieu of more
       appropriate channels (sig-storage-bugs, sig-storage-proposals, sig-storage-pr-reviews,
       etc.)
-    maintainers:
-    - saad-ali
     members:
     - childsb
     - davidopp
@@ -69,25 +64,23 @@ teams:
     - msau42
     - NickrenREN
     - rootfs
+    - saad-ali
     - smarterclayton
     - thockin
     - wattsteve
     privacy: closed
   sig-storage-pr-reviews:
     description: PR Reviews for Kubernetes Storage Special-Interest-Group
-    maintainers:
-    - saad-ali
     members:
     - childsb
     - jsafrane
     - matchstick
     - msau42
     - rootfs
+    - saad-ali
     privacy: closed
   sig-storage-proposals:
     description: Proposals for Kubernetes Storage Special-Interest-Group
-    maintainers:
-    - saad-ali
     members:
     - childsb
     - davidopp
@@ -97,6 +90,7 @@ teams:
     - mdelio
     - msau42
     - rootfs
+    - saad-ali
     - smarterclayton
     - thockin
     - vishh
@@ -104,8 +98,6 @@ teams:
     privacy: closed
   sig-storage-test-failures:
     description: Test Failures for Kubernetes Storage Special-Interest-Group
-    maintainers:
-    - saad-ali
     members:
     - childsb
     - ianchakeres
@@ -115,4 +107,5 @@ teams:
     - matchstick
     - msau42
     - rootfs
+    - saad-ali
     privacy: closed

--- a/config/kubernetes/sig-windows/teams.yaml
+++ b/config/kubernetes/sig-windows/teams.yaml
@@ -1,28 +1,24 @@
 teams:
   sig-windows-bugs:
     description: For reporting and investigating bugs for sig-windows
-    maintainers:
-    - michmike
     members:
     - alexbrand
     - asultan001
     - feiskyer
     - jbhurat
+    - michmike
     privacy: closed
   sig-windows-feature-requests:
     description: Feature requests for sig-windows
-    maintainers:
-    - michmike
     members:
     - alexbrand
     - asultan001
     - feiskyer
     - jbhurat
+    - michmike
     privacy: closed
   sig-windows-misc:
     description: Special Interest Group Windows
-    maintainers:
-    - michmike
     members:
     - alexbrand
     - andyzhangx
@@ -31,6 +27,7 @@ teams:
     - feiskyer
     - ikester
     - jbhurat
+    - michmike
     - pires
     - sarahnovotny
     privacy: closed

--- a/config/kubernetes/wg-component-standard/teams.yaml
+++ b/config/kubernetes/wg-component-standard/teams.yaml
@@ -1,17 +1,16 @@
 teams:
   wg-component-standard:
     description: Team for the Component Standard working group.
-    maintainers:
-    - luxas
-    - mtaufen
-    - sttts
     members:
     - dims
     - DirectXMan12
     - dixudx
+    - luxas
+    - mtaufen
     - neolit123
     - rosti
     - stealthybox
     - stewart-yu
+    - sttts
     - thockin
     privacy: closed


### PR DESCRIPTION
Fixes the config part of https://github.com/kubernetes/org/issues/563. Because of how the GH API works, note that org admins still need to be in the maintainers list.

/hold
I wrote some quick and hacky go code to generate this...which meant that the comments next to names got lost (eg in milestone-maintainers) with the generation. Still need to fix that but wanted to get the PR out first.

/cc @spiffxp @idealhack @rlenferink 