### PR TITLE
Prune outdated SIG Docs permissions

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -119,7 +119,6 @@ teams:
     description: Approvers for Italian content
     members:
     - mattiaperi
-    - micheleberardi
     - rlenferink
   sig-docs-it-reviews:
     description: PR reviews for Italian content
@@ -288,7 +287,6 @@ teams:
     - irvifa # L10n: Indonesian
     - jcjesus # L10n: Portuguese
     - jimangel # L10n: English
-    - micheleberardi # L10n: Italian
     - mittalyashu # L10n: Hindi
     - msheldyakov # L10n: Russian
     - nasa9084 # L10n: Japanese
@@ -313,9 +311,7 @@ teams:
     - bene2k1
     - bradamant3
     - bradtopol
-    - chenopis
     - claudiajkang
-    - cody-clark
     - cstoku
     - daminisatya
     - dianaabv
@@ -334,8 +330,6 @@ teams:
     - kbarnard10
     - lledru
     - MAKOSCAFEE
-    - micheleberardi
-    - mistyhacks
     - msheldyakov
     - nasa9084
     - ngtuna


### PR DESCRIPTION
This PR removes permissions from approvers/reviewers who are no longer active in SIG Docs.

/assign @jimangel @Bradamant3 

/cc @kbarnard10 @bradtopol 