### PR TITLE
Revert migrate maintainers to members for kubernetes-incubator

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -108,11 +108,6 @@ func testTeamMembers(teams map[string]org.Team, admins sets.String, orgMembers s
 		teamMaintainers = normalize(teamMaintainers)
 		teamMembers = normalize(teamMembers)
 
-		// check for non-admins in maintainers list
-		if nonAdminMaintainers := teamMaintainers.Difference(admins); len(nonAdminMaintainers) > 0 {
-			errs = append(errs, fmt.Errorf("The team %s in org %s has non-admins listed as maintainers; these users should be in the members list instead: %s", teamName, orgName, strings.Join(nonAdminMaintainers.List(), ",")))
-		}
-
 		// check for users in both maintainers and members
 		if both := teamMaintainers.Intersection(teamMembers); len(both) > 0 {
 			errs = append(errs, fmt.Errorf("The team %s in org %s has users in both maintainer admin and member roles: %s", teamName, orgName, strings.Join(both.List(), ", ")))
@@ -127,6 +122,9 @@ func testTeamMembers(teams map[string]org.Team, admins sets.String, orgMembers s
 		}
 
 		// check if all are org members
+		if missing := teamMaintainers.Difference(orgMembers); len(missing) > 0 {
+			errs = append(errs, fmt.Errorf("The following maintainers of team %s are not %s org members: %s", teamName, orgName, strings.Join(missing.List(), ", ")))
+		}
 		if missing := teamMembers.Difference(orgMembers); len(missing) > 0 {
 			errs = append(errs, fmt.Errorf("The following members of team %s are not %s org members: %s", teamName, orgName, strings.Join(missing.List(), ", ")))
 		}

--- a/config/kubernetes-incubator/org.yaml
+++ b/config/kubernetes-incubator/org.yaml
@@ -181,8 +181,9 @@ members:
 teams:
   admin-bootkube:
     description: ""
-    members:
+    maintainers:
     - aaronlevy
+    members:
     - philips
     privacy: closed
   admin-cluster-capacity:
@@ -202,8 +203,9 @@ teams:
     privacy: closed
   admin-custom-metrics-apiserver:
     description: Admins for the custom-metrics-apiserver repo
-    members:
+    maintainers:
     - DirectXMan12
+    members:
     - luxas
     - piosz
     privacy: closed
@@ -215,13 +217,14 @@ teams:
     privacy: closed
   admin-reference-docs:
     description: adminstration of reference-docs repo
-    members:
+    maintainers:
     - pwittrock
+    members:
     - sarahnovotny
     privacy: closed
   admins-apiserver-builder:
     description: maintainers of the apiserver-builder repository with admin access
-    members:
+    maintainers:
     - DirectXMan12
     - pwittrock
     - yue9944882
@@ -230,14 +233,15 @@ teams:
     description: administrators of the application-images repository
     maintainers:
     - calebamiles
+    - zmerlynn
     members:
     - mattf
-    - zmerlynn
     privacy: closed
   admins-client-python:
     description: admins of the client-python project
-    members:
+    maintainers:
     - mbohlool
+    members:
     - sarahnovotny
     - smarterclayton
     - yliaog
@@ -245,34 +249,35 @@ teams:
   admins-cluster-proportional-autoscaler:
     description: administers of  the cluster-proportional-autoscaler repository
     maintainers:
-    - calebamiles
-    members:
     - bowei
+    - calebamiles
     - MrHohn
+    members:
     - philips
     privacy: closed
   admins-external-dns:
     description: ""
     maintainers:
     - calebamiles
-    members:
     - justinsb
+    members:
     - sarahnovotny
     privacy: closed
   admins-ip-masq-agent:
     description: ""
-    members:
+    maintainers:
     - dnardo
-    - MrHohn
     - mtaufen
     - thockin
+    members:
+    - MrHohn
     privacy: closed
   admins-kargo:
     description: ""
     maintainers:
+    - ant31
     - calebamiles
     members:
-    - ant31
     - bogdando
     - mattymo
     - sarahnovotny
@@ -280,13 +285,14 @@ teams:
     privacy: closed
   admins-kompose:
     description: Admins for kompose
+    maintainers:
+    - sebgoa
     members:
     - bgrant0607
     - cdrage
     - janetkuo
     - kadel
     - ngtuna
-    - sebgoa
     privacy: closed
   admins-kops:
     description: administrators of the kops repository
@@ -297,8 +303,8 @@ teams:
     description: kube-aws repository administrators
     maintainers:
     - calebamiles
-    members:
     - colhom
+    members:
     - mumoshu
     - philips
     privacy: closed
@@ -306,9 +312,9 @@ teams:
     description: administrators of the kube2consul repository
     maintainers:
     - calebamiles
+    - elg0nz
     members:
     - bgrant0607
-    - elg0nz
     privacy: closed
   admins-metrics-server:
     description: ""
@@ -318,8 +324,9 @@ teams:
     privacy: closed
   admins-node-feature-discovery:
     description: Administrators of node-feature-discovery
-    members:
+    maintainers:
     - balajismaniam
+    members:
     - ConnorDoyle
     - davidopp
     - philips
@@ -328,48 +335,51 @@ teams:
     description: administrators of the rktlet repository
     maintainers:
     - calebamiles
-    members:
-    - dchen1107
     - euank
     - yifan-gu
+    members:
+    - dchen1107
     privacy: closed
   admins-service-catalog:
     description: administrators for the service catalog project
-    members:
+    maintainers:
     - carolynvs
     - duglin
-    - kibbles-n-bytes
     - pmorie
+    members:
+    - kibbles-n-bytes
     - sarahnovotny
     privacy: closed
   descheduler-admins:
     description: Admin permission for descheduler repo
-    members:
+    maintainers:
     - aveshagarwal
     privacy: closed
   descheduler-maintainers:
     description: Write permission for descheduler repo
-    members:
+    maintainers:
     - aveshagarwal
     privacy: closed
   descheduler-reviewers:
     description: Read permission for descheduler repo
-    members:
+    maintainers:
     - aveshagarwal
     privacy: closed
   design-reviewer-kube-arbitrator:
     description: The design reviewer of kube-arbitrator
+    maintainers:
+    - k82cn
     members:
     - bsalamat
     - davidopp
     - foxish
-    - k82cn
     - timothysc
     privacy: closed
   external-storage-community:
     description: the extended external storage community
-    members:
+    maintainers:
     - childsb
+    members:
     - ianchakeres
     - jsafrane
     - msau42
@@ -385,16 +395,17 @@ teams:
     privacy: closed
   kompose-contributors:
     description: Contributors to kompose repo (read access)
+    maintainers:
+    - sebgoa
     members:
     - bgrant0607
     - cdrage
     - ngtuna
     - procrypt
-    - sebgoa
     privacy: closed
   maintainers-apiserver-builder:
     description: maintainers of apiserver-builder with write access on the repository
-    members:
+    maintainers:
     - DirectXMan12
     - pwittrock
     - yue9944882
@@ -403,9 +414,9 @@ teams:
     description: contributors to the application-images repository
     maintainers:
     - calebamiles
+    - zmerlynn
     members:
     - mattf
-    - zmerlynn
     privacy: closed
   maintainers-bootkube:
     description: ""
@@ -417,11 +428,12 @@ teams:
     privacy: closed
   maintainers-client-python:
     description: maintainers of the client-python project
+    maintainers:
+    - mbohlool
     members:
     - caesarxuchao
     - dims
     - lavalamp
-    - mbohlool
     - sarahnovotny
     - yliaog
     privacy: closed
@@ -437,8 +449,8 @@ teams:
     description: contributors to the cluster-proportional-autoscaler repository
     maintainers:
     - calebamiles
-    members:
     - MrHohn
+    members:
     - philips
     privacy: closed
   maintainers-cluster-proportional-vertical-autoscaler:
@@ -449,22 +461,24 @@ teams:
     privacy: closed
   maintainers-cri-containerd:
     description: maintainers of cri-containerd repo
+    maintainers:
+    - Random-Liu
     members:
     - abhi
     - dchen1107
     - mikebrow
-    - Random-Liu
     - sarahnovotny
     - yujuhong
     privacy: closed
   maintainers-external-dns:
     description: ""
+    maintainers:
+    - justinsb
     members:
     - chrislovecnm
     - hjacobs
     - ideahitme
     - iterion
-    - justinsb
     - kris-nova
     - linki
     - njuettner
@@ -494,22 +508,23 @@ teams:
   maintainers-kargo:
     description: ""
     maintainers:
+    - ant31
     - calebamiles
     members:
-    - ant31
     - bogdando
     - mattymo
     - rsmitty
     privacy: closed
   maintainers-kompose:
     description: Write access for kompose
+    maintainers:
+    - sebgoa
     members:
     - bgrant0607
     - cab105
     - cdrage
     - janetkuo
     - kadel
-    - sebgoa
     - surajssd
     privacy: closed
   maintainers-kops:
@@ -521,8 +536,8 @@ teams:
     description: maintainers for kube-aws
     maintainers:
     - calebamiles
-    members:
     - colhom
+    members:
     - mumoshu
     - pbx0
     - philips
@@ -532,9 +547,9 @@ teams:
     description: contributors to the kube2consul repository
     maintainers:
     - calebamiles
+    - elg0nz
     members:
     - bgrant0607
-    - elg0nz
     privacy: closed
   maintainers-metrics-server:
     description: ""
@@ -552,8 +567,9 @@ teams:
     privacy: closed
   maintainers-node-feature-discovery:
     description: Maintainers of the node-feature-discovery repo.
-    members:
+    maintainers:
     - balajismaniam
+    members:
     - ConnorDoyle
     - davidopp
     - flyingcougar
@@ -562,26 +578,29 @@ teams:
     privacy: closed
   maintainers-reference-docs:
     description: maintainers of the reference-docs repo
-    members:
+    maintainers:
     - pwittrock
+    members:
     - sarahnovotny
     privacy: closed
   maintainers-rktlet:
     description: contributors to the rktlet repository
     maintainers:
     - calebamiles
-    members:
-    - dchen1107
     - euank
     - yifan-gu
+    members:
+    - dchen1107
     privacy: closed
   maintainers-service-catalog:
     description: maintainers of the service catalog project
+    maintainers:
+    - carolynvs
+    - duglin
+    - pmorie
     members:
     - arschles
     - bgrant0607
-    - carolynvs
-    - duglin
     - eriknelson
     - jberkhahn
     - jboyd01
@@ -593,7 +612,6 @@ teams:
     - MHBauer
     - n3wscott
     - nilebox
-    - pmorie
     - service-catalog-jenkins
     - slack
     - staebler
@@ -601,9 +619,10 @@ teams:
     privacy: closed
   maintainers-spartakus:
     description: People who maintain spartakus
+    maintainers:
+    - grodrigues3
     members:
     - aronchick
-    - grodrigues3
     - squat
     - thockin
     privacy: closed
@@ -628,11 +647,12 @@ teams:
     privacy: closed
   reviewers-cri-containerd:
     description: reviewers of cri-containerd repo
+    maintainers:
+    - Random-Liu
     members:
     - abhi
     - miaoyq
     - mikebrow
-    - Random-Liu
     - yanxuean
     privacy: closed
   temporary-admin-transfers:


### PR DESCRIPTION
Peribolos [fails](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-org-peribolos/201) with a 403 when it tries to update memberships for certain teams in kubernetes-incubator. This temporarily unblocks peribolos so other changes can be synced.


```
{"client":"github","component":"peribolos","level":"info","msg":"UpdateTeamMembership(2113629, euank, false)","time":"2019-03-11T03:17:04Z"}
{"component":"peribolos","error":"is the account using at least one of the following oauth scopes?: admin:org, repo","level":"warning","msg":"UpdateTeamMembership(2113629, euank, false) failed","time":"2019-03-11T03:17:07Z"}
{"component":"peribolos","level":"fatal","msg":"Configuration failed: failed to configure kubernetes-incubator teams: failed to update maintainers-rktlet members: 1 errors: [is the account using at least one of the following oauth scopes?: admin:org, repo]","time":"2019-03-11T03:17:07Z"}
```

The relevant diff from https://github.com/kubernetes/org/pull/566: https://github.com/kubernetes/org/pull/566/files#diff-3b95bdd66ee80ec3ebbed25503db3376

Note: I am only reverting the change for k-incubator here because teams in other orgs have been synced (some teams in kuberntes-incubator have also been synced but it should be ok to have that change reverted). I'm also not completely sure that this will fix the error, but it seems the best solution to me right now. I have created https://github.com/kubernetes/test-infra/pull/11720 to help debug better in the future. 

For some more context, the relevant slack discussion: https://kubernetes.slack.com/archives/C1TU9EB9S/p1552055216157000

/hold
Holding for lgtm from @spiffxp or @fejta 

/cc @spiffxp @mrbobbytables @justaugustus @rlenferink @idealhack 
/assign @spiffxp @fejta 