### PR TITLE
Add service-apis teams

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -35,3 +35,15 @@ teams:
     - bowei
     - thockin
     privacy: closed
+  service-apis-admins:
+    description: Admin access to the service-apis repo
+    members:
+    - bowei
+    - thockin
+    privacy: closed
+  service-apis-amintainers:
+    description: Write access to the service-apis repo
+    members:
+    - bowei
+    - thockin
+    privacy: closed


### PR DESCRIPTION
ref: #1292 

Adds teams for [kubernetes-sigs/service-apis](https://github.com/kubernetes-sigs/service-apis) repo.

/assign @nikhita 