### PR TITLE
Add pjh to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -277,6 +277,7 @@ members:
 - phyber
 - piosz
 - piotrmiskiewicz
+- pjh
 - pmorie
 - prankul88
 - prydonius


### PR DESCRIPTION
I am already a member of the kubernetes org, I'd like to join kubernetes-sigs as well.

Some context: https://github.com/kubernetes-sigs/windows-testing/pull/120, https://github.com/kubernetes/org/issues/1489.