### PR TITLE
Update teams for external-dns

### DIFF
--- a/config/kubernetes-incubator/org.yaml
+++ b/config/kubernetes-incubator/org.yaml
@@ -244,13 +244,6 @@ teams:
     members:
     - MrHohn
     privacy: closed
-  admins-external-dns:
-    description: Admin access to the external-dns repo
-    members:
-    - calebamiles
-    - justinsb
-    - sarahnovotny
-    privacy: closed
   admins-kargo:
     description: Admin access to the kargo repo
     members:
@@ -392,20 +385,6 @@ teams:
     members:
     - dnardo
     - thockin
-    privacy: closed
-  maintainers-external-dns:
-    description: Write access to the external-dns repo
-    members:
-    - chrislovecnm
-    - hjacobs
-    - ideahitme
-    - iterion
-    - justinsb
-    - kris-nova
-    - linki
-    - njuettner
-    - Raffo
-    - sarahnovotny
     privacy: closed
   maintainers-external-storage:
     description: Write access to the external-storage repo

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -188,6 +188,7 @@ members:
 - leakingtapan
 - lichuqiang
 - liggitt
+- linki
 - Lion-Wei
 - listx
 - Liujingfang1

--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -13,3 +13,13 @@ teams:
     - dnardo
     - MrHohn
     privacy: closed
+  admins-external-dns:
+    description: Admin access to the external-dns repo
+    members:
+    - linki
+    privacy: closed
+  maintainers-external-dns:
+    description: Write access to the external-dns repo
+    members:
+    - linki
+    privacy: closed


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1286

`linki` is a kubernetes org member and is automatically eligible for membership to kubernetes-sigs. All others mentioned in the issue are only kubernetes-incubator members, so they'll need to apply for membership to kubernetes-sigs.

/assign @mrbobbytables 