### PR TITLE
Update reference docs permissions

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -408,6 +408,7 @@ members:
 - sethp-nr
 - sethpollack
 - sflxn
+- sftim
 - sfzylad
 - Sh4d1
 - shashidharatd
@@ -598,19 +599,6 @@ teams:
     members:
     - balajismaniam
     - marquiz
-    privacy: closed
-  reference-docs-admins:
-    description: Admin access to the reference-docs repo
-    members:
-    - bradamant3
-    - jimangel
-    - zacharysarah
-    privacy: closed
-  reference-docs-maintainers:
-    description: Write access to the reference-docs repo
-    members:
-    - kbhawkey
-    - tengqm
     privacy: closed
   sig-storage-lib-external-provisioner-admins:
     description: Admin access to the sig-storage-lib-external-provisioner repo

--- a/config/kubernetes-sigs/sig-docs/OWNERS
+++ b/config/kubernetes-sigs/sig-docs/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-docs-leads
+approvers:
+  - sig-docs-leads
+labels:
+  - sig/docs

--- a/config/kubernetes-sigs/sig-docs/teams.yaml
+++ b/config/kubernetes-sigs/sig-docs/teams.yaml
@@ -1,0 +1,15 @@
+teams:
+  reference-docs-admins:
+    description: admin access to the reference-docs repo
+    members:
+    - jimangel
+    - kbarnard10
+    - zacharysarah
+    privacy: closed
+  reference-docs-maintainers:
+    description: write access to the reference-docs repo
+    members:
+    - kbhawkey
+    - onlydole
+    - sftim
+    privacy: closed


### PR DESCRIPTION
This PR updates repo admins to the current roster of [SIG Docs chairs](https://github.com/kubernetes/community/tree/master/sig-docs#chairs).

Related: https://github.com/kubernetes-sigs/reference-docs/pull/162/files#r451224287

/cc @jimangel @kbarnard10 

/sig docs
/priority important-soon