### PR TITLE
Remove myself from teams I don't participate in

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -180,8 +180,6 @@ teams:
     privacy: closed
   cluster-api-provider-vsphere-admins:
     description: Admin access to the cluster-api-provider-vsphere repo
-    maintainers:
-    - spiffxp
     members:
     - akutz
     - andrewsykim
@@ -191,8 +189,6 @@ teams:
     privacy: closed
   cluster-api-provider-vsphere-maintainers:
     description: Write access to the cluster-api-provider-vsphere repo
-    maintainers:
-    - spiffxp
     members:
     - akutz
     - andrewsykim

--- a/config/kubernetes-sigs/sig-multicluster/teams.yaml
+++ b/config/kubernetes-sigs/sig-multicluster/teams.yaml
@@ -1,8 +1,6 @@
 teams:
   kubefed-admins:
     description: admin access for the kubefed repo
-    maintainers:
-    - spiffxp
     members:
     - font
     - irfanurrehman

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1869,8 +1869,6 @@ teams:
     privacy: closed
   minikube-maintainers:
     description: Write access to the minikube repo
-    maintainers:
-    - spiffxp
     members:
     - afbjorklund
     - balopat

--- a/config/kubernetes/sig-scalability/teams.yaml
+++ b/config/kubernetes/sig-scalability/teams.yaml
@@ -1,8 +1,6 @@
 teams:
   sig-scalability-api-reviews:
     description: ""
-    maintainers:
-    - spiffxp
     members:
     - countspongebob
     - jbeda
@@ -11,8 +9,6 @@ teams:
     privacy: closed
   sig-scalability-bugs:
     description: ""
-    maintainers:
-    - spiffxp
     members:
     - countspongebob
     - jbeda
@@ -22,8 +18,6 @@ teams:
     privacy: closed
   sig-scalability-feature-requests:
     description: ""
-    maintainers:
-    - spiffxp
     members:
     - countspongebob
     - jbeda
@@ -34,8 +28,6 @@ teams:
     privacy: closed
   sig-scalability-misc:
     description: ""
-    maintainers:
-    - spiffxp
     members:
     - countspongebob
     - feiskyer
@@ -48,8 +40,6 @@ teams:
     privacy: closed
   sig-scalability-pr-reviews:
     description: ""
-    maintainers:
-    - spiffxp
     members:
     - countspongebob
     - jbeda
@@ -58,8 +48,6 @@ teams:
     privacy: closed
   sig-scalability-proprosals:
     description: ""
-    maintainers:
-    - spiffxp
     members:
     - countspongebob
     - jbeda
@@ -69,8 +57,6 @@ teams:
     privacy: closed
   sig-scalability-test-failures:
     description: ""
-    maintainers:
-    - spiffxp
     members:
     - countspongebob
     - jbeda


### PR DESCRIPTION
Most of these are artifacts of having manually created the team
in the days before we managed them with peribolos

Also removed myself from sig-scalability teams as I haven't
participated there in a while