### PR TITLE
Add cpanato to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -88,6 +88,7 @@ members:
 - codenrhoden
 - cofyc
 - corneliusweig
+- cpanato
 - craiglpeters
 - d-nishi
 - DahuK


### PR DESCRIPTION
I'm already member of `kubernetes` org and this PR is to request access to `kubernetes-sig` I've been working in some `cluster-api` projects.

/cc @justaugustus @detiber 