### PR TITLE
add Leigh and Daniel as cluster addons operator maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -11,6 +11,8 @@ teams:
     description: write access to addon-operators
     members:
     - justinsb
+    - stealthybox
+    - dholbach
     privacy: closed
   cluster-api-admins:
     description: ""

--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -10,9 +10,9 @@ teams:
   addon-operators-maintainers:
     description: write access to addon-operators
     members:
+    - dholbach
     - justinsb
     - stealthybox
-    - dholbach
     privacy: closed
   cluster-api-admins:
     description: ""


### PR DESCRIPTION
Add Leigh and Daniel to help with project logistics.

Daniel has been helping with meeting logistics since the start. Leigh has written quite a bit of code and contributed design and ideas.

It'd be good to add us to maintainers, so we can e.g. add and drive a project board for [the issues](https://github.com/kubernetes-sigs/addon-operators/issues?q=is%3Aopen+sort%3Acreated-asc).