### PR TITLE
add jhvhs to sig-service-catalog-maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-service-catalog/teams.yaml
+++ b/config/kubernetes-sigs/sig-service-catalog/teams.yaml
@@ -16,6 +16,7 @@ teams:
     members:
     - carolynvs
     - jberkhahn
+    - jhvhs
     - mhbauer
     - mszostok
     - piotrmiskiewicz


### PR DESCRIPTION
Add jhvhs as a maintainer on SIG Service Catalog.

/cc @mszostok 