### PR TITLE
Update kustomize teams.

### DIFF
--- a/config/kubernetes-sigs/sig-cli/teams.yaml
+++ b/config/kubernetes-sigs/sig-cli/teams.yaml
@@ -69,16 +69,13 @@ teams:
     description: ""
     members:
     - droot
+    - Liujingfang1
     - monopole
-    - pwittrock
-    privacy: closed
-  kustomize-contributors:
-    description: ""
-    members:
     - pwittrock
     privacy: closed
   kustomize-maintainers:
     description: ""
     members:
+    - haiyanmeng
     - pwittrock
     privacy: closed


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/kustomize/issues/1708
Removes the `kustomize-contributors` team (no longer used)
Updates `kustomize-admins` and `kustomize-maintainers` teams with the current individually granted rights -- should be a noop permissions wise.

/assign @pwittrock 