### PR TITLE
Add community-milestone-maintainers team

### DIFF
--- a/config/kubernetes/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes/sig-contributor-experience/teams.yaml
@@ -26,6 +26,30 @@ teams:
     - Phillels
     - thockin
     privacy: closed
+  community-milestone-maintainers:
+    description: Contributors who can use `/milestone` in the community repo. Defined by an entry in an OWNERS file for a contribex subproject.
+    maintainers:
+    - calebamiles
+    - cblecker
+    - fejta
+    - idvoretskyi
+    - nikhita
+    - spiffxp
+    members:
+    - castrojo
+    - dims
+    - grodrigues3
+    - guineveresaenger
+    - jberkus
+    - jdumars
+    - jeefy
+    - justaugustus
+    - lukaszgryglicki
+    - mrbobbytables
+    - parispittman
+    - Phillels
+    - tpepper
+    privacy: closed
   sig-contributor-experience-bugs:
     description: Bugs relating to contributor-experience infrastructure, such as the
       PR bot, etc.


### PR DESCRIPTION
For https://github.com/kubernetes/community/issues/3443

This team will have the power to use the `/milestone` command in the community repo. Membership in this team requires an entry in an OWNERS file (reviewer or approver) for a contribex subproject in the community repo.

Once this merges and the team is created, I'll add the team here: https://github.com/kubernetes/test-infra/blob/b9778912cf2e162c9f2b005cdff2a48be7f4a593/prow/plugins.yaml#L214.

/hold
/assign @parispittman 