### PR TITLE
Remove danielromlein from org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -238,7 +238,6 @@ members:
 - daminisatya
 - danehans
 - danielqsj
-- danielromlein
 - dankohn
 - danninov
 - danpaik
@@ -1367,7 +1366,6 @@ teams:
     - bryk
     - cheld
     - cupofcat
-    - danielromlein
     - floreks
     - ianlewis
     - jeefy

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -60,7 +60,6 @@ teams:
     - cpanato # Branch Manager
     - craiglpeters # Azure
     - d-nishi # AWS
-    - danielromlein # UI
     - dcbw # Network
     - dchen1107 # Node
     - ddebroy # Windows


### PR DESCRIPTION
https://github.com/organizations/kubernetes/settings/audit-log?q=actor%3Adanielromlein+action%3Aorg.remove_member

Looks like @danielromlein removed themselves from the org on March 16.

cc: @jeefy @floreks @maciaszczykm 