### PR TITLE
Add @sftim as website maintainer

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -314,6 +314,7 @@ teams:
     - rlenferink # L10n: German
     - SataQiu # L10n: Chinese
     - seokho-son # L10n: Korean
+    - sftim # L10n: English
     - truongnh1992 # L10n: Vietnamese
     - vineethreddy02 # Docs 1.18 lead
     - xichengliudui # L10n: Chinese


### PR DESCRIPTION
Add @sftim (me) as a website maintainer.

I'm a technical lead for SIG Docs; see [`OWNERS_ALIASES@a4a1d2f`](https://github.com/kubernetes/community/blob/a4a1d2f561eac609403f0db7d31d764daaea3b00/OWNERS_ALIASES#L46) in [k/community](https://github.com/kubernetes/community).