### PR TITLE
Isolate permissions for user markthink

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -177,7 +177,6 @@ teams:
     - irvifa # Indonesian
     - jaredbhatti # English
     - jcjesus # Portuguese
-    - markthink # Chinese
     - micheleberardi # Italian
     - mittalyashu #hindi
     - nasa9084 # Japanese


### PR DESCRIPTION
This PR removes @markthink from a team with write access to k/website.

This is in response to https://github.com/kubernetes/website/pull/16708#issuecomment-541201579, where @markthink manually merged his own PR containing architectural site changes to k/website.

The @kubernetes/sig-docs-l10n-admins team exists so that localization teams can create branches and assign milestones to localization projects. Any use of write permissions beyond localization work is an abuse of trust and [does not demonstrate sound technical judgment](https://github.com/kubernetes/community/blob/master/community-membership.md#responsibilities-and-privileges-2). 

There's a longer conversation here, but this PR needs to merge ASAP to establish safety first.