### PR TITLE
Add /me to the patch release and release managers team

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -124,6 +124,7 @@ teams:
     members:
     - aleksandra-malinowska # 1.13 / 1.14 Patch Release Team
     - feiskyer # 1.12 Patch Release Manager
+    - hoegaarden # 1.13 / 1.14 Patch Release Team
     - tpepper # 1.13 / 1.14 Patch Release Team
     privacy: closed
   publishing-bot-reviewers:
@@ -154,6 +155,7 @@ teams:
     - aleksandra-malinowska # 1.13 / 1.14 Patch Release Team
     - bubblemelon # 1.15 Branch Manager
     - feiskyer # 1.12 Patch Release Manager
+    - hoegaarden # 1.13 / 1.14 Patch Release Team
     - idealhack # 1.15 Branch Manager Shadow
     - k8s-release-robot
     - tpepper # 1.13 / 1.14 Patch Release Team


### PR DESCRIPTION
- I was removed from `patch-release-team` in [this PR][pr], I am not sure why. Re-adding myself again.
- I think I also need to be on `release-managers` to be able to actually cut a patch.

If there are good reasons why I have been removed in the first place, please let me know.

/cc @kubernetes/patch-release-team 
/cc @kubernetes/release-managers 
/cc @cblecker 

[pr]: https://github.com/kubernetes/org/pull/849