### PR TITLE
sig-pm: Update teams

### DIFF
--- a/config/kubernetes/sig-pm/teams.yaml
+++ b/config/kubernetes/sig-pm/teams.yaml
@@ -7,6 +7,7 @@ teams:
     members:
     - jdumars
     - justaugustus
+    - lachie83
     previously:
     - features-maintainers
     privacy: closed
@@ -17,6 +18,7 @@ teams:
     members:
     - jdumars
     - justaugustus
+    - lachie83
     previously:
     - enhancement-maintainers
     privacy: closed
@@ -24,7 +26,11 @@ teams:
     description: Contributors with access to groom issues on org-level project boards.
       Groups can opt-in to assistance with grooming by adding this team to their project
       board with admin permissions.
+    maintainers:
+    - idvoretskyi
     members:
     - jdumars
     - justaugustus
+    - lachie83
+    - mattfarina
     privacy: closed


### PR DESCRIPTION
- Following discussions at Open Source Leadership Summit this week with @jdumars and I, @lachie83 has stepped up to help us out with SIG PM. Adding him to the relevant teams.
- @idvoretskyi has been working with SIG ContribEx on their project mgmt needs (https://github.com/kubernetes/community/issues/3079). Adding him to `project-board-maintainers`.
- @mattfarina has offered his assistance in grooming (https://github.com/kubernetes/community/issues/3267#issuecomment-466419304). Adding him to `project-board-maintainers`.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @calebamiles @idvoretskyi @jdumars 