### PR TITLE
Add oxddr@ to milestone-maintainers

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -110,6 +110,7 @@ teams:
     - mszostok # Service Catalog
     - mwielgus # Autoscaling
     - neolit123 # Cluster Lifecycle
+    - oxddr # Scalability
     - palnabarun # 1.17 RT Enhancements shadow
     - parispittman # ContribEx
     - patricklang # Windows


### PR DESCRIPTION
@oxddr is SIG-Scalability member and part of our oncall. He should be in milestone-maintainers to flag potential release-blocking scalability regressions, e.g. see https://github.com/kubernetes/kubernetes/issues/84910#issuecomment-551021607