### PR TITLE
Add chizhg to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -89,6 +89,7 @@ members:
 - chenopis
 - chewong
 - childsb
+- chizhg
 - chrigl
 - chris-short
 - chriskim06


### PR DESCRIPTION
II'm already a member of `kubernetes` org and was added in https://github.com/kubernetes/org/issues/1936.
This PR is adding me to the `kubernetes-sigs` org.

Thanks!