### PR TITLE
Update list of folks with admin access to the website repo

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1727,18 +1727,8 @@ teams:
     description: Admin access to the website repo
     members:
     - Bradamant3
-    - chenopis
-    - jaredbhatti
-    - Kashomon
-    - lavalamp
-    - mistyhacks
-    - pwittrock
-    - sebgoa
-    - steveperry-53
-    - tfogo
-    - thockin
+    - jimangel
     - zacharysarah
-    - zparnold
     privacy: closed
   maintainer-test-exemptions:
     description: Maintainers who for whatever random reason should not own tests.


### PR DESCRIPTION
This PR updates the list of people with admin access to the k/website repo as part of [OWNERS cleanup](https://groups.google.com/d/msg/kubernetes-dev/4160VsBL7OI/BsBRZSqpCQAJ). 

I've pruned the list of people from SIG Docs to its current chairs:

```
    - Bradamant3
    - jimangel
    - zacharysarah
```

A couple of questions:

1. Is there a compelling reason for these folks to continue with admin permissions for k/website?

```
    - Kashomon
    - lavalamp
    - pwittrock
    - sebgoa
    - thockin
```
2. Are there folks whom we should add instead? 

I'm thinking it might be good to add one or two people from steering.