### PR TITLE
Add f0rmiga as adminstrator to minibroker repo

### DIFF
--- a/config/kubernetes-sigs/sig-service-catalog/teams.yaml
+++ b/config/kubernetes-sigs/sig-service-catalog/teams.yaml
@@ -18,4 +18,5 @@ teams:
     description: Admin access to the minibroker repo
     members:
     - carolynvs
+    - f0rmiga
     privacy: closed


### PR DESCRIPTION
Following up on https://github.com/kubernetes/org/issues/2019, this PR adds f0rmiga (me) from SUSE as a Minibroker admin.