### PR TITLE
Add GitHub teams for clientgofix

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -270,6 +270,7 @@ members:
 - michaelgugino
 - michelleN
 - michmike
+- mikedanese
 - miouge1
 - mirwan
 - misterikkit

--- a/config/kubernetes-sigs/sig-api-machinery/teams.yaml
+++ b/config/kubernetes-sigs/sig-api-machinery/teams.yaml
@@ -13,6 +13,18 @@ teams:
     - pwittrock
     - yue9944882
     privacy: closed
+  clientgofix-admins:
+    description: admin access to clientgofix
+    members:
+    - liggitt
+    - mikedanese
+    privacy: closed
+  clientgofix-maintainers:
+    description: write access to clientgofix
+    members:
+    - liggitt
+    - mikedanese
+    privacy: closed
   controller-runtime-admins:
     description: admin access to controller-runtime
     members:


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1731

Also adds @mikedanese to @kubernetes-sigs since he is already a member of @kubernetes. 

/assign @mrbobbytables 