### PR TITLE
Add GitHub teams for wg-policy-prototypes

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -135,6 +135,7 @@ members:
 - elmiko
 - entro-pi
 - enxebre
+- ericavonb
 - ericzhang08
 - estroz
 - Ethyling

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -161,6 +161,7 @@ members:
 - gyliu513
 - gyuho
 - haiyanmeng
+- hannibalhuang
 - hantaowang
 - haosdent
 - haoshuwei

--- a/config/kubernetes-sigs/wg-policy/OWNERS
+++ b/config/kubernetes-sigs/wg-policy/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - wg-policy-leads
+approvers:
+  - wg-policy-leads
+labels:
+  - wg/policy

--- a/config/kubernetes-sigs/wg-policy/teams.yaml
+++ b/config/kubernetes-sigs/wg-policy/teams.yaml
@@ -1,0 +1,12 @@
+teams:
+  wg-policy-prototypes-admins:
+    description: Admin access to wg-policy-prototypes
+    members:
+    - ericavonb
+    - hannibalhuang
+    privacy: closed
+  wg-policy-prototypes-maintainers:
+    description: Write access to wg-policy-prototypes
+    members:
+    - JimBugwadia
+    privacy: closed


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1669

Also adds @ericavonb and @hannibalhuang to k-sigs since they are already members of the @kubernetes org.

/assign @mrbobbytables 