### PR TITLE
Add SataQiu into cluster-api-bootstrap-provider-kubeadm-maintainers and sig-cluster-lifecycle teams

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -50,6 +50,7 @@ teams:
     - justinsb
     - luxas
     - ncdc
+    - SataQiu
     - timothysc
     privacy: closed
   cluster-api-provider-aws-admins:

--- a/config/kubernetes/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes/sig-cluster-lifecycle/teams.yaml
@@ -17,6 +17,7 @@ teams:
     - neolit123
     - pipejakob
     - rosti
+    - SataQiu
     - stealthybox
     - timothysc
     - xiangpengzhao
@@ -40,6 +41,7 @@ teams:
     - neolit123
     - pipejakob
     - rosti
+    - SataQiu
     - stealthybox
     - timothysc
     - xiangpengzhao


### PR DESCRIPTION
I am interested in the projects around `kubeadm`, and would like to actively participate in them.
So far, I have been involved in the releated contributions about one year.
Happily, I have been honored as a `kubeadm` reviewer and a `cluster-api-bootstrap-provider-kubeadm` maintainer.
This PR put myself(SataQiu) into the proper teams to get better involved in the community.

Ref: 
https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/blob/master/OWNERS_ALIASES#L20
https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/OWNERS#L21

/cc @chuckha @neolit123 