### PR TITLE
Add sheerun to Kubernetes-sigs org.

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -382,6 +382,7 @@ members:
 - Sh4d1
 - shashidharatd
 - shawn-hurley
+- sheerun
 - shivi28
 - shu-mutou
 - sidharthsurana


### PR DESCRIPTION
I'd like to become maintainer of Cloudflare provider of external-dns, but @Raffo says I should first become member of kubernetes-sigs organization. What else should I do for this to be merged?