### PR TITLE
Update SIG Docs team membership

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -176,6 +176,16 @@ teams:
     - seokho-son
     - ysyukr
     privacy: closed
+  sig-docs-leads:
+    description: Chairs and tech leads for SIG Docs
+    members:
+    - jimangel
+    - kbarnard10
+    - kbhawkey
+    - onlydole
+    - sftim
+    - zacharysarah
+    privacy: closed
   sig-docs-pl-owners:
     description: Approvers for Polish content
     members:
@@ -278,8 +288,8 @@ teams:
     previously:
     - kubernetes-website-admins
     members:
-    - Bradamant3
     - jimangel
+    - kbarnard10
     - zacharysarah
     privacy: closed
   website-maintainers:
@@ -310,6 +320,7 @@ teams:
     - nasa9084 # L10n: Japanese
     - ngtuna # L10n: Vietnamese
     - nvtkaszpir # L10n: Polish
+    - onlydole # L10n: English, 1.19 release lead
     - potapy4 # L10n: Russian
     - raelga # L10n: Spanish
     - remyleone # L10n: French
@@ -355,6 +366,7 @@ teams:
     - msheldyakov
     - nasa9084
     - ngtuna
+    - onlydole
     - oussemos
     - perriea
     - potapy4


### PR DESCRIPTION
This PR updates SIG Docs team rosters to reflect current team and role membership.

- @kbarnard10 replaced @Bradamant3 as SIG Docs chair. #1629 
- SIG Docs added technical lead roles: 
    - @kbhawkey #1683
    - @sftim  #1747 
    - @onlydole this PR
- It's useful to have a team for reaching chairs and tech leads specifically, especially for netlify-related issues. https://github.com/kubernetes/website/pull/20489/