### PR TITLE
cluster-lifecycle: Update capz GitHub teams

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -105,6 +105,14 @@ teams:
     - justaugustus
     - soggiest
     privacy: closed
+  cluster-api-provider-azure-pms:
+    description: ""
+    members:
+    - awesomenix
+    - CecileRobertMichon
+    - justaugustus
+    - rbitia
+    privacy: closed
   cluster-api-provider-digitalocean-admins:
     description: ""
     members:

--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -95,7 +95,6 @@ teams:
     - awesomenix
     - CecileRobertMichon
     - justaugustus
-    - soggiest
     privacy: closed
   cluster-api-provider-azure-maintainers:
     description: ""
@@ -103,7 +102,6 @@ teams:
     - awesomenix
     - CecileRobertMichon
     - justaugustus
-    - soggiest
     privacy: closed
   cluster-api-provider-azure-pms:
     description: ""


### PR DESCRIPTION
- Add cluster-api-provider-azure-pms team to manage capz boards
- Remove @soggiest from maintainers (ref: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/387)

/assign @neolit123 @timothysc