### PR TITLE
Remove teams for architecture-tracking repo

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -246,24 +246,6 @@ teams:
     - mattfarina
     - prydonius
     privacy: closed
-  architecture-tracking-admins:
-    description: admin permission for architecture-tracking
-    members:
-    - bgrant0607
-    - jdumars
-    privacy: closed
-  architecture-tracking-maintainers:
-    description: write permission for architecture-tracking
-    maintainers:
-    - spiffxp
-    members:
-    - bgrant0607
-    - dims
-    - jdumars
-    - liggitt
-    - mattfarina
-    - timothysc
-    privacy: closed
   bots:
     description: Bot Service Accounts in the Kubernetes-SIGs org
     maintainers:


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/738

/assign @dims @jdumars 