### PR TITLE
sig-arch: Consolidate GitHub teams

### DIFF
--- a/config/kubernetes/sig-architecture/teams.yaml
+++ b/config/kubernetes/sig-architecture/teams.yaml
@@ -1,52 +1,36 @@
 teams:
-  sig-architecture-api-reviews:
-    description: SIG Architecture API review notifications
+  sig-architecture:
+    description: SIG Architecture
     members:
     - bgrant0607
-    - liggitt
-    - smarterclayton
-    privacy: closed
-  sig-architecture-bugs:
-    description: SIG Architecture bug notifications
-    members:
-    - bgrant0607
-    privacy: closed
-  sig-architecture-feature-requests:
-    description: SIG Architecture feature request notifications
-    maintainers:
-    - idvoretskyi
-    members:
-    - bgrant0607
-    - liggitt
-    - smarterclayton
-    privacy: closed
-  sig-architecture-misc-use-only-as-a-last-resort:
-    description: SIG Architecture misc. notifications (consider notifying a more-specific
-      team first!)
-    members:
-    - bgrant0607
-    - smarterclayton
-    privacy: closed
-  sig-architecture-pr-reviews:
-    description: SIG Architecture PR review notifications
-    members:
-    - bgrant0607
+    - derekwaynecarr
+    - dims
     - jbeda
+    - johnbelamaric
     - liggitt
     - smarterclayton
     - timothysc
     privacy: closed
-  sig-architecture-proposals:
-    description: SIG Architecture proposal notifications
-    members:
-    - bgrant0607
-    - smarterclayton
-    privacy: closed
-  sig-architecture-test-failures:
-    description: SIG Architecture test failure notifications
-    members:
-    - bgrant0607
-    privacy: closed
+    teams:
+      sig-architecture-leads:
+        description: SIG Architecture Chairs and Technical Leads
+        members:
+        - derekwaynecarr
+        - dims
+        - johnbelamaric
+        privacy: closed
+      sig-architecture-pr-reviews:
+        description: SIG Architecture PR review notifications
+        members:
+        - bgrant0607
+        - derekwaynecarr
+        - dims
+        - jbeda
+        - johnbelamaric
+        - liggitt
+        - smarterclayton
+        - timothysc
+        privacy: closed
   code-organization-project-admins:
     description: admin access to code organization subproject board
     members:

--- a/config/kubernetes/sig-architecture/teams.yaml
+++ b/config/kubernetes/sig-architecture/teams.yaml
@@ -2,14 +2,12 @@ teams:
   sig-architecture:
     description: SIG Architecture
     members:
-    - bgrant0607
     - derekwaynecarr
     - dims
-    - jbeda
     - johnbelamaric
     - liggitt
     - smarterclayton
-    - timothysc
+    - thockin
     privacy: closed
     teams:
       sig-architecture-leads:
@@ -22,14 +20,12 @@ teams:
       sig-architecture-pr-reviews:
         description: SIG Architecture PR review notifications
         members:
-        - bgrant0607
         - derekwaynecarr
         - dims
-        - jbeda
         - johnbelamaric
         - liggitt
         - smarterclayton
-        - timothysc
+        - thockin
         privacy: closed
   code-organization-project-admins:
     description: admin access to code organization subproject board


### PR DESCRIPTION
- Remove obsolete GH teams
- Add '-leads' team
- Add SIG Chairs to all teams

Groups are now structured per the recommendations [here](https://github.com/kubernetes/community/issues/2323#issuecomment-400776769) (h/t @cblecker!):
```
sig-foo
|_ sig-foo-leads
|_ sig-foo-pr-reviews
```

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

Fixes: https://github.com/kubernetes/org/issues/1798
/assign @johnbelamaric @dims @derekwaynecarr 