### PR TITLE
Updated descriptions for sig-docs-[de|en]-owners

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -1,6 +1,6 @@
 teams:
   sig-docs-de-owners: 
-    description: German content admins 
+    description: Admins for German content
     members:
     - bene2k1
     - rlenferink
@@ -12,7 +12,7 @@ teams:
     - rlenferink
     privacy: closed
   sig-docs-en-owners: 
-    description: English content admins 
+    description: Admins for English content
     members:
     - bradamant3
     - bradtopol


### PR DESCRIPTION
Using the same description format for all localization teams now.

/cc @zacharysarah 
/assign @nikhita 
/sig docs