### PR TITLE
Update descheduler teams

### DIFF
--- a/config/kubernetes-incubator/org.yaml
+++ b/config/kubernetes-incubator/org.yaml
@@ -327,16 +327,6 @@ teams:
     - euank
     - yifan-gu
     privacy: closed
-  descheduler-admins:
-    description: Admin access to the descheduler repo
-    members:
-    - aveshagarwal
-    privacy: closed
-  descheduler-maintainers:
-    description: Write access to the descheduler repo
-    members:
-    - aveshagarwal
-    privacy: closed
   design-reviewer-kube-arbitrator:
     description: The design reviewer of kube-arbitrator
     members:

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -376,12 +376,14 @@ teams:
     - aveshagarwal
     - k82cn
     - ravisantoshgudimetla
+    privacy: closed
   descehduler-maintainers:
     description: Write access to the descheduler repo
     members:
     - aveshagarwal
     - k82cn
     - ravisantoshgudimetla
+    privacy: closed
   etcdadm-admins:
     description: Admin access to the etcdadm repo
     members:


### PR DESCRIPTION
Removes old descheduler teams.
Fixes privacy setting on new teams 🤦‍♂ 

ref: https://github.com/kubernetes/org/issues/1176