### PR TITLE
Cleaning up SIG-OpenStack owners

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1102,27 +1102,6 @@ teams:
     - calebamiles
     - mikedanese
     privacy: closed
-  cloud-provider-openstack-admins:
-    description: Admin access to cloud-provider-openstack repo
-    members:
-    - dims
-    - dklyle
-    - lingxiankong
-    privacy: closed
-  cloud-provider-openstack-maintainers:
-    description: Write access to the cloud-provider-openstack repo
-    members:
-    - adisky
-    - dims
-    - dklyle
-    - lingxiankong
-    privacy: closed
-  cloud-provider-openstack-members:
-    description: ""
-    members:
-    - dims
-    - lingxiankong
-    privacy: closed
   cloud-provider-vsphere-admins:
     description: Admin access to cloud-provider-vsphere repo
     members:

--- a/config/kubernetes/sig-openstack/teams.yaml
+++ b/config/kubernetes/sig-openstack/teams.yaml
@@ -1,38 +1,61 @@
 teams:
+  cloud-provider-openstack-admins:
+    description: Admin access to cloud-provider-openstack repo
+    members:
+    - adisky
+    - chrigl
+    - dims
+    - lingxiankong
+    privacy: closed
+  cloud-provider-openstack-maintainers:
+    description: Write access to the cloud-provider-openstack repo
+    members:
+    - adisky
+    - chrigl
+    - dims
+    - lingxiankong
+    privacy: closed
+  cloud-provider-openstack-members:
+    description: ""
+    members:
+    - adisky
+    - chrigl
+    - dims
+    - lingxiankong
+    privacy: closed
   provider-openstack-api-reviews:
     description: ""
-    maintainers:
-    - idvoretskyi
     members:
-    - xsgordon
+    - adisky
+    - chrigl
+    - lingxiankong
     privacy: closed
     previously:
     - sig-openstack-api-reviews
   provider-openstack-bugs:
     description: ""
-    maintainers:
-    - idvoretskyi
     members:
-    - NickrenREN
-    - xsgordon
+    - adisky
+    - chrigl
+    - lingxiankong
     privacy: closed
     previously:
     - sig-openstack-bugs
   provider-openstack-feature-requests:
     description: ""
-    maintainers:
-    - idvoretskyi
     members:
-    - xsgordon
+    - adisky
+    - chrigl
+    - lingxiankong
     privacy: closed
     previously:
     - sig-openstack-feature-requests
   provider-openstack-misc:
     description: OpenStack Special Interest Group
-    maintainers:
-    - idvoretskyi
     members:
+    - adisky
     - anguslees
+    - chrigl
     - codevulture
     - dims
     - eghobo
@@ -40,7 +63,6 @@ teams:
     - flaper87
     - grahamhayes
     - harlowja
-    - hogepodge
     - hongbin
     - kragniz
     - lingxiankong
@@ -55,29 +77,28 @@ teams:
     - sig-openstack-misc
   provider-openstack-pr-reviews:
     description: ""
-    maintainers:
-    - idvoretskyi
     members:
-    - NickrenREN
-    - xsgordon
+    - adisky
+    - chrigl
+    - lingxiankong
     privacy: closed
     previously:
     - sig-openstack-pr-reviews
   provider-openstack-proposals:
     description: ""
-    maintainers:
-    - idvoretskyi
     members:
-    - xsgordon
+    - adisky
+    - chrigl
+    - lingxiankong
     privacy: closed
     previously:
     - sig-openstack-proposals
   provider-openstack-test-failures:
     description: ""
-    maintainers:
-    - idvoretskyi
     members:
-    - xsgordon
+    - adisky
+    - chrigl
+    - lingxiankong
     privacy: closed
     previously:
     - sig-openstack-test-failures


### PR DESCRIPTION
Cleaning up the SIG-OpenStack owners files to reflect new leadership
changes over the last year.