### PR TITLE
Add lingxiankong to cloud-provider-openstack team

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -186,7 +186,7 @@ aliases:
   provider-openstack:
     - adisky
     - chrigl
-    - hogepodge
+    - lingxiankong
   provider-vmware:
     - cantbewong
     - frapposelli

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1104,7 +1104,7 @@ teams:
     members:
     - dims
     - dklyle
-    - hogepodge
+    - lingxiankong
     privacy: closed
   cloud-provider-openstack-maintainers:
     description: Write access to the cloud-provider-openstack repo
@@ -1112,12 +1112,13 @@ teams:
     - adisky
     - dims
     - dklyle
-    - hogepodge
+    - lingxiankong
     privacy: closed
   cloud-provider-openstack-members:
     description: ""
     members:
     - dims
+    - lingxiankong
     privacy: closed
   cloud-provider-vsphere-admins:
     description: Admin access to cloud-provider-vsphere repo

--- a/config/kubernetes/sig-openstack/teams.yaml
+++ b/config/kubernetes/sig-openstack/teams.yaml
@@ -43,6 +43,7 @@ teams:
     - hogepodge
     - hongbin
     - kragniz
+    - lingxiankong
     - NickrenREN
     - pigmej
     - rootfs

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -67,7 +67,6 @@ teams:
     - foxish # Big Data
     - frapposelli # VMware
     - hoegaarden # Patch Release Team
-    - hogepodge # Cloud Provider / OpenStack
     - hpandeycodeit # Usability
     - idealhack # Patch Release Team
     - janetkuo # Apps
@@ -86,6 +85,7 @@ teams:
     - lachie83 # PM
     - lavalamp # API Machinery
     - liggitt # Auth / Release
+    - lingxiankong # OpenStack
     - liyinan926 # Big Data
     - luxas # Cluster Lifecycle
     - maciaszczykm # UI


### PR DESCRIPTION
@lingxiankong has taken over the leadership for the cloud-provider-openstack from @hogepodge.