### PR TITLE
Add team for dep-approvers

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1111,6 +1111,18 @@ teams:
     members:
     - danielromlein
     privacy: closed
+  dep-approvers:
+    description: People who can approve dependency changes in kubernetes/kubernetes
+    maintainers:
+    - cblecker
+    members:
+    - apelisse
+    - BenTheElder
+    - dims
+    - soltysh
+    - sttts
+    - thockin
+    privacy: closed
   dns-admins:
     description: Admins of the DNS repository (can admin the repo)
     members:


### PR DESCRIPTION
OWNERS files don't support regex right now, which means we can't require dep-approvers to be able to approve `go.mod` and `go.sum` changes. Ref: https://github.com/kubernetes/kubernetes/pull/76167

Add a team for it so that it's easier to cc them for a review, before cc'ing a root approver.

Ref: https://github.com/kubernetes/kubernetes/blob/06150f798e271ec048cd03fef98908b7a23c4486/OWNERS_ALIASES#L290-L297

/cc @cblecker @liggitt @sttts @BenTheElder @dims 