### PR TITLE
Add nikhita to release-managers team

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -177,6 +177,8 @@ teams:
       repos where branches must be created, etc., and write access to ones where
       label/PR management is needed. Remove users who are not actively doing
       this job.
+    maintainers:
+    - nikhita # Branch Manager
     members:
     - aleksandra-malinowska # Patch Release Team
     - bubblemelon # Branch Manager


### PR DESCRIPTION
I plan to run branchff for the release-1.16 branch.
I already have admin access to k/k but would like to add myself to the
team to formally document that I am going to be running privileged actions
for release management.

/cc @idealhack @justaugustus 
/assign @idealhack 