### PR TITLE
Add teams for k-sigs/multi-tenancy

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -56,6 +56,7 @@ members:
 - danielqsj
 - dashpole
 - davidewatson
+- davidopp
 - davidz627
 - ddebroy
 - deads2k

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -71,6 +71,7 @@ members:
 - dougm
 - droot
 - dstrebel
+- easeway
 - fabriziopandini
 - fanzhangio
 - feiskyer

--- a/config/kubernetes-sigs/sig-auth/OWNERS
+++ b/config/kubernetes-sigs/sig-auth/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-auth-leads
+approvers:
+  - sig-auth-leads
+labels:
+  - sig/auth

--- a/config/kubernetes-sigs/sig-auth/teams.yaml
+++ b/config/kubernetes-sigs/sig-auth/teams.yaml
@@ -1,0 +1,13 @@
+teams:
+  multi-tenancy-admins:
+    description: Admin access to multi-tenancy repo
+    members:
+    - davidopp
+    - easeway
+    privacy: closed
+  multi-tenancy-maintainers:
+    description: Write access to multi-tenancy repo
+    members:
+    - davidopp
+    - easeway
+    privacy: closed


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/528

Adds teams to provide write access and admin access to https://github.com/kubernetes-sigs/multi-tenancy.