### PR TITLE
patch-release-team: re-add @foxish for 1.11.10

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -114,6 +114,7 @@ teams:
         members:
         - aleksandra-malinowska
         - feiskyer
+        - foxish
         - hoegaarden
         - tpepper
         privacy: closed


### PR DESCRIPTION
We're thinking we'll do at least one last build here to clear the
pending cherry picks and potentially also to deliver packages that have
a fixup around runtime dependencies' metadata.

Signed-off-by: Tim Pepper <tpepper@vmware.com>