### PR TITLE
Add members to k-sigs for descheduler repo migration

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -37,6 +37,7 @@ members:
 - ashish-amarnath
 - atoato88
 - Atoms
+- aveshagarwal
 - awesomenix
 - balajismaniam
 - bclau

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -230,6 +230,7 @@ members:
 - Rajakavitha1
 - Random-Liu
 - randomvariable
+- ravisantoshgudimetla
 - rhatdan
 - ritazh
 - riverzhang


### PR DESCRIPTION
Both `aveshagarwal` and `ravisantoshgudimetla` are already members of the kubernetes org.

Adding as a prerequisite to migrating the descheduler repo from kubernetes-incubator to kubernetes-sigs. 

ref:  https://github.com/kubernetes/org/issues/1176