### PR TITLE
add current actual google build admins to build-admins

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -208,15 +208,15 @@ teams:
               the Kubernetes project. This team is a notification-only group,
               which includes the SIG Release Chairs for continuity.
             members:
+            - aleksandra-malinowska
             - amwat
             - BenTheElder
-            - MushuEE
-            - spiffxp
-            - aleksandra-malinowska
             - calebamiles
             - justaugustus
             - listx
+            - MushuEE
             - ps882
+            - spiffxp
             - sumitranr
             - tpepper
             privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -208,6 +208,10 @@ teams:
               the Kubernetes project. This team is a notification-only group,
               which includes the SIG Release Chairs for continuity.
             members:
+            - amwat
+            - BenTheElder
+            - MushuEE
+            - spiffxp
             - aleksandra-malinowska
             - calebamiles
             - justaugustus

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -207,6 +207,8 @@ teams:
               Googlers with access to publish packages (debs/rpms) on behalf of
               the Kubernetes project. This team is a notification-only group,
               which includes the SIG Release Chairs for continuity.
+            maintainers:
+            - spiffxp
             members:
             - aleksandra-malinowska
             - amwat
@@ -216,7 +218,6 @@ teams:
             - listx
             - MushuEE
             - ps882
-            - spiffxp
             - sumitranr
             - tpepper
             privacy: closed


### PR DESCRIPTION
unclear which of the other entries should be removed

See: https://github.com/kubernetes/sig-release/issues/1150