### PR TITLE
Promote hasheddan to Release Manager Associate + temp Branch Manager access

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -186,6 +186,7 @@ teams:
     - cpanato # Branch Manager
     - dougm # Patch Release Team
     - feiskyer # Patch Release Team
+    - hasheddan # Release Manager Associate
     - hoegaarden # subproject owner / Patch Release Team
     - idealhack # Patch Release Team
     - jimangel # Release Manager Associate
@@ -306,6 +307,7 @@ teams:
     - foxish
     - girikuncoro
     - guineveresaenger
+    - hasheddan
     - hoegaarden
     - idealhack
     - imkin

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -212,6 +212,7 @@ teams:
     - cpanato # Branch Manager
     - dougm # Patch Release Team
     - feiskyer # Patch Release Team
+    - hasheddan # Release Manager Associate (temporary grant)
     - hoegaarden # Patch Release Team
     - idealhack # Patch Release Team
     - justaugustus # Branch Manager


### PR DESCRIPTION
Processing k/org updates for https://github.com/kubernetes/sig-release/issues/978.

- Add hasheddan as a Release Manager Associate
- Temporarily grant @hasheddan release-managers access to cut release `v1.18.0-alpha.4`

I'll send an accompanying PR to process the removal of `release-managers` access (to be held until after the `v1.18.0-alpha.4` release) shortly.

/assign @tpepper @calebamiles 
/cc @hoegaarden @saschagrunert @cpanato 