### PR TITLE
Correct github handle for Brendan Burns in OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -166,7 +166,7 @@ aliases:
 ## BEGIN CUSTOM CONTENT
   steering-committee:
     - bgrant0607
-    - brendanburns
+    - brendandburns
     - derekwaynecarr
     - dims
     - jbeda


### PR DESCRIPTION
Ref: https://github.com/kubernetes/community/pull/3539

/cc @brendandburns 