### PR TITLE
Adding sig-docs-vi members

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -172,6 +172,7 @@ teams:
     - girikuncoro # Indonesian
     - gochist # Korean
     - hanjiayao # Chinese
+    - huynguyennovem # Vietnamese
     - ianychoi # Korean
     - inductor # Japanese
     - irvifa # Indonesian
@@ -278,6 +279,7 @@ teams:
     - girikuncoro
     - gochist
     - hanjiayao
+    - huynguyennovem
     - inductor
     - irvifa
     - jaredbhatti
@@ -321,10 +323,12 @@ teams:
     members:
     - ngtuna
     - truongnh1992
+    - huynguyennovem
     privacy: closed
   sig-docs-vi-reviews:
     description: PR reviews for Vietnamese content
     members:
     - ngtuna
     - truongnh1992
+    - huynguyennovem
     privacy: closed


### PR DESCRIPTION
Add new owner and reviewer for the Vietnamese translation team

Signed-off-by: Nguyen Quang Huy <huynguyennovem@gmail.com>
