### PR TITLE
Add a team for the K8s blog

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -1,4 +1,11 @@
 teams:
+  kubernetes-blog:
+    description: Admins for the Kubernetes blog
+    members:
+    - kbarnard10
+    - natekartchner
+    - sarahkconway
+    privacy: closed
   sig-docs-de-owners: 
     description: Admins for German content
     members:


### PR DESCRIPTION
Fixes #754 

This PR creates a GitHub team for the Kubernetes blog.