### PR TITLE
Remove XiaoningDing from kubernetes

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -823,7 +823,6 @@ members:
 - xiang90
 - xiangpengzhao
 - xianlubird
-- XiaoningDing
 - xiaoxubeii
 - xichengliudui
 - xing-yang


### PR DESCRIPTION
This person removed themselves from the GitHub org and we immediately re-invited them. This removes that invitation.