### PR TITLE
Add teams for krew and krew-index

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -16,6 +16,7 @@ admins:
 - thelinuxfoundation
 members:
 - adelina-t
+- adohe
 - ainmosni
 - akutz
 - alejandrox1

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -17,6 +17,7 @@ admins:
 members:
 - adelina-t
 - adohe
+- ahmetb
 - ainmosni
 - akutz
 - alejandrox1

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -116,6 +116,7 @@ members:
 - johnsonj
 - jsafrane
 - juan-lee
+- juanvallejo
 - justaugustus
 - justinsb
 - k82cn

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -75,6 +75,7 @@ members:
 - droot
 - dstrebel
 - easeway
+- fabianofranz
 - fabriziopandini
 - fanzhangio
 - feiskyer

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -100,6 +100,7 @@ members:
 - ingvagabund
 - interma
 - irfanurrehman
+- janetkuo
 - javier-b-perez
 - jbeda
 - jberkus

--- a/config/kubernetes-sigs/sig-cli/teams.yaml
+++ b/config/kubernetes-sigs/sig-cli/teams.yaml
@@ -13,6 +13,50 @@ teams:
     - Liujingfang1
     - monopole
     privacy: closed
+  krew-admins:
+    description: admin access to krew
+    members:
+    - ahmetb
+    - juanvallejo
+    - seans3
+    - soltysh
+    privacy: closed
+  krew-maintainers:
+    description: write access to krew
+    members:
+    - adohe
+    - ahmetb
+    - fabianofranz
+    - janetkuo
+    - liggitt
+    - mengqiy
+    - monopole
+    - pwittrock
+    - seans3
+    - soltysh
+    privacy: closed
+  krew-index-admins:
+    description: admin access to krew-index
+    members:
+    - ahmetb
+    - juanvallejo
+    - seans3
+    - soltysh
+    privacy: closed
+  krew-index-maintainers:
+    description: write access to krew-index
+    members:
+    - adohe
+    - ahmetb
+    - fabianofranz
+    - janetkuo
+    - liggitt
+    - mengqiy
+    - monopole
+    - pwittrock
+    - seans3
+    - soltysh
+    privacy: closed
   kustomize-admins:
     description: ""
     members:


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/599

Some members of the team [sig-cli-maintainers ](https://github.com/kubernetes/org/blob/94ded1dc4a1cf58aab6ab2e332058da1f1f347dc/config/kubernetes/sig-cli/teams.yaml#L41-L53) were not members of kubernetes-sigs so I've added them to the org (all kubernetes org members are implcitly eligible for kubernetes-sigs membership)

/assign @ahmetb @soltysh @juanvallejo 