### PR TITLE
Prune sig-docs-maintainers

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -175,17 +175,6 @@ teams:
     - msheldyakov
     - potapy4
     privacy: closed
-  sig-docs-maintainers:
-    description: Website maintainers
-    members:
-    - bradamant3
-    - jimangel
-    - kbarnard10
-    - pwittrock
-    - steveperry-53
-    - zacharysarah
-    - zparnold
-    privacy: closed
   sig-docs-pr-reviews:
     description: PR reviews for docs-related issues
     members:


### PR DESCRIPTION
Per https://github.com/kubernetes/org/issues/1436#issuecomment-563327863, this PR removes the `sig-docs-maintainers` team because it's no longer required.

/assign @jimangel @nikhita 
/sig docs