### PR TITLE
move SIG Cluster Lifecycle teams to SIG sub-folders and prune the main SIG team

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -540,18 +540,6 @@ teams:
     - jeefy
     - maciaszczykm
     privacy: closed
-  etcdadm-admins:
-    description: Admin access to the etcdadm repo
-    members:
-    - dlipovetsky
-    - justinsb
-    privacy: closed
-  etcdadm-maintainers:
-    description: Write access to the etcdadm repo
-    members:
-    - dlipovetsky
-    - justinsb
-    privacy: closed
   gcp-filestore-csi-driver-admins:
     description: Admin access to the gcp-filestore-csi-driver repo
     members:
@@ -596,25 +584,6 @@ teams:
     description: Team responsible for sig-scheduling related projects
     members:
     - timothysc
-    privacy: closed
-  kubespray-admins:
-    description: Admin access to the kubespray repo
-    members:
-    - ant31
-    - chadswen
-    - mattymo
-    privacy: closed
-  kubespray-maintainers:
-    description: Write access to the kubespray repo
-    members:
-    - ant31
-    - Atoms
-    - chadswen
-    - mattymo
-    - miouge1
-    - mirwan
-    - riverzhang
-    - woopstar
     privacy: closed
   node-feature-discovery-admins:
     description: Admin access to the node-feature-discovery repo

--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -1,4 +1,14 @@
 teams:
+  bootkube-admins:
+    description: admin access to bootkube repo
+    members:
+    - aaronlevy
+    privacy: closed
+  bootkube-maintainers:
+    description: write access to bootkube repo
+    members:
+    - aaronlevy
+    privacy: closed
   cluster-addons-admins:
     description: admin access to cluster-addons
     members:
@@ -18,16 +28,6 @@ teams:
     privacy: closed
     previously:
     - addon-operators-maintainers
-  bootkube-admins:
-    description: admin access to bootkube repo
-    members:
-    - aaronlevy
-    privacy: closed
-  bootkube-maintainers:
-    description: write access to bootkube repo
-    members:
-    - aaronlevy
-    privacy: closed
   cluster-api-admins:
     description: ""
     members:
@@ -128,7 +128,7 @@ teams:
     members:
     - cpanato
     - MorrisLaw
-    - prksu 
+    - prksu
     - timothysc
     - xmudrii
     privacy: closed
@@ -222,6 +222,18 @@ teams:
     - vincepri
     - yastij
     privacy: closed
+  etcdadm-admins:
+    description: Admin access to the etcdadm repo
+    members:
+    - dlipovetsky
+    - justinsb
+    privacy: closed
+  etcdadm-maintainers:
+    description: Write access to the etcdadm repo
+    members:
+    - dlipovetsky
+    - justinsb
+    privacy: closed
   image-builder-admins:
     description: admin access to image-builder
     members:
@@ -237,4 +249,23 @@ teams:
     - luxas
     - moshloop
     - timothysc
+    privacy: closed
+  kubespray-admins:
+    description: Admin access to the kubespray repo
+    members:
+    - ant31
+    - chadswen
+    - mattymo
+    privacy: closed
+  kubespray-maintainers:
+    description: Write access to the kubespray repo
+    members:
+    - ant31
+    - Atoms
+    - chadswen
+    - mattymo
+    - miouge1
+    - mirwan
+    - riverzhang
+    - woopstar
     privacy: closed

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1673,27 +1673,6 @@ teams:
     - ngtuna
     - sebgoa
     privacy: closed
-  kops-admins:
-    description: Admin access to the kops repo
-    members:
-    - justinsb
-    - mikedanese
-    - zmerlynn
-    privacy: closed
-  kops-maintainers:
-    description: Write access to the kops repo
-    members:
-    - chrislovecnm
-    - geojaz
-    - granular-ryanbonham
-    - justinsb
-    - kris-nova
-    - mikedanese
-    - mikesplain
-    - rdrgmnzs
-    - rifelpet
-    - yissachar
-    privacy: closed
   kube-openapi-admins:
     description: Admin access to the kube-openapi repo
     members:
@@ -1869,24 +1848,6 @@ teams:
     - DirectXMan12
     - piosz
     - sarahnovotny
-    privacy: closed
-  minikube-admins:
-    description: Admin access to the minikube repo
-    members:
-    - balopat
-    - dlorenc
-    - tstromberg
-    - vishh
-    privacy: closed
-  minikube-maintainers:
-    description: Write access to the minikube repo
-    members:
-    - afbjorklund
-    - balopat
-    - ethernetdan
-    - jimmidyson
-    - sharifelgamal
-    - tstromberg
     privacy: closed
   node-problem-detector-admins:
     description: Admin access to the node-problem-detector repo

--- a/config/kubernetes/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes/sig-cluster-lifecycle/teams.yaml
@@ -55,53 +55,20 @@ teams:
     - tstromberg
     privacy: closed
   sig-cluster-lifecycle:
-    description: Use only if you can't figure out a better category
+    description: For discussing SIG Cluster Lifecycle topics
     members:
-    - chuckha
     - detiber
     - dixudx
     - ereslibre
     - fabriziopandini
-    - jbeda
     - kad
-    - karan
-    - krousey
-    - liztio
     - luxas
-    - medinatiger
     - neolit123
-    - pipejakob
     - rosti
     - SataQiu
     - stealthybox
     - timothysc
-    - xiangpengzhao
     - yagonobre
-    privacy: closed
-  sig-cluster-lifecycle-pr-reviews:
-    description: ""
-    members:
-    - chuckha
-    - detiber
-    - dixudx
-    - ereslibre
-    - fabriziopandini
-    - jbeda
-    - kad
-    - karan
-    - krousey
-    - liztio
-    - luxas
-    - medinatiger
-    - neolit123
-    - pipejakob
-    - rosti
-    - SataQiu
-    - stealthybox
-    - timothysc
-    - xiangpengzhao
-    - yagonobre
-    - zouyee
     privacy: closed
   system-validators-admins:
     description: Admin access to system-validators repo

--- a/config/kubernetes/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes/sig-cluster-lifecycle/teams.yaml
@@ -1,4 +1,25 @@
 teams:
+  kops-admins:
+    description: Admin access to the kops repo
+    members:
+    - justinsb
+    - mikedanese
+    - zmerlynn
+    privacy: closed
+  kops-maintainers:
+    description: Write access to the kops repo
+    members:
+    - chrislovecnm
+    - geojaz
+    - granular-ryanbonham
+    - justinsb
+    - kris-nova
+    - mikedanese
+    - mikesplain
+    - rdrgmnzs
+    - rifelpet
+    - yissachar
+    privacy: closed
   kubeadm-admins:
     description: Admin access to the kubeadm repo
     members:
@@ -14,6 +35,24 @@ teams:
     - neolit123
     - rosti
     - timothysc
+    privacy: closed
+  minikube-admins:
+    description: Admin access to the minikube repo
+    members:
+    - balopat
+    - dlorenc
+    - tstromberg
+    - vishh
+    privacy: closed
+  minikube-maintainers:
+    description: Write access to the minikube repo
+    members:
+    - afbjorklund
+    - balopat
+    - ethernetdan
+    - jimmidyson
+    - sharifelgamal
+    - tstromberg
     privacy: closed
   sig-cluster-lifecycle:
     description: Use only if you can't figure out a better category


### PR DESCRIPTION
please review one commit at a time.

----

first commit:

Move the teams for the following sub projects:
- etcdadm
- kubespray
- kops
- minikube

Re-order the SIG teams alphabetically.

-----------

second commit:

"pr-reviews" is a redundant list, at this point. We can use
the main team for all the purposes.

Remove jbeda, liztio, karan, krousey, medinatiger, pipejakob, xiangpengzhao, zouyee.
Thank you for the past contributions!
