### PR TITLE
cleanup sig-service-catalog teams

### DIFF
--- a/config/kubernetes-sigs/sig-service-catalog/teams.yaml
+++ b/config/kubernetes-sigs/sig-service-catalog/teams.yaml
@@ -7,9 +7,8 @@ teams:
   service-catalog-maintainers:
     description: Write access to the service-catalog repo
     members:
-    - bgrant0607
     - carolynvs
     - jberkhahn
-    - jeremyrickard
-    - pmorie
+    - mhbauer
+    - mszostok
     privacy: closed

--- a/config/kubernetes/sig-service-catalog/teams.yaml
+++ b/config/kubernetes/sig-service-catalog/teams.yaml
@@ -2,11 +2,10 @@ teams:
   sig-service-catalog:
     description: Notifications for SIG service-catalog
     members:
-    - bgrant0607
     - carolynvs
     - jberkhahn
-    - jeremyrickard
-    - pmorie
+    - mhbauer
+    - mszostok
     previously:
     - sig-service-catalog-misc
     privacy: closed


### PR DESCRIPTION
making these teams represent current membership of the sig.

-removing defunct members
-readding mhbauer who got dropped during the incubator -> sigs transition
-add new maintainer mszostok