### PR TITLE
Add prksu to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -312,6 +312,7 @@ members:
 - pjh
 - pmorie
 - prankul88
+- prksu
 - prydonius
 - ps882
 - puja108


### PR DESCRIPTION
Fixes https://github.com/kubernetes/org/issues/1725

I'm already member of kubernetes org and this PR is to request access to kubernetes-sig I've been working in `cluster-api-provider-digitalocean` project.

/cc @xmudrii @cpanato 