### PR TITLE
sig-cloud-provider: Rename OWNERS_ALIASES & GitHub teams

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,44 +1,36 @@
 aliases:
   sig-api-machinery-leads:
-    - lavalamp
     - deads2k
+    - lavalamp
   sig-apps-leads:
+    - janetkuo
+    - kow3ns
     - mattfarina
     - prydonius
-    - kow3ns
   sig-architecture-leads:
     - bgrant0607
-    - jdumars
-    - mattfarina
     - derekwaynecarr
     - dims
+    - jdumars
+    - mattfarina
   sig-auth-leads:
-    - mikedanese
     - enj
+    - mikedanese
     - tallclair
     - deads2k
     - liggitt
     - mikedanese
   sig-autoscaling-leads:
     - mwielgus
-  sig-aws-leads:
-    - justinsb
-    - kris-nova
-    - d-nishi
-  sig-azure-leads:
-    - justaugustus
-    - dstrebel
-    - khenidak
-    - feiskyer
   sig-cli-leads:
-    - soltysh
     - seans3
     - soltysh
     - pwittrock
+    - soltysh
   sig-cloud-provider-leads:
     - andrewsykim
+    - cheftako
     - hogepodge
-    - jagosan
   sig-cluster-lifecycle-leads:
     - justinsb
     - luxas
@@ -49,127 +41,119 @@ aliases:
     - cblecker
     - nikhita
   sig-docs-leads:
+    - bradamant3
     - jaredbhatti
     - zacharysarah
-    - bradamant3
-  sig-gcp-leads:
-    - abgworrall
-  sig-ibmcloud-leads:
-    - khahmed
-    - rtheis
-    - spzala
   sig-instrumentation-leads:
-    - piosz
     - brancz
+    - piosz
   sig-multicluster-leads:
-    - csbell
+    - pmorie
     - quinton-hoole
   sig-network-leads:
-    - thockin
-    - dcbw
     - caseydavenport
+    - dcbw
+    - thockin
   sig-node-leads:
     - dchen1107
     - derekwaynecarr
-  sig-openstack-leads:
-    - hogepodge
-    - adisky
-    - chrigl
   sig-pm-leads:
     - calebamiles
-    - idvoretskyi
     - jdumars
     - justaugustus
+    - lachie83
   sig-release-leads:
     - calebamiles
     - justaugustus
     - tpepper
   sig-scalability-leads:
-    - wojtek-t
     - shyamjvs
+    - wojtek-t
   sig-scheduling-leads:
     - bsalamat
     - k82cn
   sig-service-catalog-leads:
-    - kibbles-n-bytes
     - jberkhahn
-    - jboyd01
+    - mszostok
   sig-storage-leads:
-    - saad-ali
     - childsb
+    - saad-ali
   sig-testing-leads:
-    - spiffxp
     - fejta
+    - spiffxp
     - stevekuznetsov
     - timothysc
   sig-ui-leads:
-    - floreks
-    - maciaszczykm
     - danielromlein
+    - floreks
     - jeefy
-  sig-vmware-leads:
-    - frapposelli
-    - cantbewong
+    - maciaszczykm
+  sig-usability-leads:
+    - Rajakavitha1
+    - hpandeycodeit
+    - tashimi
+    - vllry
   sig-windows-leads:
     - michmike
     - patricklang
   wg-apply-leads:
     - lavalamp
   wg-component-standard-leads:
-    - luxas
-    - sttts
     - mtaufen
+    - stealthybox
+    - sttts
   wg-iot-edge-leads:
+    - cantbewong
     - cindyxing
     - dejanb
     - ptone
-    - cantbewong
   wg-k8s-infra-leads:
     - dims
     - spiffxp
   wg-lts-leads:
-    - tpepper
     - imkin
     - quinton-hoole
+    - tpepper
     - youngnick
   wg-machine-learning-leads:
-    - vishh
-    - kow3ns
-    - balajismaniam
     - ConnorDoyle
+    - balajismaniam
+    - kow3ns
+    - vishh
   wg-multitenancy-leads:
-    - davidopp
+    - srampal
     - tashimi
   wg-policy-leads:
-    - hannibalhuang
-    - tsandall
     - easeway
     - ericavonb
+    - hannibalhuang
     - mdelder
+    - tsandall
   wg-resource-management-leads:
-    - vishh
     - derekwaynecarr
+    - vishh
   wg-security-audit-leads:
     - aasmall
-    - joelsmith
     - cji
     - jaybeale
+    - joelsmith
   ug-big-data-leads:
-    - foxish
     - erikerlandson
+    - foxish
     - liyinan926
   committee-code-of-conduct:
-    - jdumars
-    - parispittman
+    - bradamant3
     - carolynvs
     - eparis
-    - bradamant3
+    - jdumars
+    - parispittman
   committee-product-security:
-    - philips
     - cjcullen
-    - tallclair
-    - liggitt
     - joelsmith
+    - jonpulsifer
+    - liggitt
+    - philips
+    - tallclair
   committee-steering:
     - bgrant0607
     - brendandburns
@@ -184,5 +168,24 @@ aliases:
     - spiffxp
     - timothysc
 ## BEGIN CUSTOM CONTENT
-
+  provider-aws:
+    - d-nishi
+    - justinsb
+    - kris-nova
+  provider-azure:
+    - craiglpeters
+    - justaugustus
+    - feiskyer
+    - khenidak
+  provider-gcp:
+    - abgworrall
+  provider-ibmcloud:
+    - spzala
+  provider-openstack:
+    - adisky
+    - chrigl
+    - hogepodge
+  provider-vmware:
+    - cantbewong
+    - frapposelli
 ## END CUSTOM CONTENT

--- a/config/kubernetes-sigs/sig-aws/OWNERS
+++ b/config/kubernetes-sigs/sig-aws/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-aws-leads
+  - provider-aws
 approvers:
-  - sig-aws-leads
+  - provider-aws
 labels:
   - sig/azure

--- a/config/kubernetes-sigs/sig-azure/OWNERS
+++ b/config/kubernetes-sigs/sig-azure/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-azure-leads
+  - provider-azure
 approvers:
-  - sig-azure-leads
+  - provider-azure
 labels:
   - sig/azure

--- a/config/kubernetes-sigs/sig-ibmcloud/OWNERS
+++ b/config/kubernetes-sigs/sig-ibmcloud/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-ibmcloud-leads
+  - provider-ibmcloud
 approvers:
-  - sig-ibmcloud-leads
+  - provider-ibmcloud
 labels:
   - sig/ibmcloud

--- a/config/kubernetes-sigs/sig-vmware/OWNERS
+++ b/config/kubernetes-sigs/sig-vmware/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-vmware-leads
+  - provider-vmware
 approvers:
-  - sig-vmware-leads
+  - provider-vmware
 labels:
   - sig/vmware

--- a/config/kubernetes/sig-aws/OWNERS
+++ b/config/kubernetes/sig-aws/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-aws-leads
+  - provider-aws
 approvers:
-  - sig-aws-leads
+  - provider-aws
 labels:
   - sig/aws

--- a/config/kubernetes/sig-aws/teams.yaml
+++ b/config/kubernetes/sig-aws/teams.yaml
@@ -1,5 +1,5 @@
 teams:
-  sig-aws-misc:
+  provider-aws-misc:
     description: ""
     members:
     - d-nishi
@@ -11,3 +11,5 @@ teams:
     - nckturner
     - sethpollack
     privacy: closed
+    previously:
+    - sig-aws-misc

--- a/config/kubernetes/sig-azure/OWNERS
+++ b/config/kubernetes/sig-azure/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-azure-leads
+  - provider-azure
 approvers:
-  - sig-azure-leads
+  - provider-azure
 labels:
   - sig/azure

--- a/config/kubernetes/sig-azure/teams.yaml
+++ b/config/kubernetes/sig-azure/teams.yaml
@@ -1,5 +1,5 @@
 teams:
-  sig-azure:
+  provider-azure:
     description: General discussion for SIG Azure
     members:
     - andyzhangx
@@ -14,6 +14,8 @@ teams:
     - ritazh
     - soggiest
     privacy: closed
+    previously:
+    - sig-azure
   cloud-provider-azure-admins:
     description: ""
     members:

--- a/config/kubernetes/sig-gcp/OWNERS
+++ b/config/kubernetes/sig-gcp/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-gcp-leads
+  - provider-gcp
 approvers:
-  - sig-gcp-leads
+  - provider-gcp
 labels:
   - sig/gcp

--- a/config/kubernetes/sig-gcp/teams.yaml
+++ b/config/kubernetes/sig-gcp/teams.yaml
@@ -1,36 +1,50 @@
 teams:
-  sig-gcp-api-reviews:
+  provider-gcp-api-reviews:
     description: ""
     members:
     - abgworrall
     privacy: closed
-  sig-gcp-bugs:
+    previously:
+    - sig-gcp-api-reviews
+  provider-gcp-bugs:
     description: ""
     members:
     - abgworrall
     privacy: closed
-  sig-gcp-feature-requests:
+    previously:
+    - sig-gcp-bugs
+  provider-gcp-feature-requests:
     description: ""
     members:
     - abgworrall
     privacy: closed
-  sig-gcp-misc:
+    previously:
+    - sig-gcp-feature-requests
+  provider-gcp-misc:
     description: ""
     members:
     - abgworrall
     privacy: closed
-  sig-gcp-pr-reviews:
+    previously:
+    - sig-gcp-misc
+  provider-gcp-pr-reviews:
     description: ""
     members:
     - abgworrall
     privacy: closed
-  sig-gcp-proposals:
+    previously:
+    - sig-gcp-pr-reviews
+  provider-gcp-proposals:
     description: ""
     members:
     - abgworrall
     privacy: closed
-  sig-gcp-test-failures:
+    previously:
+    - sig-gcp-proposals
+  provider-gcp-test-failures:
     description: ""
     members:
     - abgworrall
     privacy: closed
+    previously:
+    - sig-gcp-test-failures

--- a/config/kubernetes/sig-ibmcloud/OWNERS
+++ b/config/kubernetes/sig-ibmcloud/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-ibmcloud-leads
+  - provider-ibmcloud
 approvers:
-  - sig-ibmcloud-leads
+  - provider-ibmcloud
 labels:
   - sig/ibmcloud

--- a/config/kubernetes/sig-ibmcloud/teams.yaml
+++ b/config/kubernetes/sig-ibmcloud/teams.yaml
@@ -1,9 +1,11 @@
 teams:
-  sig-ibmcloud-misc:
-    description: This is a team for sig ibmcloud. The related google group is kubernetes-sig-ibmcloud-misc
+  provider-ibmcloud-misc:
+    description: This is a team for sig ibmcloud. The related google group is kubernetes-provider-ibmcloud-misc
       for emails.  The k8s-mirror-ibmcloud-misc github user is the main stake holder/member
       of the team.
     members:
     - k82cn
     - spzala
     privacy: closed
+    previously:
+    - sig-ibmcloud-misc

--- a/config/kubernetes/sig-openstack/OWNERS
+++ b/config/kubernetes/sig-openstack/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - sig-openstack-leads
+  - provider-openstack
 approvers:
-  - sig-openstack-leads
+  - provider-openstack
 labels:
   - sig/openstack

--- a/config/kubernetes/sig-openstack/teams.yaml
+++ b/config/kubernetes/sig-openstack/teams.yaml
@@ -1,12 +1,14 @@
 teams:
-  sig-openstack-api-reviews:
+  provider-openstack-api-reviews:
     description: ""
     maintainers:
     - idvoretskyi
     members:
     - xsgordon
     privacy: closed
-  sig-openstack-bugs:
+    previously:
+    - sig-openstack-api-reviews
+  provider-openstack-bugs:
     description: ""
     maintainers:
     - idvoretskyi
@@ -14,14 +16,18 @@ teams:
     - NickrenREN
     - xsgordon
     privacy: closed
-  sig-openstack-feature-requests:
+    previously:
+    - sig-openstack-bugs
+  provider-openstack-feature-requests:
     description: ""
     maintainers:
     - idvoretskyi
     members:
     - xsgordon
     privacy: closed
-  sig-openstack-misc:
+    previously:
+    - sig-openstack-feature-requests
+  provider-openstack-misc:
     description: OpenStack Special Interest Group
     maintainers:
     - idvoretskyi
@@ -44,7 +50,9 @@ teams:
     - stevemcquaid
     - xsgordon
     privacy: closed
-  sig-openstack-pr-reviews:
+    previously:
+    - sig-openstack-misc
+  provider-openstack-pr-reviews:
     description: ""
     maintainers:
     - idvoretskyi
@@ -52,17 +60,23 @@ teams:
     - NickrenREN
     - xsgordon
     privacy: closed
-  sig-openstack-proposals:
+    previously:
+    - sig-openstack-pr-reviews
+  provider-openstack-proposals:
     description: ""
     maintainers:
     - idvoretskyi
     members:
     - xsgordon
     privacy: closed
-  sig-openstack-test-failures:
+    previously:
+    - sig-openstack-proposals
+  provider-openstack-test-failures:
     description: ""
     maintainers:
     - idvoretskyi
     members:
     - xsgordon
     privacy: closed
+    previously:
+    - sig-openstack-test-failures


### PR DESCRIPTION
- OWNERS: Update OWNER_ALIASES from k/community
- sig-cloud-provider: Update OWNER_ALIASES for consolidated SIGs
- sig-cloud-provider: Update GitHub teams for consolidated SIGs

Ref: [kubernetes/community#3941](https://github.com/kubernetes/community/pull/3941), [kubernetes/community#3895](https://github.com/kubernetes/community/pull/3895), #1051

/assign @andrewsykim @nikhita 