### PR TITLE
Add danninov and phanama as docs-id reviewers

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -111,8 +111,10 @@ teams:
   sig-docs-id-reviews:
     description: PR reviews for Indonesian content
     members:
+    - danninov
     - girikuncoro
     - irvifa
+    - phanama
     privacy: closed
   sig-docs-it-owners:
     description: Approvers for Italian content


### PR DESCRIPTION
Adding @danninov and @phanama as additional reviewers for Indonesian localization as they have demonstrated consistent contribution with the localization effort for Bahasa Indonesia for the past months.

/assign @zacharysarah

Co-authored-by: Giri Kuncoro girikuncoro@gmail.com
Co-authored-by: Irvi Firqotul Aini irvifa@gmail.com