### PR TITLE
Add descheduler teams to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -368,6 +368,18 @@ teams:
     - jeefy
     - maciaszczykm
     privacy: closed
+  descheduler-admins:
+    description: Admin access to the descheduler repo
+    members:
+    - aveshagarwal
+    - k82cn
+    - ravisantoshgudimetla
+  descehduler-maintainers:
+    description: Write access to the descheduler repo
+    members:
+    - aveshagarwal
+    - k82cn
+    - ravisantoshgudimetla
   etcdadm-admins:
     description: Admin access to the etcdadm repo
     members:


### PR DESCRIPTION
Adding as a prerequisite to migrating the descheduler repo from kubernetes-incubator to kubernetes-sigs. 

ref:  https://github.com/kubernetes/org/issues/1176


/hold

holding for https://github.com/kubernetes/org/pull/1179