### PR TITLE
sig-release: Update Release Managers teams

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -170,7 +170,7 @@ teams:
     - aleksandra-malinowska # subproject owner / Build Admin / Patch Release Team
     - alexeldeib # Release Manager Associate
     - bubblemelon # Branch Manager
-    - calebamiles # subproject owner / Build Admin
+    - calebamiles # subproject owner
     - cpanato # Branch Manager
     - dougm # Patch Release Team
     - feiskyer # Patch Release Team
@@ -179,13 +179,20 @@ teams:
     - idealhack # Patch Release Team
     - imkin # Release Manager Associate
     - javier-b-perez # Release Manager Associate
+    - jimangel # Release Manager Associate
     - justaugustus # subproject owner / Branch Manager / Build Admin
+    - kacole2 # Release Manager Associate
     - listx # Build Admin
+    - onlydole # Release Manager Associate
+    - paulbouwer # Release Manager Associate
     - ps882 # Build Admin
     - pswica # Release Manager Associate
+    - saschagrunert # Release Manager Associate
+    - sethmccombs # Release Manager Associate
     - slicknik # Release Manager Associate
     - sumitranr # Build Admin
     - tpepper # subproject owner / Build Admin / Patch Release Team
+    - xmudrii # Release Manager Associate
     privacy: closed
   release-managers:
     description: People actively pushing k8s releases. Gives admin access to

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -202,6 +202,9 @@ teams:
     - idealhack # Patch Release Team
     - justaugustus # Branch Manager
     - k8s-release-robot
+    # TODO(justaugustus): Temporary assignment to shadow Branch Managers
+    #                     Remove after 11/5/19.
+    - saschagrunert # Release Manager Associate
     - tpepper # Patch Release Team
     privacy: closed
     previously:


### PR DESCRIPTION
- Temporarily grant Sascha access to `release-managers` team
  Sascha will be cutting the `1.17.0-beta.1` release, so we're granting him
  temporary write access to `kubernetes/kubernetes`.

- Add new Release Manager Associates to `release-engineering`
  - Kendrick Coleman - @kacole2 
  - Sascha Grunert - @saschagrunert 
  - Seth McCombs - @sethmccombs 
  - Marko Mudrinić - @xmudrii 
  - Taylor Dolezal - @onlydole 
  - Paul Bouwer - @paulbouwer 
  - Jim Angel - @jimangel 