### PR TITLE
Revert "Remove k8s-release-robot from all teams"

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -980,6 +980,7 @@ teams:
     - thelinuxfoundation
     members:
     - k8s-publishing-bot
+    - k8s-release-robot
     privacy: closed
   client-go-admins:
     description: Admin access to the client-go repo

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -75,6 +75,7 @@ teams:
     - justaugustus # Azure / PM / Release
     - justinsb # AWS
     - k82cn # Scheduling
+    - k8s-release-robot # Release
     - kacole2 # 1.15 Enhancements
     - khenidak # Azure
     - kow3ns # Apps
@@ -174,6 +175,7 @@ teams:
     - feiskyer # Patch Release Team
     - hoegaarden # Patch Release Team
     - idealhack # Branch Manager
+    - k8s-release-robot
     - tpepper # Patch Release Team
     privacy: closed
     previously:


### PR DESCRIPTION
This reverts commit 18c15544dce0ee2b89a080cb0ddb006829ebd47a.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/cc @kubernetes/owners @kubernetes/sig-release-admins 
/assign @cblecker @nikhita 

ref: #980, https://groups.google.com/d/topic/kubernetes-release-managers-private/eunbbd2WN_E/discussion, https://groups.google.com/d/topic/kubernetes-release-managers-private/V9ZHE6iHbvU/discussion