### PR TITLE
Fix visibility of secret teams

### DIFF
--- a/config/kubernetes-client/org.yaml
+++ b/config/kubernetes-client/org.yaml
@@ -58,7 +58,7 @@ teams:
     - krabhishek8260
     - lwander
     - mbohlool
-    privacy: secret
+    privacy: closed
   csharp-admins:
     description: Admin access to csharp repo
     members:

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -31,3 +31,4 @@ teams:
     - marpaia
     - onyiny-ang
     - tpepper
+    privacy: closed

--- a/config/kubernetes/wg-lts/teams.yaml
+++ b/config/kubernetes/wg-lts/teams.yaml
@@ -8,3 +8,4 @@ teams:
       - quinton-hoole
       - tpepper
       - youngnick
+    privacy: closed


### PR DESCRIPTION
These teams don't need to be secret. If the `privacy` field is not included for a team, they are secret by default.

For `wg-lts` and `release-notes-maintainers` teams, it looks like we just missed adding the `privacy` field.

/assign @cblecker 