### PR TITLE
Remove teams for testing_frameworks

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -598,18 +598,6 @@ teams:
     - msau42
     - saad-ali
     privacy: closed
-  testing_frameworks-admins:
-    description: Admin access to the testing_frameworks repo
-    members:
-    - hoegaarden
-    - totherme
-    privacy: closed
-  testing_frameworks-maintainers:
-    description: Write access to the testing_frameworks repo
-    members:
-    - liztio
-    - marun
-    privacy: closed
   windows-testing-admins:
     description: Admin access to the windows-testing repo
     members:


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1519

/assign @spiffxp @mrbobbytables 