### PR TITLE
Add clarketm to the kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -91,6 +91,7 @@ members:
 - chriskim06
 - christopherhein
 - chuckha
+- clarketm
 - clarklee92
 - claudiubelu
 - clyang82


### PR DESCRIPTION
They are already a member of kubernetes.
This should resolve the issue when repo-infra is brought in as a submodule
ref: kubernetes-sigs/kubefed#1244
ref: https://kubernetes.slack.com/archives/C1TU9EB9S/p1593719089153000
ref: https://github.com/kubernetes/repo-infra/pull/193
/cc @cblecker 