### PR TITLE
add daminisatya to milestone maintainers

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -267,6 +267,7 @@ teams:
     - claudiajkang
     - cody-clark
     - cstoku
+    - daminisatya
     - femrtnz
     - girikuncoro
     - gochist


### PR DESCRIPTION
This PR add 1.17 doc lead @daminisatya to @kubernetes/website-milestone-maintainers 