### PR TITLE
Add sftim as SIG Docs en approver

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -29,6 +29,7 @@ teams:
     - mistyhacks
     - Rajakavitha1
     - ryanmcginnis
+    - sftim
     - simplytunde
     - steveperry-53
     - stewart-yu


### PR DESCRIPTION
I was added as an en-localization owner for [k/website](https://github.com/kubernetes/website) in PR  https://github.com/kubernetes/website/pull/18398

This PR brings k/org up to parity

/sig docs