### PR TITLE
releng: Revoke Sascha's temporary access to release-managers team

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -209,9 +209,6 @@ teams:
     - idealhack # Patch Release Team
     - justaugustus # Branch Manager
     - k8s-release-robot
-    # TODO(justaugustus): Temporary assignment to shadow Branch Managers
-    #                     Remove after 11/5/19.
-    - saschagrunert # Release Manager Associate
     - tpepper # Patch Release Team
     privacy: closed
     previously:


### PR DESCRIPTION
We granted Sascha temporary access to cut the 1.17.0-beta.1 release.
Revoking it here.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

For the record, @idealhack was right [here](https://github.com/kubernetes/org/pull/1383#discussion_r342386023):
> correct me if I'm wrong: it seems this is only needed for branch fast-forwarding?

We didn't need to actually grant this, so oversight on my part.

/assign @tpepper @calebamiles @saschagrunert
cc: @kubernetes/release-engineering