### PR TITLE
Add mszostok to the Service Catalog repo admin

### DIFF
--- a/config/kubernetes-sigs/sig-service-catalog/teams.yaml
+++ b/config/kubernetes-sigs/sig-service-catalog/teams.yaml
@@ -3,6 +3,7 @@ teams:
     description: Admin access to the service-catalog repo
     members:
     - jberkhahn
+    - mszostok
     privacy: closed
   service-catalog-maintainers:
     description: Write access to the service-catalog repo


### PR DESCRIPTION
**Description**

I'm one of the Service Catalog chair: https://github.com/kubernetes/community/tree/master/sig-service-catalog#chairs 

During the repo configuration, we overlooked that entry.

/cc @jberkhahn 