### PR TITLE
Adding marosset to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -255,6 +255,7 @@ members:
 - maisem
 - mariantalla
 - markyjackson-taulia
+- marosset
 - marpaia
 - marquiz
 - mars1024


### PR DESCRIPTION
I'm a member of `kubernetes` org and am requesting access to `kubernetes-sigs`.
I'm maintaining configs for test passes which live in https://github.com/kubernetes-sigs/windows-testing

/cc @justaugustus 