### PR TITLE
Add GitHub teams for instrumentation-tools

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -264,6 +264,7 @@ members:
 - liyinan926
 - liztio
 - loburm
+- logicalhan
 - LuckySB
 - luxas
 - m00nf1sh

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -136,6 +136,7 @@ members:
 - dvonthenen
 - easeway
 - eddiezane
+- ehashman
 - elmiko
 - entro-pi
 - enxebre

--- a/config/kubernetes-sigs/sig-instrumentation/teams.yaml
+++ b/config/kubernetes-sigs/sig-instrumentation/teams.yaml
@@ -11,6 +11,22 @@ teams:
     - s-urbaniak
     - serathius
     privacy: closed
+  instrumentation-tools-admins:
+    description: Admin access to the instrumentation-tools repo
+    members:
+    - brancz
+    - dashpole
+    - ehashman
+    - logicalhan
+    privacy: closed
+  instrumentation-tools-maintainers:
+    description: Write access to the instrumentation-tools repo
+    members:
+    - brancz
+    - dashpole
+    - ehashman
+    - logicalhan
+    privacy: closed
   metrics-server-admins:
     description: Admin access to the metrics-server repo
     members:


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1907

Also adds @ehashman and @logicalhan to kubernetes-sigs since they are already members of the kubernetes org.

/assign @mrbobbytables 