### PR TITLE
Add wg-lts leads owner alias and wg-lts team

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -137,6 +137,11 @@ aliases:
   wg-kubeadm-adoption-leads:
     - luxas
     - justinsb
+  wg-lts-leads:
+    - tpepper
+    - imkin
+    - quinton-hoole-2
+    - youngnick
   wg-machine-learning-leads:
     - vishh
     - kow3ns

--- a/config/kubernetes/wg-lts/OWNERS
+++ b/config/kubernetes/wg-lts/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - wg-lts-leads
+approvers:
+  - wg-lts-leads
+labels:
+  - wg/lts

--- a/config/kubernetes/wg-lts/teams.yaml
+++ b/config/kubernetes/wg-lts/teams.yaml
@@ -1,0 +1,10 @@
+teams:
+  wg-lts:
+    description: Team for wg-lts working group
+    members:
+      - imkin
+      - liggitt
+      - neolit123
+      - quinton-hoole-2
+      - tpepper
+      - youngnick


### PR DESCRIPTION
Added the WG_LTS chairs/organizers to the leads alias

https://github.com/kubernetes/community/tree/master/wg-lts

