### PR TITLE
Remove ericzhang08 from kubernetes, kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -152,7 +152,6 @@ members:
 - enxebre
 - EppO
 - ericavonb
-- ericzhang08
 - estroz
 - Ethyling
 - f0rmiga

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -293,7 +293,6 @@ members:
 - ericavonb
 - ericchiang
 - erictune
-- ericzhang08
 - erikerlandson
 - errordeveloper
 - ethernetdan


### PR DESCRIPTION
https://github.com/ericzhang08 doesn't exist anymore and it broke peribolos.

Ref: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-org-peribolos/1298662606931759104

```
 {"client":"github","component":"peribolos","file":"external/io_k8s_test_infra/prow/github/client.go:526","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"UpdateOrgMembership(kubernetes, ericzhang08, false)","time":"2020-08-26T17:02:48Z"}
{"component":"peribolos","error":"status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/orgs#set-organization-membership-for-a-user\"}","file":"external/io_k8s_test_infra/prow/cmd/peribolos/main.go:517","func":"main.configureOrgMembers.func1","level":"warning","msg":"UpdateOrgMembership(kubernetes, ericzhang08, false) failed","time":"2020-08-26T17:02:54Z"} 
```

/assign @mrbobbytables 