### PR TITLE
Add codenrhoden as admin for image-builder repo

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -208,6 +208,7 @@ teams:
   image-builder-admins:
     description: admin access to image-builder
     members:
+    - codenrhoden
     - justinsb
     - luxas
     - timothysc


### PR DESCRIPTION
I tend to be the one who admins this repo the most, and right now there is an [open issue](https://github.com/kubernetes-sigs/image-builder/issues/216) to modify the repo's about section to include a doc link. I need admin access to do so.

/assign @timothysc @justinsb 
/cc @detiber 