### PR TITLE
Remove vaikas-google from kubernetes orgs

### DIFF
--- a/config/kubernetes-incubator/org.yaml
+++ b/config/kubernetes-incubator/org.yaml
@@ -163,7 +163,6 @@ members:
 - thockin
 - timothysc
 - tsmetana
-- vaikas-google
 - vishh
 - warmchang
 - wongma7

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -959,7 +959,6 @@ members:
 - ttousai
 - unguiculus
 - vagababov
-- vaikas-google
 - varshavaradarajan
 - vefimova
 - venezia


### PR DESCRIPTION
https://github.com/vaikas-google doesn't exist anymore, peribolos is broken right now: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-org-peribolos/1191287543132327936

/assign @mrbobbytables 