### PR TITLE
Add craiglpeters to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -88,6 +88,7 @@ members:
 - codenrhoden
 - cofyc
 - corneliusweig
+- craiglpeters
 - d-nishi
 - DahuK
 - damemi


### PR DESCRIPTION
I'm a member of the kubernetes org, but more of my projects are moving to kubernetes-sigs