### PR TITLE
Add roycaihw to admin groups in kubernetes-client gen, python and go repos

### DIFF
--- a/config/kubernetes-client/org.yaml
+++ b/config/kubernetes-client/org.yaml
@@ -71,16 +71,19 @@ teams:
     members:
     - brendandburns
     - mbohlool
+    - roycaihw
     privacy: closed
   go-admins:
     description: Admin access to go repo
     members:
     - brendandburns
+    - roycaihw
     privacy: closed
   go-base-admins:
     description: Admin access to go-base repo
     members:
     - brendandburns
+    - roycaihw
     privacy: closed
   haskell-admins:
     description: Admin access to haskell repo
@@ -119,6 +122,7 @@ teams:
     members:
     - brendandburns
     - mbohlool
+    - roycaihw
     - yliaog
     privacy: closed
   python-base-admins:
@@ -126,6 +130,7 @@ teams:
     members:
     - brendandburns
     - mbohlool
+    - roycaihw
     - yliaog
     privacy: closed
   ruby-admins:


### PR DESCRIPTION
Add @roycaihw to the admin groups in 
- kubernetes-client/python
- kubernetes-client/python-base
- kubernetes-client/go
- kubernetes-client/go-base

since I already have admin access to these repos. I maintain the python client repo and do [releases](https://github.com/kubernetes-client/python/releases) regularly.

Also add myself to the admin group in
- kubernetes-client/gen

per conversation in https://github.com/kubernetes-client/gen/pull/97#issuecomment-530034348.