### PR TITLE
Adding more owners to external-dns

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -16,12 +16,18 @@ teams:
   admins-external-dns:
     description: Admin access to the external-dns repo
     members:
+    - hjacobs
     - linki
+    - njuettner
+    - Raffo
     privacy: closed
   maintainers-external-dns:
     description: Write access to the external-dns repo
     members:
+    - hjacobs
     - linki
+    - njuettner
+    - Raffo
     privacy: closed
   admins-ingress-controller-conformance:
     description: Admin access to the ingress-controller-conformance repo


### PR DESCRIPTION
After joining the kubernetes-sigs I'd request admin access for the other owners:

- @Raffo
- @hjacobs
- @njuettner

/cc @nikhita 
/cc @mrbobbytables 

Signed-off-by: njuettner <nick@zalando.de>