### PR TITLE
Add Release Manager Associates to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -386,6 +386,7 @@ members:
 - sedefsavas
 - serathius
 - serbrech
+- sethmccombs
 - sethp-nr
 - sethpollack
 - sflxn

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -429,6 +429,7 @@ members:
 - tpepper
 - truongnh1992
 - umohnani8
+- Verolop
 - verult
 - vikaschoudhary16
 - vincepri

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -174,6 +174,7 @@ members:
 - haoshuwei
 - hardikdr
 - hasbro17
+- hasheddan
 - hbagdi
 - hchenxa
 - hectorj2f


### PR DESCRIPTION
(Needed for https://github.com/kubernetes/org/pull/1924)
Adds the following @kubernetes/release-engineering members to k-sigs: @hasheddan, @sethmccombs, @Verolop

/assign @nikhita 