### PR TITLE
Add saschagrunert and alejandrox1 as SIG Release admins 

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -60,8 +60,9 @@ aliases:
     - dchen1107
     - derekwaynecarr
   sig-release-leads:
-    - calebamiles
+    - alejandrox1
     - justaugustus
+    - saschagrunert
     - tpepper
   sig-scalability-leads:
     - mm4tt

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -284,7 +284,8 @@ teams:
       sig-release-admins:
         description: Admins for SIG Release repositories
         members:
-        - calebamiles
+        - alejandrox1
         - justaugustus
+        - saschagrunert
         - tpepper
         privacy: closed


### PR DESCRIPTION
To fulfill the role as new technical lead we need to be part of the SIG
release admin role.

Ref: https://github.com/kubernetes/community/pull/4867

/assign @kubernetes/sig-release-admins 
/cc @kubernetes/sig-release 