### PR TITLE
Reconcile capz GitHub team membership w/ repo OWNERS

### DIFF
--- a/config/kubernetes-sigs/provider-azure/teams.yaml
+++ b/config/kubernetes-sigs/provider-azure/teams.yaml
@@ -13,19 +13,6 @@ teams:
     - justaugustus
     - ritazh
     privacy: closed
-  cluster-api-provider-azure-admins:
-    description: ""
-    members:
-    - CecileRobertMichon
-    - justaugustus
-    privacy: closed
-  cluster-api-provider-azure-maintainers:
-    description: ""
-    members:
-    - CecileRobertMichon
-    - justaugustus
-    - soggiest
-    privacy: closed
   azuredisk-csi-driver-admins:
     description: ""
     members:

--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -88,12 +88,15 @@ teams:
   cluster-api-provider-azure-admins:
     description: ""
     members:
+    - awesomenix
     - CecileRobertMichon
     - justaugustus
+    - soggiest
     privacy: closed
   cluster-api-provider-azure-maintainers:
     description: ""
     members:
+    - awesomenix
     - CecileRobertMichon
     - justaugustus
     - soggiest

--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -85,6 +85,19 @@ teams:
     - timothysc
     - vincepri
     privacy: closed
+  cluster-api-provider-azure-admins:
+    description: ""
+    members:
+    - CecileRobertMichon
+    - justaugustus
+    privacy: closed
+  cluster-api-provider-azure-maintainers:
+    description: ""
+    members:
+    - CecileRobertMichon
+    - justaugustus
+    - soggiest
+    privacy: closed
   cluster-api-provider-digitalocean-admins:
     description: ""
     members:


### PR DESCRIPTION
(Also, moves capz teams under SIG Cluster Lifecycle approval.)

/assign @neolit123 @timothysc @fabriziopandini @justinsb 
cc: @CecileRobertMichon @soggiest @awesomenix 