### PR TITLE
Remote stale invites for kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -143,7 +143,6 @@ members:
 - gerred
 - girikuncoro
 - giuseppe
-- grayluck
 - grodrigues3
 - guineveresaenger
 - gyliu513

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -120,7 +120,6 @@ members:
 - draveness
 - droot
 - dstrebel
-- dtoledo67
 - dvonthenen
 - easeway
 - entro-pi

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -64,7 +64,6 @@ members:
 - Bradamant3
 - bradtopol
 - brancz
-- brendandburns
 - bzub
 - caesarxuchao
 - calebamiles

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -65,7 +65,6 @@ members:
 - bradtopol
 - brancz
 - brendandburns
-- bryk
 - bzub
 - caesarxuchao
 - calebamiles
@@ -453,7 +452,6 @@ teams:
   dashboard-metrics-scraper-admins:
     description: Admin access to the dashboard-metrics-scraper repo
     members:
-    - bryk
     - floreks
     - jeefy
     - maciaszczykm
@@ -461,7 +459,6 @@ teams:
   dashboard-metrics-scraper-maintainers:
     description: Write access to the dashboard-metrics-scraper
     members:
-    - bryk
     - floreks
     - jeefy
     - maciaszczykm

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -286,7 +286,6 @@ members:
 - odinuge
 - onyiny-ang
 - oomichi
-- openstacker
 - parispittman
 - PatrickLang
 - pbnj

--- a/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
+++ b/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
@@ -49,7 +49,6 @@ teams:
    description: Admin access to the blobfuse-csi-driver repo
    members:
    - andyzhangx
-   - brendandburns
    - feiskyer
    - justaugustus
    - khenidak
@@ -59,7 +58,6 @@ teams:
    description: Write access to the blobfuse-csi-driver repo
    members:
    - andyzhangx
-   - brendandburns
    - feiskyer
    - justaugustus
    - khenidak


### PR DESCRIPTION
Remove stale invites for kubernetes-sigs org.

 2019-01-22 19:18:14 -0800  68) - bryk
 2019-10-15 22:46:33 +0100 146) - grayluck
2019-10-30 21:13:57 -0400 123) - dtoledo67
2019-12-06 12:16:09 +0530  67) - brendandburns
 2019-07-16 16:18:43 -0400 289) - openstacker

