### PR TITLE
Add teams for Azure CSI repo migrations

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -23,6 +23,7 @@ members:
 - ameukam
 - amwat
 - andrewsykim
+- andyzhangx
 - animeshsingh
 - ant31
 - apelisse

--- a/config/kubernetes-sigs/sig-azure/teams.yaml
+++ b/config/kubernetes-sigs/sig-azure/teams.yaml
@@ -12,3 +12,23 @@ teams:
     - soggiest
     - tariq1890
     privacy: closed
+  azuredisk-csi-driver-admins:
+    description: ""
+    members:
+    - andyzhangx
+    privacy: closed
+  azuredisk-csi-driver-maintainers:
+    description: ""
+    members:
+    - andyzhangx
+    privacy: closed
+  azurefile-csi-driver-admins:
+    description: ""
+    members:
+    - andyzhangx
+    privacy: closed
+  azurefile-csi-driver-maintainers:
+    description: ""
+    members:
+    - andyzhangx
+    privacy: closed


### PR DESCRIPTION
ref: #344

Only adding @andyzhangx, as he's the only one listed in the repo OWNERS file. Additional manual write access can be provided at a later time. Once the repo moves over, using the bots and labels to merge things is the standardized way to do thing

/assign @nikhita 