### PR TITLE
Fix description for stage-bots team

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1819,7 +1819,7 @@ teams:
     - bgrant0607
     privacy: closed
   stage-bots:
-    description: Bots that only have write access to staged repositories. Giving write
+    description: Bots that only have admin access to staged repositories. Giving admin
       access to other repositories may allow the bot to automatically unintentionally
       close issues in those repositories.
     members:


### PR DESCRIPTION
The publishing-bot requires admin to access to be able to push to protected branches. Also see https://github.com/orgs/kubernetes/teams/stage-bots/repositories.

This confused me for a second while assigning access to a new staging repo.

/assign @cblecker 