### PR TITLE
config/kubernetes/org.yaml: update kubeadm-maintainers

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1722,19 +1722,11 @@ teams:
   kubeadm-maintainers:
     description: Write access to the kubeadm repo
     members:
-    - chuckha
     - detiber
-    - errordeveloper
     - fabriziopandini
-    - jamiehannaford
-    - jbeda
-    - liztio
-    - lukemarsden
     - luxas
-    - medinatiger
     - neolit123
-    - pipejakob
-    - stealthybox
+    - rosti
     - timothysc
     privacy: closed
   kubectl-admins:

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1713,22 +1713,6 @@ teams:
     - LiliC
     - tariq1890
     privacy: closed
-  kubeadm-admins:
-    description: Admin access to the kubeadm repo
-    members:
-    - luxas
-    - timothysc
-    privacy: closed
-  kubeadm-maintainers:
-    description: Write access to the kubeadm repo
-    members:
-    - detiber
-    - fabriziopandini
-    - luxas
-    - neolit123
-    - rosti
-    - timothysc
-    privacy: closed
   kubectl-admins:
     description: Admin access to the kubectl repo
     members:

--- a/config/kubernetes/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes/sig-cluster-lifecycle/teams.yaml
@@ -1,4 +1,20 @@
 teams:
+  kubeadm-admins:
+    description: Admin access to the kubeadm repo
+    members:
+    - luxas
+    - timothysc
+    privacy: closed
+  kubeadm-maintainers:
+    description: Write access to the kubeadm repo
+    members:
+    - detiber
+    - fabriziopandini
+    - luxas
+    - neolit123
+    - rosti
+    - timothysc
+    privacy: closed
   sig-cluster-lifecycle:
     description: Use only if you can't figure out a better category
     members:


### PR DESCRIPTION
first commit:

- Clear inactive maintainers:
chuckha, errordeveloper, jamiehannaford, jbeda, liztio, lukemarsden,
medinatiger, pipejakob, stealthybox
Hope to see you again soon.

- Add rosti.

--------

second commit:

- Move the kubeadm teams to the SIG teams.yaml
