### PR TITLE
Remove SIG Docs approver permissions

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -32,7 +32,6 @@ teams:
     - simplytunde
     - steveperry-53
     - stewart-yu
-    - tengqm
     - tfogo
     - xiangpengzhao
     - zacharysarah
@@ -184,7 +183,6 @@ teams:
     - kbarnard10
     - pwittrock
     - steveperry-53
-    - tengqm
     - zacharysarah
     - zparnold
     privacy: closed
@@ -228,7 +226,6 @@ teams:
     members:
     - hanjiayao
     - SataQiu
-    - tengqm
     - xiangpengzhao
     - xichengliudui
     - zhangxiaoyu-zidif
@@ -350,7 +347,6 @@ teams:
     - smana
     - steveperry-53
     - stewart-yu
-    - tengqm
     - tfogo
     - truongnh1992
     - xiangpengzhao


### PR DESCRIPTION
This PR removes approval/write access for @tengqm pending review of recent actions:

- https://github.com/kubernetes/website/pull/16135#issuecomment-562714349
- https://github.com/kubernetes/website/pull/17888#issuecomment-562071814
- https://github.com/kubernetes/website/pull/17894#issuecomment-562713120

/sig docs
/assign @mrbobbytables 