### PR TITLE
Adding new service-apis maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -107,6 +107,9 @@ teams:
     description: Write access to the service-apis repo
     members:
     - bowei
+    - hbagdi
+    - jpeach
+    - robscott
     - thockin
     privacy: closed
     previously:


### PR DESCRIPTION
This adds @hbagdi, @jpeach, and myself as new maintainers for the [Service APIs subproject](https://github.com/kubernetes-sigs/service-apis). 

/cc @bowei
/sig network