### PR TITLE
Add WG Naming teams

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -47,6 +47,7 @@ aliases:
     - zacharysarah
   sig-instrumentation-leads:
     - brancz
+    - dashpole
     - ehashman
     - logicalhan
   sig-multicluster-leads:
@@ -84,22 +85,20 @@ aliases:
     - spiffxp
     - stevekuznetsov
   sig-ui-leads:
-    - danielromlein
     - floreks
     - jeefy
     - maciaszczykm
   sig-usability-leads:
-    - Rajakavitha1
     - hpandeycodeit
     - tashimi
-    - vllry
   sig-windows-leads:
     - benmoss
     - ddebroy
     - marosset
     - michmike
-  wg-apply-leads:
-    - lavalamp
+  wg-api-expression-leads:
+    - apelisse
+    - kwiesmueller
   wg-component-standard-leads:
     - mtaufen
     - stealthybox
@@ -127,12 +126,14 @@ aliases:
   wg-multitenancy-leads:
     - srampal
     - tashimi
+  wg-naming-leads:
+    - celestehorgan
+    - jdumars
+    - justaugustus
+    - zacharysarah
   wg-policy-leads:
     - ericavonb
     - hannibalhuang
-  wg-resource-management-leads:
-    - derekwaynecarr
-    - vishh
   wg-security-audit-leads:
     - aasmall
     - cji
@@ -155,10 +156,11 @@ aliases:
     - tashimi
   committee-product-security:
     - cjcullen
+    - cji
     - joelsmith
-    - liggitt
     - lukehinds
     - micahhausler
+    - swamymsft
     - tallclair
   committee-steering:
     - cblecker

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -79,6 +79,7 @@ members:
 - caseydavenport
 - castrojo
 - CecileRobertMichon
+- celestehorgan
 - chadswen
 - chaosaffe
 - charleszheng44

--- a/config/kubernetes-sigs/wg-naming/OWNERS
+++ b/config/kubernetes-sigs/wg-naming/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - wg-naming-leads
+approvers:
+  - wg-naming-leads
+labels:
+  - wg/naming

--- a/config/kubernetes-sigs/wg-naming/teams.yaml
+++ b/config/kubernetes-sigs/wg-naming/teams.yaml
@@ -1,0 +1,18 @@
+teams:
+  wg-naming:
+    description: WG Naming
+    members:
+    - celestehorgan
+    - jdumars
+    - justaugustus
+    - zacharysarah
+    privacy: closed
+    teams:
+      wg-naming-leads:
+        description: WG Naming Leads
+        members:
+        - celestehorgan
+        - jdumars
+        - justaugustus
+        - zacharysarah
+        privacy: closed

--- a/config/kubernetes/wg-naming/OWNERS
+++ b/config/kubernetes/wg-naming/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - wg-naming-leads
+approvers:
+  - wg-naming-leads
+labels:
+  - wg/naming

--- a/config/kubernetes/wg-naming/teams.yaml
+++ b/config/kubernetes/wg-naming/teams.yaml
@@ -1,0 +1,18 @@
+teams:
+  wg-naming:
+    description: WG Naming
+    members:
+    - celestehorgan
+    - jdumars
+    - justaugustus
+    - zacharysarah
+    privacy: closed
+    teams:
+      wg-naming-leads:
+        description: WG Naming Leads
+        members:
+        - celestehorgan
+        - jdumars
+        - justaugustus
+        - zacharysarah
+        privacy: closed


### PR DESCRIPTION
WG Naming, now with GitHub teams for notifications on the `kubernetes` and `kubernetes-sigs` GH orgs!

/assign @cblecker @nikhita 
/cc @celestehorgan @zacharysarah @jdumars 

Formation PR: https://github.com/kubernetes/community/pull/4884