### PR TITLE
Update kubernetes-sigs scheduling teams.

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -92,6 +92,7 @@ members:
 - davidz627
 - ddebroy
 - deads2k
+- deepak-vij
 - denkensk
 - derekwaynecarr
 - detiber

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -19,6 +19,7 @@ members:
 - adelina-t
 - adohe
 - adrianludwin
+- ahg-g
 - ahmetb
 - ainmosni
 - akutz

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -441,22 +441,6 @@ teams:
     - jeefy
     - maciaszczykm
     privacy: closed
-  descheduler-admins:
-    description: Admin access to the descheduler repo
-    members:
-    - aveshagarwal
-    - k82cn
-    - ravisantoshgudimetla
-    privacy: closed
-  descheduler-maintainers:
-    description: Write access to the descheduler repo
-    members:
-    - aveshagarwal
-    - k82cn
-    - ravisantoshgudimetla
-    privacy: closed
-    previously:
-    - descehduler-maintainers
   etcdadm-admins:
     description: Admin access to the etcdadm repo
     members:
@@ -492,24 +476,6 @@ teams:
     members:
     - BenTheElder
     - munnerz
-    privacy: closed
-  kube-batch-admins:
-    description: Admin access to the kube-batch repo
-    maintainers:
-    - spiffxp
-    members:
-    - calebamiles
-    - k82cn
-    - timothysc
-    privacy: closed
-  kube-batch-maintainers:
-    description: Write access to the kube-batch repo
-    maintainers:
-    - spiffxp
-    members:
-    - calebamiles
-    - k82cn
-    - timothysc
     privacy: closed
   kubernetes/sig-apps:
     description: Parent team for all SIG Apps subteams (approvers, reviewers, admins)

--- a/config/kubernetes-sigs/sig-scheduling/OWNERS
+++ b/config/kubernetes-sigs/sig-scheduling/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-scheduling-leads
+approvers:
+  - sig-scheduling-leads
+labels:
+  - sig/scheduling

--- a/config/kubernetes-sigs/sig-scheduling/teams.yaml
+++ b/config/kubernetes-sigs/sig-scheduling/teams.yaml
@@ -19,11 +19,23 @@ teams:
     description: Admin access to the kube-batch repo
     members:
     - k82cn
-    - ahg-g
     privacy: closed
   kube-batch-maintainers:
     description: Write access to the kube-batch repo
     members:
     - k82cn
+    privacy: closed
+  poseidon-admins:
+    description: Admin access to the poseidon repo
+    members:
     - ahg-g
+    - deepak-vij
+    - k82cn
+    privacy: closed
+  poseidon-maintainers:
+    description: Write access to the poseidon repo
+    members:
+    - ahg-g
+    - deepak-vij
+    - k82cn
     privacy: closed

--- a/config/kubernetes-sigs/sig-scheduling/teams.yaml
+++ b/config/kubernetes-sigs/sig-scheduling/teams.yaml
@@ -1,0 +1,29 @@
+teams:
+  descheduler-admins:
+    description: Admin access to the descheduler repo
+    members:
+    - aveshagarwal
+    - k82cn
+    - ravisantoshgudimetla
+    privacy: closed
+  descheduler-maintainers:
+    description: Write access to the descheduler repo
+    members:
+    - aveshagarwal
+    - k82cn
+    - ravisantoshgudimetla
+    privacy: closed
+    previously:
+    - descehduler-maintainers
+  kube-batch-admins:
+    description: Admin access to the kube-batch repo
+    members:
+    - k82cn
+    - ahg-g
+    privacy: closed
+  kube-batch-maintainers:
+    description: Write access to the kube-batch repo
+    members:
+    - k82cn
+    - ahg-g
+    privacy: closed


### PR DESCRIPTION
- Adds @ahg-g and @deepak-vij to kubernetes-sigs org (both are members of kubernetes)
- Breaks out sig-scheduling teams into their own directory and updates current teams.
- Adds teams for the poseidon repo.

ref: https://github.com/kubernetes-sigs/poseidon/issues/178
/assign @ahg-g @k82cn 
/cc @deepak-vij 
/hold