### PR TITLE
Remove chenopis, add jaredbhatti

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -51,7 +51,7 @@ aliases:
     - cblecker
     - nikhita
   sig-docs-leads:
-    - chenopis
+    - jaredbhatti
     - zacharysarah
     - bradamant3
   sig-gcp-leads:


### PR DESCRIPTION
This PR updates SIG Docs leads by removing @chenopis and adding @jaredbhatti. 

See also: https://github.com/kubernetes/community/pull/3523

/assign @Bradamant3 @chenopis @jaredbhatti 
/sig docs