### PR TITLE
update kube-state-metrics admins and maintainers

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1420,11 +1420,16 @@ teams:
   kube-state-metrics-admins:
     description: Admin access to the kube-state-metrics repo
     members:
-    - fabxc
-    - ghodss
+    - andyxning
+    - brancz
     privacy: closed
   kube-state-metrics-maintainers:
     description: Write access to the kube-state-metrics repo
+    members:
+    - andyxning
+    - brancz
+    - mxinden
+    - tariq1890
     privacy: closed
   kubeadm-admins:
     description: Admin access to the kubeadm repo


### PR DESCRIPTION
The kube-state-metrics portion is very outdated.

i) Removing ghodss and fabxc as they are no longer active.
ii) Adding brancz and andyxing as admins since they are the Security Contacts of kube-state-metrics.
iii) Adding the listed `approvers` of `kube-state-metrics` as maintainers.

Reference:
i) https://github.com/kubernetes/kube-state-metrics/blob/master/OWNERS
ii) https://github.com/kubernetes/kube-state-metrics/blob/master/SECURITY_CONTACTS


cc @brancz @mxinden @andyxning 