### PR TITLE
Add GitHub teams for cloud-provider-huaweicloud

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -219,6 +219,7 @@ members:
 - kbhawkey
 - kendallnelson
 - kensipe
+- kevin-wangzefeng
 - kfox1111
 - khenidak
 - kkmsft

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -313,6 +313,7 @@ members:
 - qvicksilver
 - raelga
 - Raffo
+- RainbowMango
 - Rajakavitha1
 - rajansandeep
 - Random-Liu

--- a/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
+++ b/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
@@ -63,3 +63,15 @@ teams:
    - khenidak
    - lachie83
    privacy: closed
+  cloud-provider-huaweicloud-admins:
+   description: Admin access to the cloud-provider-huaweicloud repo
+   members:
+   - kevin-wangzefeng
+   - RainbowMango
+   privacy: closed
+  cloud-provider-huaweicloud-maintainers:
+   description: Write access to the cloud-provider-huaweicloud repo
+   members:
+   - kevin-wangzefeng
+   - RainbowMango
+   privacy: closed


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1691

Also adds @RainbowMango and @kevin-wangzefeng to the kubernetes-sigs org since they are already members of the @kubernetes org.

/assign @mrbobbytables 