### PR TITLE
Update admins and approvers for -sigs/krew repos

### DIFF
--- a/config/kubernetes-sigs/sig-cli/teams.yaml
+++ b/config/kubernetes-sigs/sig-cli/teams.yaml
@@ -33,21 +33,16 @@ teams:
     description: admin access to krew
     members:
     - ahmetb
-    - juanvallejo
+    - corneliusweig
+    - pwittrock
     - seans3
     - soltysh
     privacy: closed
   krew-maintainers:
     description: write access to krew
     members:
-    - adohe
     - ahmetb
     - corneliusweig
-    - fabianofranz
-    - janetkuo
-    - liggitt
-    - mengqiy
-    - monopole
     - pwittrock
     - seans3
     - soltysh
@@ -56,20 +51,16 @@ teams:
     description: admin access to krew-index
     members:
     - ahmetb
-    - juanvallejo
+    - corneliusweig
+    - pwittrock
     - seans3
     - soltysh
     privacy: closed
   krew-index-maintainers:
     description: write access to krew-index
     members:
-    - adohe
     - ahmetb
-    - fabianofranz
-    - janetkuo
-    - liggitt
-    - mengqiy
-    - monopole
+    - corneliusweig
     - pwittrock
     - seans3
     - soltysh


### PR DESCRIPTION
It appears like during 732ea009 we have added a set of people do not
directly work on krew and krew-index as admins/maintainers. This fixes that.

Additionally, this moves juanvallejo out of admins/maintainers and promotes
corneliusweig as such, since Juan hasn't been active in this repo.

/assign @soltysh
/cc @corneliusweig