### PR TITLE
Add Sh4d1 to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -330,6 +330,7 @@ members:
 - sethpollack
 - sflxn
 - sfzylad
+- Sh4d1
 - shashidharatd
 - shawn-hurley
 - shivi28


### PR DESCRIPTION
Add Sh4d1 to the kubernetes-sigs org so that I can work on https://github.com/kubernetes-sigs/apiserver-network-proxy