### PR TITLE
Add damemi to descheduler admins

### DIFF
--- a/config/kubernetes-sigs/sig-scheduling/teams.yaml
+++ b/config/kubernetes-sigs/sig-scheduling/teams.yaml
@@ -13,6 +13,7 @@ teams:
     description: Admin access to the descheduler repo
     members:
     - aveshagarwal
+    - damemi
     - k82cn
     - ravisantoshgudimetla
     privacy: closed
@@ -20,6 +21,7 @@ teams:
     description: Write access to the descheduler repo
     members:
     - aveshagarwal
+    - damemi
     - k82cn
     - ravisantoshgudimetla
     privacy: closed


### PR DESCRIPTION
Ref https://github.com/kubernetes-sigs/descheduler/issues/273#issuecomment-627096107

I was recently added as an approver to the kubernetes-sigs/descheduler repo, having admin access to the repo will enable me to assist with release branching and general maintenance of the repo going forward 