### PR TITLE
Add dashpole and logicalhan to milestone maintainers

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -32,6 +32,7 @@ teams:
     - cpanato # Release Manager
     - craiglpeters # Azure
     - d-nishi # AWS
+    - dashpole # Instrumentation
     - dcbw # Network
     - dchen1107 # Node
     - ddebroy # Windows
@@ -75,6 +76,7 @@ teams:
     - liggitt # Auth / Release
     - lingxiankong # OpenStack
     - liyinan926 # Big Data
+    - logicalhan # Instrumentation
     - luxas # Cluster Lifecycle
     - maciaszczykm # UI
     - markyjackson-taulia # Release Manager Associate


### PR DESCRIPTION
Based on https://github.com/kubernetes/enhancements/pull/1554, as a sig lead for instrumentation I should be able to triage PRs.

cc @brancz @logicalhan 