### PR TITLE
Remove write access to cluster-api-do repo for nikhita

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -112,7 +112,7 @@ teams:
     - rbitia
     privacy: closed
   cluster-api-provider-digitalocean-admins:
-    description: ""
+    description: Admin access to the cluster-api-provider-digitalocean repo
     members:
     - luxas
     - roberthbailey
@@ -120,9 +120,7 @@ teams:
     - xmudrii
     privacy: closed
   cluster-api-provider-digitalocean-maintainers:
-    description: ""
-    maintainers:
-    - nikhita
+    description: Write access to the cluster-api-provider-digitalocean repo
     members:
     - alvaroaleman
     - timothysc


### PR DESCRIPTION
Ref: https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/141, https://github.com/kubernetes/test-infra/pull/16815

I don't have the bandwidth for reviews, etc. for the repo right now.

/cc @xmudrii 