### PR TITLE
sig-contribex: add castrojo to OWNERS_ALIASES and teams

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -34,7 +34,7 @@ aliases:
     - neolit123
     - timothysc
   sig-contributor-experience-leads:
-    - Phillels
+    - castrojo
     - cblecker
     - mrbobbytables
     - nikhita

--- a/config/kubernetes/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes/sig-contributor-experience/teams.yaml
@@ -4,6 +4,7 @@ teams:
     maintainers:
     - cblecker
     - idvoretskyi
+    - mrbobbytables
     - nikhita
     members:
     - calebamiles
@@ -16,10 +17,11 @@ teams:
     description: ""
     maintainers:
     - cblecker
+    - mrbobbytables
     - nikhita
     members:
+    - castrojo
     - parispittman
-    - Phillels
     privacy: closed
   community-milestone-maintainers:
     description: Contributors who can use `/milestone` in the community repo. Defined by an entry in an OWNERS file for a contribex subproject.
@@ -53,6 +55,7 @@ teams:
     - mrbobbytables
     - nikhita
     members:
+    - castrojo
     - dims
     - eparis
     - foxish
@@ -94,7 +97,7 @@ teams:
         - mrbobbytables
         - nikhita
         members:
-        - Phillels
+        - castrojo
         privacy: closed
       sig-contributor-experience-pr-reviews:
         description: PR reviews for contributor-experience infrastructure, such as the


### PR DESCRIPTION
Ref: https://github.com/kubernetes/community/pull/4693

/hold
until https://github.com/kubernetes/community/pull/4693 is merged

/assign @mrbobbytables @cblecker @Phillels @castrojo