### PR TITLE
Add teams for legacyflag

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -200,6 +200,7 @@ members:
 - sohankunkerkar
 - soltysh
 - srampal
+- sttts
 - suleisl2000
 - syjabri
 - tao12345666333

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -160,6 +160,7 @@ members:
 - mrbobbytables
 - mrunalp
 - msau42
+- mtaufen
 - munnerz
 - ncdc
 - neolit123

--- a/config/kubernetes-sigs/wg-component-standard/OWNERS
+++ b/config/kubernetes-sigs/wg-component-standard/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - wg-component-standard-leads
+approvers:
+  - wg-component-standard-leads
+labels:
+  - wg/component-standard

--- a/config/kubernetes-sigs/wg-component-standard/teams.yaml
+++ b/config/kubernetes-sigs/wg-component-standard/teams.yaml
@@ -1,0 +1,15 @@
+teams:
+  legacyflag-admins:
+    description: admin access to legacyflag
+    members:
+    - luxas
+    - mtaufen
+    - sttts
+    privacy: closed
+  legacyflag-maintainers:
+    description: write access to legacyflag
+    members:
+    - luxas
+    - mtaufen
+    - sttts
+    privacy: closed


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/683

@sttts and @mtaufen were not part of k-sigs, so I've added them in this PR. They are members of @kubernetes and are implicitly eligible for members to @kubernetes-sigs. 

/assign @sttts 