### PR TITLE
Add Maria as Milestone Maintainer

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -87,6 +87,7 @@ teams:
     - liyinan926 # Big Data
     - luxas # Cluster Lifecycle
     - MAKOSCAFEE # 1.15 Docs
+    - mariantalla # 1.16 Enhancement Shadow
     - mattfarina # Apps / Architecture
     - michmike # Windows
     - mikedanese # Auth


### PR DESCRIPTION
I overlooked Maria as a milestone maintainer as 1.16 Enhancement Shadow. She needs the powers.

Signed-off-by: Kendrick Coleman <kendrickc@vmware.com>