### PR TITLE
Add rajula96reddy to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -371,6 +371,7 @@ members:
 - RainbowMango
 - Rajakavitha1
 - rajansandeep
+- rajula96reddy
 - Random-Liu
 - randomvariable
 - RaunakShah


### PR DESCRIPTION
Needed for https://github.com/kubernetes-sigs/contributor-tweets/issues/2#issuecomment-663598159. They are already a member of @kubernetes and are doing amazing work in the contribex marketing team. :) 

/assign @rajula96reddy 