### PR TITLE
sig-instrumentation: Re-add loburm, remove mxinden

### DIFF
--- a/config/kubernetes/sig-instrumentation/teams.yaml
+++ b/config/kubernetes/sig-instrumentation/teams.yaml
@@ -10,8 +10,8 @@ teams:
     - ehashman
     - kawych
     - lilic
+    - loburm
     - logicalhan
-    - mxinden
     - piosz
     - RainbowMango
     - s-urbaniak
@@ -31,8 +31,8 @@ teams:
     - ehashman
     - kawych
     - lilic
+    - loburm
     - logicalhan
-    - mxinden
     - piosz
     - RainbowMango
     - s-urbaniak
@@ -52,8 +52,8 @@ teams:
     - ehashman
     - kawych
     - lilic
+    - loburm
     - logicalhan
-    - mxinden
     - piosz
     - RainbowMango
     - s-urbaniak
@@ -72,8 +72,8 @@ teams:
     - ehashman
     - kawych
     - lilic
+    - loburm
     - logicalhan
-    - mxinden
     - piosz
     - RainbowMango
     - s-urbaniak
@@ -92,8 +92,8 @@ teams:
     - ehashman
     - kawych
     - lilic
+    - loburm
     - logicalhan
-    - mxinden
     - piosz
     - RainbowMango
     - s-urbaniak
@@ -113,8 +113,8 @@ teams:
     - ehashman
     - kawych
     - lilic
+    - loburm
     - logicalhan
-    - mxinden
     - piosz
     - RainbowMango
     - s-urbaniak
@@ -133,8 +133,8 @@ teams:
     - ehashman
     - kawych
     - lilic
+    - loburm
     - logicalhan
-    - mxinden
     - piosz
     - RainbowMango
     - s-urbaniak


### PR DESCRIPTION
I wasn't aware loburm was on parental leave for 10w within the last half a year, so adding him back and we'll reassess in some time. Sorry!

Removing mxinden due to inactivity. Thanks Max for everything you've done and contributed!