### PR TITLE
Update sig-docs-ja member

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -145,17 +145,15 @@ teams:
   sig-docs-ja-owners:
     description: Approvers for Japanese content
     members:
-    - cstoku
     - inductor
     - nasa9084
     privacy: closed
   sig-docs-ja-reviews:
     description: PR reviews for Japanese content
     members:
-    - cstoku
+    - bells17
     - inductor
     - makocchi-git
-    - MasayaAoyama
     - nasa9084
     - oke-py
     privacy: closed


### PR DESCRIPTION
fixed: #2089
Updated teams.yaml according to OWNER_ALIAS on k/website.

https://github.com/kubernetes/website/blob/master/OWNERS_ALIASES#L116-L127