### PR TITLE
Add GitHub teams for seccomp operator

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -348,6 +348,7 @@ members:
 - phyber
 - piosz
 - piotrmiskiewicz
+- pjbgf
 - pjh
 - pmorie
 - pohly

--- a/config/kubernetes-sigs/sig-node/teams.yaml
+++ b/config/kubernetes-sigs/sig-node/teams.yaml
@@ -11,3 +11,17 @@ teams:
     - marquiz
     - zvonkok
     privacy: closed
+  seccomp-operator-admins:
+    description: Admin access to seccomp-operator repo
+    members:
+    - hasheddan
+    - pjbgf
+    - saschagrunert
+    privacy: closed
+  seccomp-operator-maintainers:
+    description: Write access to seccomp-operator repo
+    members:
+    - hasheddan
+    - pjbgf
+    - saschagrunert
+    privacy: closed


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/1873

@pjbgf is a member of @kubernetes and is implicitly eligible for membership to k-sigs.

/assign @saschagrunert 