### PR TITLE
Add teams for release-notes

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -154,6 +154,7 @@ members:
 - maciaszczykm
 - maisem
 - mariantalla
+- marpaia
 - marquiz
 - marun
 - marwanad

--- a/config/kubernetes-sigs/sig-release/OWNERS
+++ b/config/kubernetes-sigs/sig-release/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-release-leads
+approvers:
+  - sig-release-leads
+labels:
+  - sig/release

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -15,3 +15,20 @@ teams:
     - listx
     - tpepper
     privacy: closed
+  release-notes-admins:
+    description: admin access to release-notes
+    members:
+    - jeefy
+    - marpaia
+    - onyiny-ang
+    privacy: closed
+  release-notes-maintainers:
+    description: write access to release-notes
+    maintainers:
+    - calebamiles
+    members:
+    - jeefy
+    - justaugustus
+    - marpaia
+    - onyiny-ang
+    - tpepper


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/801

@marpaia was not a member of k-sigs, so I've added him in this PR. Since he is a member of @kubernetes, he is implicitly eligible for membership to @kubernetes-sigs. 

@jeefy you mentioned that release-engineering should also have write access to this repo. I'm not entirely sure if we have it codified somewhere who comes under release-engineering? Could you add them as a follow-up?

/assign @jeefy @justaugustus 