### PR TITLE
Add corneliusweig to krew-maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-cli/teams.yaml
+++ b/config/kubernetes-sigs/sig-cli/teams.yaml
@@ -42,6 +42,7 @@ teams:
     members:
     - adohe
     - ahmetb
+    - corneliusweig
     - fabianofranz
     - janetkuo
     - liggitt


### PR DESCRIPTION
Hey there, among the active maintainers of sigs.k8s.io/krew there is only @ahmetb who has sufficient rights to do a release of a new krew version (see https://github.com/kubernetes-sigs/krew/issues/324). We would like to reduce the truck factor here, so that there are at least two of the maintainers with the appropriate rights. In particular, I need the right to create tags manually.

So I was digging into this and I found this config file where @ahmetb is listed in `krew-maintainers`, who apparently have write access to the repository. Is it appropriate to add me there as well (I have been krew maintainer for just a few months only)? If so, is there a particular process that needs to be followed?

Thanks in advance!

Also see the discussion here https://github.com/kubernetes-sigs/krew/issues/324#issuecomment-527232091