### PR TITLE
Remove teams for cri-o

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -287,23 +287,6 @@ teams:
     - sflxn
     - sidharthsurana
     privacy: closed
-  cri-o-admins:
-    description: admin access to cri-o
-    members:
-    - mrunalp
-    - runcom
-    privacy: closed
-  cri-o-maintainers:
-    description: write access to cri-o
-    members:
-    - giuseppe
-    - mrunalp
-    - rhatdan
-    - runcom
-    - saschagrunert
-    - sboeuf
-    - umohnani8
-    privacy: closed
   cri-tools-admins:
     description: admin access to cri-tools
     members:


### PR DESCRIPTION
The repo has moved to the cri-o GitHub org: https://github.com/cri-o/cri-o

Ref: https://github.com/kubernetes/org/issues/675

/assign @cblecker 