### PR TITLE
Add team for sig-usability

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -271,6 +271,7 @@ members:
 - verult
 - vikaschoudhary16
 - vincepri
+- vllry
 - wk8
 - wongma7
 - woopstar

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -215,6 +215,7 @@ members:
 - puja108
 - pwittrock
 - quinton-hoole
+- Rajakavitha1
 - Random-Liu
 - randomvariable
 - rhatdan

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -114,6 +114,7 @@ members:
 - hidekazuna
 - hoegaarden
 - holmsten
+- hpandeycodeit
 - hzxuzhonghu
 - iamemilio
 - ibzib

--- a/config/kubernetes-sigs/sig-usability/OWNERS
+++ b/config/kubernetes-sigs/sig-usability/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-usability-leads
+approvers:
+  - sig-usability-leads
+labels:
+  - sig/usability

--- a/config/kubernetes-sigs/sig-usability/teams.yaml
+++ b/config/kubernetes-sigs/sig-usability/teams.yaml
@@ -1,0 +1,17 @@
+teams:
+  sig-usability-admins:
+    description: Admin access to sig-usability repo
+    members:
+    - hpandeycodeit
+    - Rajakavitha1
+    - tashimi
+    - vllry
+    privacy: closed
+  sig-usability-maintainers:
+    description: Write access to sig-usability repo
+    members:
+    - hpandeycodeit
+    - Rajakavitha1
+    - tashimi
+    - vllry
+    privacy: closed


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1047

This PR:

- Adds team for sig-usability
- Adds @hpandeycodeit @Rajakavitha1 @vllry to k-sigs org, since they are already members of the kubernetes org.
- ~~Adds `sig-usability-leads` to `OWNERS_ALIASES`. Ideally we should just do a sync of the OWNERS_ALIASES file in k/community but that removes aliases for cloud providers sigs (sig-azure, etc). I'd prefer to clean those up in a follow-up (https://github.com/kubernetes/org/issues/1051)~~