### PR TITLE
Update SIG Release teams

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -16,7 +16,7 @@ teams:
     description: Members of the CI Signal team for the current release cycle.
     members:
       - droslean # 1.18 CI Signal Lead
-      - hasheddan # 1.18 CI Signal shadow
+      - hasheddan # 1.19 CI Signal Lead
       - hrishin # 1.18 CI Signal shadow
       - jpreese # 1.18 CI Signal shadow
       - prksu # 1.18 CI Signal shadow
@@ -79,7 +79,7 @@ teams:
     - frapposelli # VMware
     - gianarb # 1.18 Bug Triage shadow
     - guineveresaenger # 1.17 Release Lead
-    - hasheddan # 1.17 CI Signal Shadow
+    - hasheddan # Branch Manager / 1.19 CI Signal Lead
     - helayoty # 1.18 RT Enhancemments Shadow
     - hoegaarden # Patch Release Team
     - hpandeycodeit # Usability
@@ -185,7 +185,7 @@ teams:
     - cpanato # Branch Manager
     - dougm # Patch Release Team
     - feiskyer # Patch Release Team
-    - hasheddan # Release Manager Associate
+    - hasheddan # Branch Manager
     - hoegaarden # subproject owner / Patch Release Team
     - idealhack # Patch Release Team
     - jimangel # Release Manager Associate
@@ -210,6 +210,7 @@ teams:
     - cpanato # Branch Manager
     - dougm # Patch Release Team
     - feiskyer # Patch Release Team
+    - hasheddan # Branch Manager
     - hoegaarden # Patch Release Team
     - idealhack # Patch Release Team
     - justaugustus # Branch Manager

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -37,15 +37,13 @@ teams:
     maintainers:
     - cblecker # ContribEx
     - fejta # Testing
-    - mrbobbytables # 1.18 RT Lead Shadow
+    - mrbobbytables # 1.19 RT Lead Shadow
     - nikhita # ContribEx
     - spiffxp # Testing
     members:
     - abgworrall # GCP
     - adisky # OpenStack
     - ahg-g # Scheduling
-    - alejandrox1 # 1.18 RT Lead
-    - alenkacz # 1.17 RT CI Signal lead
     - andrewsykim # Cloud Provider
     - annajung # 1.18 Bug Triage shadow
     - benmoss # Windows
@@ -69,18 +67,15 @@ teams:
     - derekwaynecarr # Architecture / Node
     - dims # Architecture / Release
     - dougm # Patch Release Team
-    - droslean # 1.17 CI Signal Shadow
     - enj # Auth
-    - evillgenius75 # 1.17 Release Notes Shadow
     - fabriziopandini # Cluster Lifecycle
     - feiskyer # Azure
     - floreks # UI
     - foxish # Big Data
     - frapposelli # VMware
-    - gianarb # 1.18 Bug Triage shadow
-    - guineveresaenger # 1.17 Release Lead
+    - gianarb # 1.19 Bug Triage Lead
     - hasheddan # Branch Manager / 1.19 CI Signal Lead
-    - helayoty # 1.18 RT Enhancemments Shadow
+    - helayoty # 1.18 RT Enhancements Shadow
     - hoegaarden # Patch Release Team
     - hpandeycodeit # Usability
     - idealhack # Patch Release Team
@@ -89,51 +84,50 @@ teams:
     - jberkus # Release
     - jdumars # Architecture / PM
     - jeefy # UI
-    - jeremyrickard # 1.18 RT Enhancements Lead
+    - jeremyrickard # 1.19 RT Lead Shadow
     - jimangel # Docs
-    - johnbelamaric # 1.18 RT Enhancements Shadow
-    - josiahbjorgaard # 1.17 Bug Triage Lead
+    - johnbelamaric # Architecture
     - jtslear # 1.18 Bug Triage shadow
     - justaugustus # Azure / PM / Release
     - justinsb # AWS / Cluster Lifecycle
     - k82cn # Scheduling
     - k8s-release-robot # Release
-    - kcmartin # 1.17 RT Enhancements shadow
     - khenidak # Azure
     - kikisdeliveryservice # 1.18 RT Enhancements Shadow
     - kow3ns # Apps
     - kris-nova # AWS
-    - lachie83 # PM
     - lavalamp # API Machinery
     - liggitt # Auth / Release
     - lingxiankong # OpenStack
     - liyinan926 # Big Data
     - luxas # Cluster Lifecycle
     - maciaszczykm # UI
-    - mariantalla # 1.17 RT Lead Shadow
     - marosset # Windows
     - mattfarina # Apps / Architecture
     - mborsz # Scalability
     - michmike # Windows
     - mikedanese # Auth
+    - mkorbi # 1.19 RT Communications Lead
     - mm4tt # Scalability
     - mszostok # Service Catalog
     - mwielgus # Autoscaling
     - neolit123 # Cluster Lifecycle
     - onlydole # 1.19 RT Lead
     - oxddr # Scalability
-    - palnabarun # 1.18 RT Enhancements shadow
+    - palnabarun # 1.19 RT Enhancements Lead
     - parispittman # ContribEx
     - phillels # ContribEx
     - piosz # Instrumentation
     - pmorie # Multicluster
     - prydonius # Apps
+    - puerco # 1.19 RT Release Notes Lead
     - pwittrock # CLI
     - quinton-hoole # Multicluster
     - RainbowMango # Instrumentation
     - rajakavitha1 # Usability
     - saad-ali # Storage
     - saschagrunert # Branch Manager
+    - savitharaghunathan # 1.19 RT Docs Lead
     - seans3 # CLI
     - serathius # Instrumentation
     - shyamjvs # Scalability
@@ -220,35 +214,24 @@ teams:
   release-team:
     description: Members of the current Release Team and subproject owners.
     maintainers:
-    - mrbobbytables # 1.18 RT Lead Shadow
-    - spiffxp # subproject owner
+    - mrbobbytables # 1.19 RT Lead Shadow
     members:
-    - aishsundar # subproject owner
-    - alejandrox1 # 1.18 RT Lead
-    - alenkacz # 1.17 CI Signal Lead
-    - bubblemelon # Emeritus Branch Manager
-    - cartyc # 1.17 Release Notes Lead
+    - alejandrox1 # subproject owner
     - claurence # subproject owner
     - cpanato # Branch Manager
-    - evillgenius75 # 1.17 Release Notes Shadow
-    - guineveresaenger # 1.17 RT Lead
-    - idealhack # Branch Manager
-    - jberkus # subproject owner
-    - jeefy # 1.17 RT Lead Shadow
-    - josiahbjorgaard # 1.17 Bug Triage Lead
+    - gianarb # 1.19 Bug Triage Lead
+    - guineveresaenger # subproject owner
+    - hasheddan # Branch Manager / 1.19 CI Signal Lead
+    - jeremyrickard # 1.19 RT Lead Shadow
     - justaugustus # subproject owner
     - lachie83 # subproject owner
-    - mariantalla # 1.17 RT Lead Shadow
-    - nikopen # 1.16 RT Lead Shadow
+    - mkorbi # 1.19 RT Communications Lead
     - onlydole # 1.19 RT Lead
-    - onyiny-ang # 1.16 Release Notes Shadow
-    - rawkode # 1.17 Communications Lead
-    - rbitia # 1.16 Enhancements Shadow
-    - saschagrunert # 1.16 Release Notes Lead
-    - simplytunde # 1.16 Docs Lead
-    - soggiest # 1.16 CI Signal Shadow
-    - tpepper # subproject owner
-    - xmudrii # 1.16 Bug Triage Lead
+    - palnabarun # 1.19 RT Enhancements Lead
+    - puerco # 1.19 RT Release Notes Lead
+    - saschagrunert # Branch Manager
+    - savitharaghunathan # 1.19 RT Docs Lead
+    - tpepper # subproject owner / 1.19 Emeritus Adviser
     privacy: closed
     teams:
       release-team-leads:
@@ -257,10 +240,11 @@ teams:
            and can be used as a notification group.
           Remove org members who are not current Release Team Leads.
         maintainers:
-        - mrbobbytables # 1.18 RT Lead Shadow
+        - mrbobbytables # 1.19 RT Lead Shadow
         members:
-        - alejandrox1 # 1.18 RT Lead
+        - jeremyrickard # 1.19 RT Lead Shadow
         - onlydole # 1.19 RT Lead
+        - tpepper # 1.19 Emeritus Adviser
         privacy: closed
   sig-release:
     description: SIG Release Members
@@ -300,6 +284,7 @@ teams:
     - evillgenius75
     - feiskyer
     - foxish
+    - gianarb
     - girikuncoro
     - guineveresaenger
     - hasheddan
@@ -311,6 +296,7 @@ teams:
     - jberkus
     - jdumars
     - jeefy
+    - jeremyrickard
     - jimangel
     - josiahbjorgaard
     - jpbetz
@@ -332,6 +318,7 @@ teams:
     - mbohlool
     - mcrute
     - mistyhacks
+    - mkorbi
     - mohammedzee1000
     - monopole
     - nickchase
@@ -339,14 +326,17 @@ teams:
     - nwoods3
     - onlydole
     - onyiny-ang
+    - palnabarun
     - ps882
     - pswica
+    - puerco
     - pwittrock
     - radhikapc
     - rawkode
     - rbitia
     - saad-ali
     - saschagrunert
+    - savitharaghunathan
     - shyamjvs
     - simplytunde
     - slicknik

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -111,7 +111,6 @@ teams:
     - luxas # Cluster Lifecycle
     - maciaszczykm # UI
     - mariantalla # 1.17 RT Lead Shadow
-    - markyjackson-taulia # 1.18 Bug Triage shadow
     - marosset # Windows
     - mattfarina # Apps / Architecture
     - mborsz # Scalability
@@ -121,7 +120,7 @@ teams:
     - mszostok # Service Catalog
     - mwielgus # Autoscaling
     - neolit123 # Cluster Lifecycle
-    - onlydole # 1.18 RT Lead Shadow
+    - onlydole # 1.19 RT Lead
     - oxddr # Scalability
     - palnabarun # 1.18 RT Enhancements shadow
     - parispittman # ContribEx
@@ -180,7 +179,6 @@ teams:
       Patch Release Team, Branch Managers, and Release Manager Associates.
     members:
     - aleksandra-malinowska # Build Admin
-    - alexeldeib # Release Manager Associate
     - calebamiles # subproject owner
     - cpanato # Branch Manager
     - dougm # Patch Release Team
@@ -190,15 +188,14 @@ teams:
     - idealhack # Patch Release Team
     - jimangel # Release Manager Associate
     - justaugustus # subproject owner / Build Admin / Patch Release Team
-    - kacole2 # Release Manager Associate
     - listx # Build Admin
-    - onlydole # Release Manager Associate
-    - paulbouwer # Release Manager Associate
+    - markyjackson-taulia # Release Manager Associate
     - ps882 # Build Admin
     - saschagrunert # Branch Manager
     - sethmccombs # Release Manager Associate
     - sumitranr # Build Admin
     - tpepper # subproject owner / Build Admin / Patch Release Team
+    - Verolop # Release Manager Associate
     - xmudrii # Release Manager Associate
     privacy: closed
   release-managers:
@@ -240,11 +237,10 @@ teams:
     - jeefy # 1.17 RT Lead Shadow
     - josiahbjorgaard # 1.17 Bug Triage Lead
     - justaugustus # subproject owner
-    - kacole2 # 1.16 Enhancements Lead
     - lachie83 # subproject owner
     - mariantalla # 1.17 RT Lead Shadow
     - nikopen # 1.16 RT Lead Shadow
-    - onlydole # 1.18 RT Lead Shadow
+    - onlydole # 1.19 RT Lead
     - onyiny-ang # 1.16 Release Notes Shadow
     - rawkode # 1.17 Communications Lead
     - rbitia # 1.16 Enhancements Shadow
@@ -264,7 +260,7 @@ teams:
         - mrbobbytables # 1.18 RT Lead Shadow
         members:
         - alejandrox1 # 1.18 RT Lead
-        - onlydole # 1.18 RT Lead Shadow
+        - onlydole # 1.19 RT Lead
         privacy: closed
   sig-release:
     description: SIG Release Members
@@ -330,6 +326,7 @@ teams:
     - MaciekPytel
     - MAKOSCAFEE
     - mariantalla
+    - markyjackson-taulia
     - marpaia
     - marun
     - mbohlool
@@ -358,6 +355,7 @@ teams:
     - sumitranr
     - tfogo
     - tpepper
+    - Verolop
     - wojtek-t
     - xmudrii
     - zacharysarah

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -45,7 +45,6 @@ teams:
     - adisky # OpenStack
     - ahg-g # Scheduling
     - alejandrox1 # 1.18 RT Lead
-    - aleksandra-malinowska # Patch Release Team
     - alenkacz # 1.17 RT CI Signal lead
     - andrewsykim # Cloud Provider
     - annajung # 1.18 Bug Triage shadow
@@ -159,7 +158,6 @@ teams:
       branches. This team is used for notifications for all active patch
       managers, but does not give permissions.
     members:
-    - aleksandra-malinowska
     - dougm
     - feiskyer
     - hoegaarden
@@ -181,7 +179,7 @@ teams:
     description: Members of the Release Engineering subproject, including Build Admins,
       Patch Release Team, Branch Managers, and Release Manager Associates.
     members:
-    - aleksandra-malinowska # subproject owner / Build Admin / Patch Release Team
+    - aleksandra-malinowska # Build Admin
     - alexeldeib # Release Manager Associate
     - calebamiles # subproject owner
     - cpanato # Branch Manager
@@ -209,7 +207,6 @@ teams:
       label/PR management is needed. Remove users who are not actively doing
       this job.
     members:
-    - aleksandra-malinowska # Patch Release Team
     - cpanato # Branch Manager
     - dougm # Patch Release Team
     - feiskyer # Patch Release Team


### PR DESCRIPTION
- releng: Remove @aleksandra-malinowska from Patch Release Team (ref: https://github.com/kubernetes/sig-release/issues/987)
- releng: Promote @hasheddan to Branch Manager (ref: https://github.com/kubernetes/sig-release/issues/1041)
- releng: Update Release Manager Associates
  - Add (ref: https://github.com/kubernetes/sig-release/issues/1047):
    - Marky Jackson (@markyjackson-taulia)
    - Verónica López (@Verolop)
  - Remove:
    - Ace Eldeib (@alexeldeib)
    - Kendrick Coleman (@kacole2)
    - Paul Bouwer (@paulbouwer)
    - Taylor Dolezal (@onlydole)
- sig-release: Update Release Team membership for Kubernetes 1.19 (cc: @onlydole @mrbobbytables @jeremyrickard)

/assign @tpepper 
/cc @mrbobbytables @kubernetes/release-managers @kubernetes/release-engineering 
