### PR TITLE
disable simplytunde as an approver due to inactivity.

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -27,7 +27,6 @@ teams:
     - makoscafee
     - Rajakavitha1
     - sftim
-    - simplytunde
     - steveperry-53
     - stewart-yu
     - tengqm
@@ -50,7 +49,6 @@ teams:
     - Rajakavitha1
     - ryanmcginnis
     - sftim
-    - simplytunde
     - steveperry-53
     - stewart-yu
     - tengqm
@@ -218,7 +216,6 @@ teams:
     - mistyhacks
     - Rajakavitha1
     - ryanmcginnis
-    - simplytunde
     - steveperry-53
     - stewart-yu
     - tengqm
@@ -367,7 +364,6 @@ teams:
     - rlenferink
     - ryanmcginnis
     - SataQiu
-    - simplytunde
     - smana
     - steveperry-53
     - stewart-yu


### PR DESCRIPTION
disabling simplytunde as an approver due to inactivity
Always welcome to come back if able to become
active again

Signed-off-by: Brad Topol <btopol@us.ibm.com>