### PR TITLE
Add tashimi to multi-tenancy sub-project teams

### DIFF
--- a/config/kubernetes-sigs/sig-auth/teams.yaml
+++ b/config/kubernetes-sigs/sig-auth/teams.yaml
@@ -4,10 +4,12 @@ teams:
     members:
     - davidopp
     - easeway
+    - tashimi
     privacy: closed
   multi-tenancy-maintainers:
     description: Write access to multi-tenancy repo
     members:
     - davidopp
     - easeway
+    - tashimi
     privacy: closed


### PR DESCRIPTION
@tashimi (Tasha Drew) from VMware is lead of kubernetes-wg-multitenancy.