### PR TITLE
Add SataQiu to sig-docs-zh teams

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -184,6 +184,7 @@ teams:
     - raelga # Spanish
     - remyleone # French
     - rlenferink # Italian
+    - SataQiu # Chinese
     - seokho-son # Korean
     - tnir # Japanese
     - zacharysarah # English
@@ -240,6 +241,7 @@ teams:
     description: Approvers for Chinese content
     members:
     - hanjiayao
+    - SataQiu
     - tengqm
     - xiangpengzhao
     - zhangxiaoyu-zidif
@@ -250,6 +252,7 @@ teams:
     - chenrui333
     - idealhack
     - pigletfly
+    - SataQiu
     - tengqm
     - xiangpengzhao
     - zhangxiaoyu-zidif
@@ -293,6 +296,7 @@ teams:
     - remyleone
     - rlenferink
     - ryanmcginnis
+    - SataQiu
     - simplytunde
     - smana
     - steveperry-53


### PR DESCRIPTION
I've been involved with the kubernetes community for a long time (more than 1 year), and I've become reviewer/approver for zh docs.
As a matter of fact, I am assisting in the management of zh related tasks ( such as https://github.com/kubernetes/website/pull/16755).
This PR adds myself(SataQiu) to sig-docs-zh teams, then I can better participate in the contribution and management work related to zh docs.

Looking forward to your support @zacharysarah @zhangxiaoyu-zidif @markthink @chenrui333 :)

