### PR TITLE
Add metrics server members and teams to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -279,6 +279,7 @@ members:
 - runcom
 - runyontr
 - s-ito-ts
+- s-urbaniak
 - saad-ali
 - sallyom
 - SandeepPissay

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -531,22 +531,6 @@ teams:
     - riverzhang
     - woopstar
     privacy: closed
-  mutating-trace-admission-controller:
-    description: Parent team for mutating-trace-admission-controller repo (maintainers, admins)
-    members:
-    - calebamiles
-    privacy: closed
-    teams:
-      mutating-trace-admission-controller-admins:
-        description: Admin access to the mutating-trace-admission-controller repo
-        members:
-        - calebamiles
-        privacy: closed
-      mutating-trace-admission-controller-maintainers:
-        description: Write access to the mutating-trace-admission-controller repo
-        members:
-        - calebamiles
-        privacy: closed
   node-feature-discovery-admins:
     description: Admin access to the node-feature-discovery repo
     members:

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -178,6 +178,7 @@ members:
 - k82cn
 - kad
 - Katharine
+- kawych
 - kbarnard10
 - kbhawkey
 - kendallnelson

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -289,6 +289,7 @@ members:
 - sbueringer
 - screeley44
 - seans3
+- serathius
 - serbrech
 - sethp-nr
 - sethpollack

--- a/config/kubernetes-sigs/sig-instrumentation/OWNERS
+++ b/config/kubernetes-sigs/sig-instrumentation/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-instrumentation-leads
+approvers:
+  - sig-instrumentation-leads
+labels:
+  - sig/instrumentation

--- a/config/kubernetes-sigs/sig-instrumentation/teams.yaml
+++ b/config/kubernetes-sigs/sig-instrumentation/teams.yaml
@@ -1,0 +1,17 @@
+teams:
+  mutating-trace-admission-controller:
+    description: Parent team for mutating-trace-admission-controller repo (maintainers, admins)
+    members:
+    - calebamiles
+    privacy: closed
+    teams:
+      mutating-trace-admission-controller-admins:
+        description: Admin access to the mutating-trace-admission-controller repo
+        members:
+        - calebamiles
+        privacy: closed
+      mutating-trace-admission-controller-maintainers:
+        description: Write access to the mutating-trace-admission-controller repo
+        members:
+        - calebamiles
+        privacy: closed

--- a/config/kubernetes-sigs/sig-instrumentation/teams.yaml
+++ b/config/kubernetes-sigs/sig-instrumentation/teams.yaml
@@ -1,4 +1,16 @@
 teams:
+  metrics-server-admins:
+    description: Admin access to the metrics-server repo
+    members:
+    - brancz
+    - piosz
+    privacy: closed
+  metrics-server-maintainers:
+    description: Write access to the metrics-server repo
+    members:
+    - s-urbaniak
+    - serathius
+    privacy: closed
   mutating-trace-admission-controller:
     description: Parent team for mutating-trace-admission-controller repo (maintainers, admins)
     members:


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/1382

Adds members and teams for metrics-server migration to kubernetes-sigs.

@s-urbaniak, @serathius, and @kawych are all members of the kubernetes org and implicitly permitted to join other orgs.

@kawych is not a part of the teams, but is being added as the [primary approver for the repo](https://github.com/kubernetes/org/issues/1382).

/area github-membership
/area github-repo