### PR TITLE
Use repo-infra to bootstrap go rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,49 @@
+build --verbose_failures
 test --test_output=errors
 
+# Note needs an instance name
+# https://github.com/bazelbuild/bazel-toolchains/blob/master/bazelrc/bazel-0.27.0.bazelrc
+build:remote --jobs=500
+build:remote --host_javabase=@rbe_default//java:jdk
+build:remote --javabase=@rbe_default//java:jdk
+build:remote --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --crosstool_top=@rbe_default//cc:toolchain
+build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+
+build:remote --extra_toolchains=@rbe_default//config:cc-toolchain
+build:remote --extra_execution_platforms=@io_k8s_repo_infra//:rbe_with_network
+build:remote --host_platform=@io_k8s_repo_infra//:rbe_with_network
+build:remote --platforms=@io_k8s_repo_infra//:rbe_with_network
+
+build:remote --define=EXECUTOR=remote
+build:remote --remote_executor=grpcs://remotebuildexecution.googleapis.com
+build:remote --remote_timeout=3600
+
+# Alt: --google_credentials=some_file.json
+build:remote --google_default_credentials=true
+
+# Minimize what is downloaded
+build:inmemory --experimental_inmemory_jdeps_files
+build:inmemory --experimental_inmemory_dotd_files
+
+# Minimize what is downloaded
+build:toplevel --config=inmemory
+build:toplevel --experimental_remote_download_outputs=toplevel
+
+build:minimal --config=inmemory
+build:minimal --experimental_remote_download_outputs=minimal
+
+build:remote --config=toplevel
+
+run:remote --experimental_remote_download_outputs=all --noexperimental_inmemory_jdeps_files --noexperimental_inmemory_dotd_files
+
+# Compose the remote configs with an instance name
+# A couple examples below:
+
+# --config=ci-instance adds the instance name
+build:ci-instance --remote_instance_name=projects/k8s-prow-builds/instances/default_instance
+
+# Config we want to use in ci
+#build:ci --config=remote --config=ci-instance # TODO(fejta): enable after CI sets this flag
+build:ci --noshow_progress

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -48,7 +48,7 @@ gazelle(
 
 workspace_binary(
     name = "kazel",
-    cmd = "@io_k8s_repo_infra//kazel",
+    cmd = "@io_k8s_repo_infra//cmd/kazel",
 )
 
 workspace_binary(
@@ -57,7 +57,7 @@ workspace_binary(
         "--dry-run",
         "--print-diff",
     ],
-    cmd = "@io_k8s_repo_infra//kazel",
+    cmd = "@io_k8s_repo_infra//cmd/kazel",
 )
 
 workspace_binary(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,50 +1,23 @@
 # gazelle:repository_macro repos.bzl%go_repositories
 workspace(name = "io_k8s_org")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//:load.bzl", "repositories")
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz"],
-)
+repositories()
 
-load("@bazel_skylib//lib:versions.bzl", "versions")
+load("@io_k8s_repo_infra//:load.bzl", repo_infra_repos = "repositories")
 
-versions.check(minimum_bazel_version = "0.27.0")
+repo_infra_repos()
 
-http_archive(
-    name = "io_k8s_repo_infra",
-    sha256 = "f6d65480241ec0fd7a0d01f432938b97d7395aeb8eefbe859bb877c9b4eafa56",
-    strip_prefix = "repo-infra-9f4571ad7242bf3ec4b47365062498c2528f9a5f",
-    urls = ["https://github.com/kubernetes/repo-infra/archive/9f4571ad7242bf3ec4b47365062498c2528f9a5f.tar.gz"],
-)
+load("@io_k8s_repo_infra//:repos.bzl", "configure")
 
-http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "313f2c7a23fecc33023563f082f381a32b9b7254f727a7dd2d6380ccc6dfe09b",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.19.3/rules_go-0.19.3.tar.gz"],
-)
-
-http_archive(
-    name = "bazel_gazelle",
-    sha256 = "7fc87f4170011201b1690326e8c16c5d802836e3a0d617d8f75c3af2b23180c4",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.2/bazel-gazelle-0.18.2.tar.gz"],
-)
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains()
-
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-
-gazelle_dependencies()
+configure(go_modules = None)
 
 load("//:repos.bzl", "go_repositories")
 
 go_repositories()
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_k8s_test_infra",

--- a/load.bzl
+++ b/load.bzl
@@ -1,0 +1,23 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+def repositories():
+    git_repository(
+        name = "io_k8s_repo_infra",
+        commit = "db6ceb5f992254db76af7c25db2edc5469b5ea82",
+        remote = "https://github.com/kubernetes/repo-infra.git",
+        shallow_since = "1570128715 -0700",
+    )

--- a/repos.bzl
+++ b/repos.bzl
@@ -1903,3 +1903,19 @@ def go_repositories():
         sum = "h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=",
         version = "v2.0.1",
     )
+    go_repository(
+        name = "com_github_golang_lint",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/golang/lint",
+        sum = "h1:2hRPrmiwPrp3fQX967rNJIhQPtiGXdlQWAxKbKw3VHA=",
+        version = "v0.0.0-20180702182130-06c8688daad7",
+    )
+    go_repository(
+        name = "org_apache_git_thrift_git",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "git.apache.org/thrift.git",
+        sum = "h1:OR8VhtwhcAI3U48/rzBsVOuHi0zDPzYI1xASVcdSgR8=",
+        version = "v0.0.0-20180902110319-2566ecd5d999",
+    )


### PR DESCRIPTION
Needs https://github.com/kubernetes/test-infra/pull/14646

* Reuses some repo-loading logic from repo-infra.
* Adds RBE support when using `--config=remote`
* Adds a stub `--config=ci` that does nearly nothing

Next:
* Update CI to use `--config=ci` and make this config use RBE
* Replace hack scripts with common repo-infra versions.

/assign