### PR TITLE
Add issue template for project boards

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-board.md
+++ b/.github/ISSUE_TEMPLATE/project-board.md
@@ -1,0 +1,30 @@
+---
+name: Project Board Creation
+about: Create a project board
+title: ''
+labels: area/github-board
+assignees: ''
+
+---
+### Requested name for the Project Board
+e.g. SIG Foo
+
+### Which Organization should it reside
+e.g. kubernetes-sigs
+
+### Who should have admin access
+e.g. alice, bob
+
+### Who should have write access
+By default all members of the org will have write access.
+If you want to restrict write access, mention the names here.
+e.g. chris, dianne
+
+### What should the Project Board description be
+By default we will set it to "created due to (link to this issue)"
+
+### Approvals
+Please include links to any relevant approvals.
+
+### Additional context for request
+Any additional information or context to describe the request.


### PR DESCRIPTION
xref #823 

This should help us in getting the relevant info easily. For approvals, I left it somewhat ambiguous...if the project board is for a particular SIG, I think SIG leads should approve and if it is for a subproject, approvals from subproject owners (approvers in the root OWNERS file) should be enough.

/assign @cblecker @spiffxp 