### PR TITLE
Added bartsmykla to k-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -52,6 +52,7 @@ members:
 - balajismaniam
 - BaluDontu
 - barney-s
+- bartsmykla
 - benmoss
 - BenTheElder
 - bertinatto


### PR DESCRIPTION
Closes https://github.com/kubernetes/org/issues/1645

I’m a k org member but need to also be a k-sigs member for https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/174 which adds me to the OWNERS file for the image promotor tool.

Signed-off-by: Bart Smykla <bartek@smykla.com>