### PR TITLE
Add xing-yang as external-snapshotter admin

### DIFF
--- a/config/kubernetes-csi/org.yaml
+++ b/config/kubernetes-csi/org.yaml
@@ -334,6 +334,7 @@ teams:
     - childsb
     - lpabon
     - saad-ali
+    - xing-yang
     privacy: closed
   external-snapshotter-maintainers:
     description: Write access to external-snapshotter repo


### PR DESCRIPTION
I've been managing and doing releases of the external-snapshotter repo.