### PR TITLE
Add client go teams

### DIFF
--- a/config/kubernetes-client/org.yaml
+++ b/config/kubernetes-client/org.yaml
@@ -69,6 +69,16 @@ teams:
     - brendandburns
     - mbohlool
     privacy: closed
+  go-admins:
+    description: admin access to go
+    members:
+    - brendandburns
+    privacy: closed
+  go-base-admins:
+    description: admin access to go-base
+    members:
+    - brendandburns
+    privacy: closed
   haskell-admins:
     description: admin access to haskell
     members:

--- a/config/kubernetes-client/org.yaml
+++ b/config/kubernetes-client/org.yaml
@@ -104,7 +104,7 @@ teams:
     - yliaog
     privacy: closed
   python-base-admins:
-    description: ""
+    description: admin access to python-base
     members:
     - mbohlool
     - yliaog


### PR DESCRIPTION
Created the missing teams for the kubernetes-client repos (#615). 
Added a description to the python-base-admins team as well.

@nikhita can you assign the repository permissions to the teams?
@brendandburns is this sufficient for you to setup the CI/CD pipelines?

/assign @nikhita