### PR TITLE
Add MorrisLaw to kubernetes-sigs org.

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -235,6 +235,7 @@ members:
 - Monkeyanator
 - monopole
 - mook-as
+- MorrisLaw
 - mortent
 - morvencao
 - moshloop


### PR DESCRIPTION
Fixes #1734

I'm already a member of the kubernetes org and this PR is to request access to kubernetes-sig and I've starting working on the cluster-api-provider-digitalocean project.

/cc @xmudrii