### PR TITLE
Remove rustyrobot from Kubernetes org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -723,7 +723,6 @@ members:
 - rsdcastro
 - runcom
 - russellb
-- rustyrobot
 - rutsky
 - ryanmcginnis
 - s-ito-ts


### PR DESCRIPTION
The user doesn't exist anymore, probably moved to @yoojinl.

@yoojinl can you confirm that @rustyrobot was your old username and it was renamed to @yoojinl? Will readd you after that.

This should fix peribolos.

/assign @cblecker 