### PR TITLE
Add team for ip-masq-agent in k-sigs

### DIFF
--- a/config/kubernetes-incubator/org.yaml
+++ b/config/kubernetes-incubator/org.yaml
@@ -257,14 +257,6 @@ teams:
     - justinsb
     - sarahnovotny
     privacy: closed
-  admins-ip-masq-agent:
-    description: Admin access to the ip-masq-agent repo
-    members:
-    - dnardo
-    - MrHohn
-    - mtaufen
-    - thockin
-    privacy: closed
   admins-kargo:
     description: Admin access to the kargo repo
     members:
@@ -433,13 +425,6 @@ teams:
     - sbezverk
     - tsmetana
     - wongma7
-    privacy: closed
-  maintainers-ip-masq-agent:
-    description: Write access to the ip-masq-agent repo
-    members:
-    - dnardo
-    - mtaufen
-    - thockin
     privacy: closed
   maintainers-kargo:
     description: Write access to the kargo repo

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -46,6 +46,7 @@ members:
 - bgrant0607
 - bigkraig
 - Birdrock
+- bowei
 - Bradamant3
 - brancz
 - bryk

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -204,6 +204,7 @@ members:
 - mook-as
 - morvencao
 - moshloop
+- MrHohn
 - mrunalp
 - msau42
 - mszostok

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -89,6 +89,7 @@ members:
 - dkoshkin
 - dlipovetsky
 - dmatch01
+- dnardo
 - dougm
 - draveness
 - droot

--- a/config/kubernetes-sigs/sig-network/OWNERS
+++ b/config/kubernetes-sigs/sig-network/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-network-leads
+approvers:
+  - sig-network-leads
+labels:
+  - sig/network

--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -1,0 +1,15 @@
+teams:
+  admins-ip-masq-agent:
+    description: Admin access to the ip-masq-agent repo
+    members:
+    - bowei
+    - dnardo
+    - MrHohn
+    privacy: closed
+  maintainers-ip-masq-agent:
+    description: Write access to the ip-masq-agent repo
+    members:
+    - bowei
+    - dnardo
+    - MrHohn
+    privacy: closed


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1154

Also add @bowei @dnardo and @MrHohn to @kubernetes-sigs since they are already members of the @kubernetes org.

/assign @mrbobbytables 