### PR TITLE
Add mszostok to the kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -179,6 +179,7 @@ members:
 - mrbobbytables
 - mrunalp
 - msau42
+- mszostok
 - mtaufen
 - munnerz
 - ncdc


### PR DESCRIPTION
I'm already the member of the @kubernetes org and I need to join the @kubernetes-sigs because the Service Catalog project (to which I contribute) will be moved there soon.