### PR TITLE
Add RainbowMango as a milestone maintainer for sig instrumentation

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -119,6 +119,7 @@ teams:
     - prydonius # Apps
     - pwittrock # CLI
     - quinton-hoole # Multicluster
+    - RainbowMango # Instrumentation
     - rajakavitha1 # Usability
     - saad-ali # Storage
     - seans3 # CLI


### PR DESCRIPTION
Request to be added as a milestone maintainer for sig instrumentation.

/cc @brancz 