### PR TITLE
Add dummy team for testing prow project plugin

### DIFF
--- a/config/kubernetes/sig-testing/teams.yaml
+++ b/config/kubernetes/sig-testing/teams.yaml
@@ -72,3 +72,8 @@ teams:
     - krzyzacy
     - stevekuznetsov
     privacy: closed
+  sig-testing-dummy-project-team:
+    description: dummy team to test prow project plugin; no acl
+    members:
+    - taragu
+    privacy: closed


### PR DESCRIPTION
Create a dummy team to test prow project plugin to add issues/PRs to github projects (https://github.com/kubernetes/test-infra/pull/10982). No ACL is needed. 
FYI @stevekuznetsov @spiffxp 