### PR TITLE
Add new cluster-api-provider-digitalocean maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -122,6 +122,9 @@ teams:
   cluster-api-provider-digitalocean-maintainers:
     description: Write access to the cluster-api-provider-digitalocean repo
     members:
+    - cpanato
+    - MorrisLaw
+    - prksu 
     - timothysc
     - xmudrii
     privacy: closed


### PR DESCRIPTION
This PR adds new `cluster-api-provider-digitalocean` maintainers to the CAPI-DO-maintainers GitHub team. The new maintainers are already added to the project [OWNERS file](https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/blob/master/OWNERS_ALIASES).

/hold
~until https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/146 is not merged~