### PR TITLE
Remove nicoaragon from kubernetes org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -770,7 +770,6 @@ members:
 - nickchase
 - NickrenREN
 - nicksardo
-- nicoaragon
 - nikhiljindal
 - nikopen
 - nilebox


### PR DESCRIPTION
Fixes peribolos failure - https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-org-peribolos/1239327869197357056

@nicoaragon is probably now @gnarled-cipher

@gnarled-cipher -- can you confirm that it is indeed you? Once confirmed, we can add you back with the new username. :)

/assign @mrbobbytables 