### PR TITLE
Add benmoss to sig-windows-tools-admins

### DIFF
--- a/config/kubernetes-sigs/sig-windows/teams.yaml
+++ b/config/kubernetes-sigs/sig-windows/teams.yaml
@@ -16,6 +16,7 @@ teams:
   sig-windows-tools-admins:
     description: Admin access to sig-windows-tools repo
     members:
+    - benmoss
     - michmike
     - PatrickLang
     privacy: closed


### PR DESCRIPTION
So we are planning to use GitHub actions to maintain the [Windows kube-proxy image](https://hub.docker.com/repository/docker/sigwindowstools/kube-proxy), but doing so requires me to add a secret to the repo for the action to use to access Docker Hub. I could have someone else else do this but it'd be simpler if I can do it myself 😸 .

GitHub action PR is open [here](https://github.com/kubernetes-sigs/sig-windows-tools/pull/45) if you're curious.

@michmike @justaugustus 