### PR TITLE
sig-release: Add justaugustus to Release Managers team

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -183,6 +183,7 @@ teams:
     - feiskyer # Patch Release Team
     - hoegaarden # Patch Release Team
     - idealhack # Branch Manager
+    - justaugustus # Branch Manager
     - k8s-release-robot
     - tpepper # Patch Release Team
     privacy: closed


### PR DESCRIPTION
I'll be doing some branch management tasks which require superpowers e.g., `branchff`

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/area release-eng
/sig release
/cc @kubernetes/release-engineering 
/assign @tpepper @calebamiles 