### PR TITLE
Remove owners team in kubernetes-incubator org

### DIFF
--- a/config/kubernetes-incubator/org.yaml
+++ b/config/kubernetes-incubator/org.yaml
@@ -626,24 +626,6 @@ teams:
     - squat
     - thockin
     privacy: closed
-  owners:
-    description: owners of the kubernetes-incubator org
-    maintainers:
-    - calebamiles
-    - spiffxp
-    members:
-    - alex-mohr
-    - bgrant0607
-    - ConnorDoyle
-    - eparis
-    - lavalamp
-    - philips
-    - piosz
-    - sarahnovotny
-    - smarterclayton
-    - spxtr
-    - thockin
-    privacy: closed
   reviewers-cri-containerd:
     description: reviewers of cri-containerd repo
     maintainers:


### PR DESCRIPTION
The [GitHub Admin team](https://github.com/kubernetes/community/tree/master/github-management#github-administration-team) is responsible for having admin privileges across all Kubernetes orgs.

/assign @idvoretskyi @spiffxp 