### PR TITLE
add neolit123 to kubernetes-milestone-maintainers

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -67,6 +67,7 @@ teams:
     - mikedanese # Auth
     - mortent # 1.14 CI Signal
     - mwielgus # Autoscaling
+    - neolit123 # Cluster Lifecycle
     - nikopen # 1.14 Bug Triage
     - nwoods3 # 1.14 Communications
     - parispittman # ContribEx


### PR DESCRIPTION
we had a discussion today about this in the kubeadm office hours meeting and i got approval from a SIG chair (@timothysc) and a tech lead (@fabriziopandini).

i have read the details about the milestone maintainers role:
https://github.com/kubernetes/sig-release/blob/master/release-team/README.md#milestone-maintainers

this is a primary "super power" i'm interested in, because our k/e items descriptions need update:
> Milestone maintainers also have write access to kubernetes/enhancements, which allows them to keep enhancement tracking issue descriptions up-to-date.

---

> for SIGs: Request approval from a SIG Chair or Technical Lead

/assign @timothysc @fabriziopandini 

> Once your request is approved by the appropriate group, you can now assign to the PR to a SIG Release Chair for final approval.

/assign @tpepper @justaugustus 

