### PR TITLE
Add chaodaiG as test-infra-maintainers

### DIFF
--- a/config/kubernetes/sig-testing/teams.yaml
+++ b/config/kubernetes/sig-testing/teams.yaml
@@ -57,12 +57,12 @@ teams:
     - spiffxp
     members:
     - BenTheElder
+    - chaodaiG
     - chases2
     - cjwagner
     - Katharine
     - michelle192837
     - stevekuznetsov
-    - chaodaiG
     privacy: closed
   test-infra-maintainers:
     description: write access to test-infra

--- a/config/kubernetes/sig-testing/teams.yaml
+++ b/config/kubernetes/sig-testing/teams.yaml
@@ -62,6 +62,7 @@ teams:
     - Katharine
     - michelle192837
     - stevekuznetsov
+    - chaodaiG
     privacy: closed
   test-infra-maintainers:
     description: write access to test-infra


### PR DESCRIPTION
chaodaiG just started oncall rotation, add to this group for admin access of test-infra