### PR TITLE
Remove kylix3511 from kubernetes

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -543,7 +543,6 @@ members:
 - ksubrmnn
 - ktsakalozos
 - kwiesmueller
-- kylix3511
 - lachie83
 - lapee79
 - lavalamp


### PR DESCRIPTION
```
{"component":"peribolos","error":"status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://developer.github.com/v3/orgs/members/#add-or-update-organization-membership\"}","file":"external/io_k8s_test_infra/prow/cmd/peribolos/main.go:441","func":"main.configureOrgMembers.func1","level":"warning","msg":"UpdateOrgMembership(kubernetes, kylix3511, false) failed","time":"2019-10-14T22:25:57Z"}
```