### PR TITLE
releng: Update Release Managers

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -160,6 +160,7 @@ teams:
     - feiskyer
     - hoegaarden
     - idealhack
+    - justaugustus
     - tpepper
     privacy: closed
   publishing-bot-reviewers:
@@ -185,7 +186,7 @@ teams:
     - hoegaarden # subproject owner / Patch Release Team
     - idealhack # Patch Release Team
     - jimangel # Release Manager Associate
-    - justaugustus # subproject owner / Branch Manager / Build Admin
+    - justaugustus # subproject owner / Build Admin / Patch Release Team
     - kacole2 # Release Manager Associate
     - listx # Build Admin
     - onlydole # Release Manager Associate

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -53,7 +53,6 @@ teams:
     - bgrant0607 # Architecture
     - bradamant3 # Docs
     - brancz # Instrumentation
-    - bubblemelon # Branch Manager
     - calebamiles # Release / PM
     - cantbewong # VMware
     - caseydavenport # Network
@@ -181,7 +180,6 @@ teams:
     members:
     - aleksandra-malinowska # subproject owner / Build Admin / Patch Release Team
     - alexeldeib # Release Manager Associate
-    - bubblemelon # Branch Manager
     - calebamiles # subproject owner
     - cpanato # Branch Manager
     - dougm # Patch Release Team
@@ -213,7 +211,6 @@ teams:
       this job.
     members:
     - aleksandra-malinowska # Patch Release Team
-    - bubblemelon # Branch Manager
     - cpanato # Branch Manager
     - dougm # Patch Release Team
     - feiskyer # Patch Release Team
@@ -235,7 +232,7 @@ teams:
     - aishsundar # subproject owner
     - alejandrox1 # 1.17 RT Lead Shadow
     - alenkacz # 1.17 CI Signal Lead
-    - bubblemelon # Branch Manager
+    - bubblemelon # Emeritus Branch Manager
     - cartyc # 1.17 Release Notes Lead
     - claurence # subproject owner
     - cpanato # Branch Manager

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -132,6 +132,7 @@ teams:
     - RainbowMango # Instrumentation
     - rajakavitha1 # Usability
     - saad-ali # Storage
+    - saschagrunert # Branch Manager
     - seans3 # CLI
     - shyamjvs # Scalability
     - smourapina # 1.17 Bug Triage shadow
@@ -198,7 +199,7 @@ teams:
     - paulbouwer # Release Manager Associate
     - ps882 # Build Admin
     - pswica # Release Manager Associate
-    - saschagrunert # Release Manager Associate
+    - saschagrunert # Branch Manager
     - sethmccombs # Release Manager Associate
     - slicknik # Release Manager Associate
     - sumitranr # Build Admin
@@ -220,6 +221,7 @@ teams:
     - idealhack # Patch Release Team
     - justaugustus # Branch Manager
     - k8s-release-robot
+    - saschagrunert # Branch Manager
     - tpepper # Patch Release Team
     privacy: closed
     previously:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -175,8 +175,6 @@ teams:
   release-engineering:
     description: Members of the Release Engineering subproject, including Build Admins,
       Patch Release Team, Branch Managers, and Release Manager Associates.
-    maintainers:
-    - nikhita # Release Manager Associate
     members:
     - aleksandra-malinowska # subproject owner / Build Admin / Patch Release Team
     - alexeldeib # Release Manager Associate
@@ -184,11 +182,8 @@ teams:
     - cpanato # Branch Manager
     - dougm # Patch Release Team
     - feiskyer # Patch Release Team
-    - girikuncoro # Release Manager Associate
     - hoegaarden # subproject owner / Patch Release Team
     - idealhack # Patch Release Team
-    - imkin # Release Manager Associate
-    - javier-b-perez # Release Manager Associate
     - jimangel # Release Manager Associate
     - justaugustus # subproject owner / Branch Manager / Build Admin
     - kacole2 # Release Manager Associate
@@ -196,10 +191,8 @@ teams:
     - onlydole # Release Manager Associate
     - paulbouwer # Release Manager Associate
     - ps882 # Build Admin
-    - pswica # Release Manager Associate
     - saschagrunert # Branch Manager
     - sethmccombs # Release Manager Associate
-    - slicknik # Release Manager Associate
     - sumitranr # Build Admin
     - tpepper # subproject owner / Build Admin / Patch Release Team
     - xmudrii # Release Manager Associate


### PR DESCRIPTION
Accompanying GitHub team membership changes to https://github.com/kubernetes/sig-release/pull/868.

### Patch Release Team
- Add Stephen Augustus

### Branch Managers
- Promote Sascha Grunert (@saschagrunert)
- Remove Cheryl Fong (@Bubblemelon)

### Release Manager Associates

Remove inactive associates:
- Nikhil Manchanda (@SlickNik)
- Dhawal Yogesh Bhanushali (@imkin)
- Nikhita Raghunath (@nikhita)
- Javier B Perez (@javier-b-perez)
- Giri Kuncoro (@girikuncoro)
- Peter Swica (@pswica)

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**On hold until https://github.com/kubernetes/sig-release/pull/868 merges**
/hold

/assign @tpepper @calebamiles 
@kubernetes/sig-release-admins @kubernetes/release-engineering @kubernetes/release-managers 
/milestone v1.18
/priority important-longterm
/kind feature cleanup