### PR TITLE
Remove GitHub teams for kubernetes-anywhere repo

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1729,24 +1729,6 @@ teams:
     - soltysh
     - yue9944882
     privacy: closed
-  kubernetes-anywhere-admins:
-    description: Admin access to the kubernetes-anywhere repo
-    members:
-    - luxas
-    - neolit123
-    - timothysc
-    privacy: closed
-  kubernetes-anywhere-maintainers:
-    description: Write access to the kubernetes-anywhere repo
-    members:
-    - errordeveloper
-    - fabriziopandini
-    - kerneltime
-    - luxas
-    - monadic
-    - neolit123
-    - timothysc
-    privacy: closed
   kubernetes-feature-branch-admins:
     description: Admin access to the kubernetes repo, for maintaining feature branches. Will deprecate when this access is no longer needed.
     members:


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1812
The repo is being archived.

/assign @neolit123 