### PR TITLE
releng: Remove hasheddan's temporary Branch Manager access

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -212,7 +212,6 @@ teams:
     - cpanato # Branch Manager
     - dougm # Patch Release Team
     - feiskyer # Patch Release Team
-    - hasheddan # Release Manager Associate (temporary grant)
     - hoegaarden # Patch Release Team
     - idealhack # Patch Release Team
     - justaugustus # Branch Manager


### PR DESCRIPTION
Reverts the temporary Branch Manager access granted to @hasheddan in https://github.com/kubernetes/org/pull/1620.

/hold until https://github.com/kubernetes/org/pull/1620 merges AND `v.1.18.0-alpha.4` has been released

/assign @tpepper @calebamiles 
/cc @hoegaarden @saschagrunert @cpanato 