### PR TITLE
Add teams for apiserver-network-proxy

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -26,6 +26,7 @@ members:
 - amwat
 - andrewsykim
 - andyzhangx
+- anfernee
 - animeshsingh
 - ant31
 - apelisse

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -48,6 +48,7 @@ members:
 - castrojo
 - chadswen
 - chaosaffe
+- cheftako
 - chenopis
 - childsb
 - chrigl

--- a/config/kubernetes-sigs/sig-cloud-provider/OWNERS
+++ b/config/kubernetes-sigs/sig-cloud-provider/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-cloud-provider-leads
+approvers:
+  - sig-cloud-provider-leads
+labels:
+  - sig/cloud-provider

--- a/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
+++ b/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
@@ -1,0 +1,17 @@
+teams:
+  apiserver-network-proxy-admins:
+    description: admin access to apiserver-network-proxy
+    members:
+    - andrewsykim
+    - anfernee
+    - cheftako
+    - mcrute
+    privacy: closed
+  apiserver-network-proxy-maintainers:
+    description: write access to apiserver-network-proxy
+    members:
+    - andrewsykim
+    - anfernee
+    - cheftako
+    - mcrute
+    privacy: closed


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/715

@cheftako and @anfernee are members of Kubernetes but were not members of Kubernetes SIGs so I've added them as members in this PR (members of Kubernetes are implicitly eligible for membership to Kubernetes SIGs).

/assign @cheftako @andrewsykim 