### PR TITLE
sig-release: Add active image promoter contribs to release-engineering

### DIFF
--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -32,12 +32,14 @@ teams:
     - idealhack # Release Manager
     - jimangel # Release Manager Associate
     - justaugustus # subproject owner / Build Admin / Release Manager
+    - listx # Build Admin / Image promoter admin
     - markyjackson-taulia # Release Manager Associate
     - saschagrunert # Release Manager
     - sethmccombs # Release Manager Associate
     - tpepper # subproject owner / Build Admin / Release Manager
     - Verolop # Release Manager Associate
     - xmudrii # Release Manager Associate
+    - yodahekinsew # Image promoter contributor (ref: https://github.com/kubernetes/org/pull/1938)
     privacy: closed
   release-notes-admins:
     description: admin access to release-notes


### PR DESCRIPTION
Grants Triage role to kubernetes-sigs/k8s-container-image-promoter
I've already granted the triage role on the repo; this adds @listx and @yodahekinsew to the team, so they can triage the https://github.com/kubernetes-sigs/k8s-container-image-promoter/projects/3 project.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @saschagrunert @alejandrox1 
ref: https://github.com/kubernetes/org/pull/1938, https://github.com/kubernetes/org/pull/1943, https://github.com/kubernetes/org/issues/1939