### PR TITLE
Rename sieben to remyleone

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -642,6 +642,7 @@ members:
 - rcj4747
 - rdrgmnzs
 - rekcah78
+- remyleone
 - RenaudWasTaken
 - rendhalver
 - resouer
@@ -708,7 +709,6 @@ members:
 - shubheksha
 - shyamjvs
 - sidharthsurana
-- sieben
 - simonswine
 - siwyd
 - sjenning

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -68,7 +68,7 @@ teams:
     - perriea
     - rbenzair
     - rekcah78
-    - sieben
+    - remyleone
     - smana
     - yastij
     privacy: closed
@@ -82,7 +82,7 @@ teams:
     - perriea
     - rbenzair
     - rekcah78
-    - sieben
+    - remyleone
     - smana
     - yastij
     privacy: closed
@@ -142,8 +142,8 @@ teams:
     - markthink # Chinese
     - micheleberardi # Italian
     - raelga # Spanish
+    - remyleone # French
     - rlenferink # Italian
-    - sieben # French
     - tnir # Japanese
     - zacharysarah # English
     - zhangxiaoyu-zidif # Chinese
@@ -232,9 +232,9 @@ teams:
     - rajakavitha1
     - rbenzair
     - rekcah78
+    - remyleone
     - rlenferink
     - ryanmcginnis
-    - sieben
     - smana
     - steveperry-53
     - stewart-yu


### PR DESCRIPTION
fixes #700 

ref: https://github.com/kubernetes/website/pull/13690
old github profile description points to current: https://github.com/sieben

/area github-membership