### PR TITLE
Add k8s-release-robot to milestone-maintainers team

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -52,6 +52,7 @@ teams:
     - justaugustus # Azure / PM / Release
     - justinsb # AWS
     - k82cn # Scheduling
+    - k8s-release-robot # Release
     - kacole2 # 1.15 Enhancements
     - khenidak # Azure
     - kow3ns # Apps


### PR DESCRIPTION
So that @k8s-release-robot can add milestone for the publishing bot issue. See https://github.com/kubernetes/kubernetes/issues/77871#issuecomment-492299856 and https://github.com/kubernetes/release/pull/711 for more details.

/assign @justaugustus 