### PR TITLE
Enforce non-admins shouldn't be team maintainers

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -108,6 +108,11 @@ func testTeamMembers(teams map[string]org.Team, admins sets.String, orgMembers s
 		teamMaintainers = normalize(teamMaintainers)
 		teamMembers = normalize(teamMembers)
 
+		// check for non-admins in maintainers list
+		if nonAdminMaintainers := teamMaintainers.Difference(admins); len(nonAdminMaintainers) > 0 {
+			errs = append(errs, fmt.Errorf("The team %s in org %s has non-admins listed as maintainers; these users should be in the members list instead: %s", teamName, orgName, strings.Join(nonAdminMaintainers.List(), ",")))
+		}
+
 		// check for users in both maintainers and members
 		if both := teamMaintainers.Intersection(teamMembers); len(both) > 0 {
 			errs = append(errs, fmt.Errorf("The team %s in org %s has users in both maintainer admin and member roles: %s", teamName, orgName, strings.Join(both.List(), ", ")))
@@ -122,9 +127,6 @@ func testTeamMembers(teams map[string]org.Team, admins sets.String, orgMembers s
 		}
 
 		// check if all are org members
-		if missing := teamMaintainers.Difference(orgMembers); len(missing) > 0 {
-			errs = append(errs, fmt.Errorf("The following maintainers of team %s are not %s org members: %s", teamName, orgName, strings.Join(missing.List(), ", ")))
-		}
 		if missing := teamMembers.Difference(orgMembers); len(missing) > 0 {
 			errs = append(errs, fmt.Errorf("The following members of team %s are not %s org members: %s", teamName, orgName, strings.Join(missing.List(), ", ")))
 		}

--- a/config/kubernetes-incubator/org.yaml
+++ b/config/kubernetes-incubator/org.yaml
@@ -182,9 +182,8 @@ members:
 teams:
   admin-bootkube:
     description: ""
-    maintainers:
-    - aaronlevy
     members:
+    - aaronlevy
     - philips
     privacy: closed
   admin-cluster-capacity:
@@ -204,9 +203,8 @@ teams:
     privacy: closed
   admin-custom-metrics-apiserver:
     description: Admins for the custom-metrics-apiserver repo
-    maintainers:
-    - DirectXMan12
     members:
+    - DirectXMan12
     - luxas
     - piosz
     privacy: closed
@@ -218,14 +216,13 @@ teams:
     privacy: closed
   admin-reference-docs:
     description: adminstration of reference-docs repo
-    maintainers:
-    - pwittrock
     members:
+    - pwittrock
     - sarahnovotny
     privacy: closed
   admins-apiserver-builder:
     description: maintainers of the apiserver-builder repository with admin access
-    maintainers:
+    members:
     - DirectXMan12
     - pwittrock
     - yue9944882
@@ -234,15 +231,14 @@ teams:
     description: administrators of the application-images repository
     maintainers:
     - calebamiles
-    - zmerlynn
     members:
     - mattf
+    - zmerlynn
     privacy: closed
   admins-client-python:
     description: admins of the client-python project
-    maintainers:
-    - mbohlool
     members:
+    - mbohlool
     - sarahnovotny
     - smarterclayton
     - yliaog
@@ -250,10 +246,10 @@ teams:
   admins-cluster-proportional-autoscaler:
     description: administers of  the cluster-proportional-autoscaler repository
     maintainers:
-    - bowei
     - calebamiles
-    - MrHohn
     members:
+    - bowei
+    - MrHohn
     - philips
     privacy: closed
   admins-cluster-proportional-vertical-autoscaler:
@@ -265,25 +261,24 @@ teams:
     description: ""
     maintainers:
     - calebamiles
-    - justinsb
     members:
+    - justinsb
     - sarahnovotny
     privacy: closed
   admins-ip-masq-agent:
     description: ""
-    maintainers:
+    members:
     - dnardo
+    - MrHohn
     - mtaufen
     - thockin
-    members:
-    - MrHohn
     privacy: closed
   admins-kargo:
     description: ""
     maintainers:
-    - ant31
     - calebamiles
     members:
+    - ant31
     - bogdando
     - mattymo
     - sarahnovotny
@@ -291,14 +286,13 @@ teams:
     privacy: closed
   admins-kompose:
     description: Admins for kompose
-    maintainers:
-    - sebgoa
     members:
     - bgrant0607
     - cdrage
     - janetkuo
     - kadel
     - ngtuna
+    - sebgoa
     privacy: closed
   admins-kops:
     description: administrators of the kops repository
@@ -309,8 +303,8 @@ teams:
     description: kube-aws repository administrators
     maintainers:
     - calebamiles
-    - colhom
     members:
+    - colhom
     - mumoshu
     - philips
     privacy: closed
@@ -318,9 +312,9 @@ teams:
     description: administrators of the kube2consul repository
     maintainers:
     - calebamiles
-    - elg0nz
     members:
     - bgrant0607
+    - elg0nz
     privacy: closed
   admins-metrics-server:
     description: ""
@@ -330,9 +324,8 @@ teams:
     privacy: closed
   admins-node-feature-discovery:
     description: Administrators of node-feature-discovery
-    maintainers:
-    - balajismaniam
     members:
+    - balajismaniam
     - ConnorDoyle
     - davidopp
     - philips
@@ -341,48 +334,45 @@ teams:
     description: administrators of the rktlet repository
     maintainers:
     - calebamiles
-    - euank
-    - yifan-gu
     members:
     - dchen1107
+    - euank
+    - yifan-gu
     privacy: closed
   admins-service-catalog:
     description: administrators for the service catalog project
-    maintainers:
+    members:
     - jberkhahn
     - jboyd01
-    members:
     privacy: closed
   descheduler-admins:
     description: Admin permission for descheduler repo
-    maintainers:
+    members:
     - aveshagarwal
     privacy: closed
   descheduler-maintainers:
     description: Write permission for descheduler repo
-    maintainers:
+    members:
     - aveshagarwal
     privacy: closed
   descheduler-reviewers:
     description: Read permission for descheduler repo
-    maintainers:
+    members:
     - aveshagarwal
     privacy: closed
   design-reviewer-kube-arbitrator:
     description: The design reviewer of kube-arbitrator
-    maintainers:
-    - k82cn
     members:
     - bsalamat
     - davidopp
     - foxish
+    - k82cn
     - timothysc
     privacy: closed
   external-storage-community:
     description: the extended external storage community
-    maintainers:
-    - childsb
     members:
+    - childsb
     - ianchakeres
     - jsafrane
     - msau42
@@ -398,17 +388,16 @@ teams:
     privacy: closed
   kompose-contributors:
     description: Contributors to kompose repo (read access)
-    maintainers:
-    - sebgoa
     members:
     - bgrant0607
     - cdrage
     - ngtuna
     - procrypt
+    - sebgoa
     privacy: closed
   maintainers-apiserver-builder:
     description: maintainers of apiserver-builder with write access on the repository
-    maintainers:
+    members:
     - DirectXMan12
     - pwittrock
     - yue9944882
@@ -417,9 +406,9 @@ teams:
     description: contributors to the application-images repository
     maintainers:
     - calebamiles
-    - zmerlynn
     members:
     - mattf
+    - zmerlynn
     privacy: closed
   maintainers-bootkube:
     description: ""
@@ -431,12 +420,11 @@ teams:
     privacy: closed
   maintainers-client-python:
     description: maintainers of the client-python project
-    maintainers:
-    - mbohlool
     members:
     - caesarxuchao
     - dims
     - lavalamp
+    - mbohlool
     - sarahnovotny
     - yliaog
     privacy: closed
@@ -452,8 +440,8 @@ teams:
     description: contributors to the cluster-proportional-autoscaler repository
     maintainers:
     - calebamiles
-    - MrHohn
     members:
+    - MrHohn
     - philips
     privacy: closed
   maintainers-cluster-proportional-vertical-autoscaler:
@@ -464,24 +452,22 @@ teams:
     privacy: closed
   maintainers-cri-containerd:
     description: maintainers of cri-containerd repo
-    maintainers:
-    - Random-Liu
     members:
     - abhi
     - dchen1107
     - mikebrow
+    - Random-Liu
     - sarahnovotny
     - yujuhong
     privacy: closed
   maintainers-external-dns:
     description: ""
-    maintainers:
-    - justinsb
     members:
     - chrislovecnm
     - hjacobs
     - ideahitme
     - iterion
+    - justinsb
     - kris-nova
     - linki
     - njuettner
@@ -511,23 +497,22 @@ teams:
   maintainers-kargo:
     description: ""
     maintainers:
-    - ant31
     - calebamiles
     members:
+    - ant31
     - bogdando
     - mattymo
     - rsmitty
     privacy: closed
   maintainers-kompose:
     description: Write access for kompose
-    maintainers:
-    - sebgoa
     members:
     - bgrant0607
     - cab105
     - cdrage
     - janetkuo
     - kadel
+    - sebgoa
     - surajssd
     privacy: closed
   maintainers-kops:
@@ -539,8 +524,8 @@ teams:
     description: maintainers for kube-aws
     maintainers:
     - calebamiles
-    - colhom
     members:
+    - colhom
     - mumoshu
     - pbx0
     - philips
@@ -550,9 +535,9 @@ teams:
     description: contributors to the kube2consul repository
     maintainers:
     - calebamiles
-    - elg0nz
     members:
     - bgrant0607
+    - elg0nz
     privacy: closed
   maintainers-metrics-server:
     description: ""
@@ -570,9 +555,8 @@ teams:
     privacy: closed
   maintainers-node-feature-discovery:
     description: Maintainers of the node-feature-discovery repo.
-    maintainers:
-    - balajismaniam
     members:
+    - balajismaniam
     - ConnorDoyle
     - davidopp
     - flyingcougar
@@ -581,10 +565,9 @@ teams:
     privacy: closed
   maintainers-reference-docs:
     description: maintainers of the reference-docs repo
-    maintainers:
-    - pwittrock
     members:
     - jimangel
+    - pwittrock
     - sarahnovotny
     - tengqm
     privacy: closed
@@ -592,22 +575,21 @@ teams:
     description: contributors to the rktlet repository
     maintainers:
     - calebamiles
-    - euank
-    - yifan-gu
     members:
     - dchen1107
+    - euank
+    - yifan-gu
     privacy: closed
   maintainers-service-catalog:
     description: maintainers of the service catalog project
-    maintainers:
-    - jberkhahn
-    - jboyd01
     members:
     - arschles
     - bgrant0607
     - carolynvs
     - duglin
     - eriknelson
+    - jberkhahn
+    - jboyd01
     - jeremyrickard
     - jpeeler
     - kibbles-n-bytes
@@ -624,21 +606,19 @@ teams:
     privacy: closed
   maintainers-spartakus:
     description: People who maintain spartakus
-    maintainers:
-    - grodrigues3
     members:
     - aronchick
+    - grodrigues3
     - squat
     - thockin
     privacy: closed
   reviewers-cri-containerd:
     description: reviewers of cri-containerd repo
-    maintainers:
-    - Random-Liu
     members:
     - abhi
     - miaoyq
     - mikebrow
+    - Random-Liu
     - yanxuean
     privacy: closed
   temporary-admin-transfers:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -110,14 +110,11 @@ teams:
     teams:
       patch-release-team:
         description: People managing patch releases of prior k8s minor release branches.
-        maintainers:
-        - justaugustus
         members:
-        - aleksandra-malinowska
-        - feiskyer
-        - foxish
-        - hoegaarden
-        - tpepper
+        - aleksandra-malinowska # 1.13 / 1.14 Patch Release Team
+        - feiskyer # 1.12 Patch Release Manager
+        - foxish # 1.11 Patch Release Manager
+        - tpepper # 1.13 / 1.14 Patch Release Team
         privacy: closed
   sig-release:
     description: SIG Release Members


### PR DESCRIPTION
This is a manual revert of https://github.com/kubernetes/org/pull/591, and a retake of https://github.com/kubernetes/org/pull/592

If this looks good, I'll do a manual peribolos run to fix any weird errors that arise.
