### PR TITLE
Add brendandburns to kubernetes-client owners

### DIFF
--- a/config/kubernetes-client/org.yaml
+++ b/config/kubernetes-client/org.yaml
@@ -5,6 +5,7 @@ has_organization_projects: true
 has_repository_projects: true
 members_can_create_repositories: false
 admins:
+- brendandburns
 - calebamiles
 - cblecker
 - fejta
@@ -19,7 +20,6 @@ members:
 - avinassh
 - bgrant0607
 - brejoc
-- brendandburns
 - bsherman
 - caesarxuchao
 - codevulture


### PR DESCRIPTION
This is needed for me to use Azure pipelines for CI/CD for CSharp and other projects.

(I'm also the primary maintainer for most of the client libraries)

Thanks!