### PR TITLE
Cleaning up SIG-OpenStack owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -72,9 +72,9 @@ aliases:
     - dchen1107
     - derekwaynecarr
   sig-openstack-leads:
-    - hogepodge
     - adisky
     - chrigl
+    - hogepodge
   sig-pm-leads:
     - calebamiles
     - idvoretskyi

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -996,22 +996,26 @@ teams:
   cloud-provider-openstack-admins:
     description: Admin access to cloud-provider-openstack repo
     members:
+    - adisky
+    - chrigl
     - dims
-    - dklyle
     - hogepodge
     privacy: closed
   cloud-provider-openstack-maintainers:
     description: Write access to the cloud-provider-openstack repo
     members:
     - adisky
+    - chrigl
     - dims
-    - dklyle
     - hogepodge
     privacy: closed
   cloud-provider-openstack-members:
     description: ""
     members:
+    - adisky
+    - chrigl
     - dims
+    - hogepodge
     privacy: closed
   cloud-provider-vsphere-admins:
     description: Admin access to cloud-provider-vsphere repo

--- a/config/kubernetes/sig-openstack/teams.yaml
+++ b/config/kubernetes/sig-openstack/teams.yaml
@@ -2,30 +2,36 @@ teams:
   sig-openstack-api-reviews:
     description: ""
     maintainers:
-    - idvoretskyi
+    - hogepodge
     members:
-    - xsgordon
+    - adisky
+    - chrigl
     privacy: closed
   sig-openstack-bugs:
     description: ""
     maintainers:
-    - idvoretskyi
+    - hogepodge
     members:
     - NickrenREN
-    - xsgordon
+    - adisky
+    - chrigl
     privacy: closed
   sig-openstack-feature-requests:
     description: ""
     maintainers:
-    - idvoretskyi
+    - hogepodge
     members:
-    - xsgordon
+    - adisky
+    - chrigl
     privacy: closed
   sig-openstack-misc:
     description: OpenStack Special Interest Group
     maintainers:
-    - idvoretskyi
+    - adisky
+    - chrigl
+    - hogepodge
     members:
+    - NickrenREN
     - anguslees
     - codevulture
     - dims
@@ -34,10 +40,8 @@ teams:
     - flaper87
     - grahamhayes
     - harlowja
-    - hogepodge
     - hongbin
     - kragniz
-    - NickrenREN
     - pigmej
     - rootfs
     - russellb
@@ -47,22 +51,24 @@ teams:
   sig-openstack-pr-reviews:
     description: ""
     maintainers:
-    - idvoretskyi
+    - hogepodge
     members:
-    - NickrenREN
-    - xsgordon
+    - adisky
+    - chrigl
     privacy: closed
   sig-openstack-proposals:
     description: ""
     maintainers:
-    - idvoretskyi
+    - hogepodge
     members:
-    - xsgordon
+    - adisky
+    - chrigl
     privacy: closed
   sig-openstack-test-failures:
     description: ""
     maintainers:
-    - idvoretskyi
+    - hogepodge
     members:
-    - xsgordon
+    - adisky
+    - chrigl
     privacy: closed


### PR DESCRIPTION
Cleaning up the SIG-OpenStack owners files to reflect new leadership
changes over the last year.