### PR TITLE
Update blog team members

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1528,15 +1528,6 @@ teams:
     - neolit123
     - timothysc
     privacy: closed
-  kubernetes-blog-maintainers:
-    description: Maintainers of the kubernetes blog
-    members:
-    - bobsky
-    - kbarnard10
-    - natekartchner
-    - SarahKConway
-    - zacharysarah
-    privacy: closed
   kubernetes-feature-branch-admins:
     description: Admin access to the kubernetes repo, for maintaining feature branches. Will deprecate when this access is no longer needed.
     members:

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -1,11 +1,4 @@
 teams:
-  kubernetes-blog:
-    description: Approvers for the Kubernetes blog
-    members:
-    - kbarnard10
-    - natekartchner
-    - sarahkconway
-    privacy: closed
   sig-docs-de-owners:
     description: Approvers for German content
     members:


### PR DESCRIPTION
This PR updates K8s blog team info by removing deprecated teams.

Instead of org-level teams, a Prow/OWNERS group in [k/website](https://github.com/kubernetes/website/blob/master/content/en/blog/OWNERS) handles blog maintenance.

/assign @kbarnard10 @mrbobbytables 

/sig docs
/area github-permissions