### PR TITLE
remove mcs-api-admins team from sig service catalog teams

### DIFF
--- a/config/kubernetes-sigs/sig-multicluster/teams.yaml
+++ b/config/kubernetes-sigs/sig-multicluster/teams.yaml
@@ -36,3 +36,9 @@ teams:
     - quinton-hoole
     - shashidharatd
     privacy: closed
+  mcs-api-admins:
+    description: Admin access to the mcs-api repo
+    members:
+    - JeremyOT
+    - pmorie
+    privacy: closed

--- a/config/kubernetes-sigs/sig-service-catalog/teams.yaml
+++ b/config/kubernetes-sigs/sig-service-catalog/teams.yaml
@@ -1,10 +1,4 @@
 teams:
-  mcs-api-admins:
-    description: Admin access to the mcs-api repo
-    members:
-    - JeremyOT
-    - pmorie
-    privacy: closed
   service-catalog-admins:
     description: Admin access to the service-catalog repo
     members:


### PR DESCRIPTION
This team was added to SIG Service Catalog in error. I think it's supposed to be part of SIG multicluster, but I'm not really sure. I can edit the PR to add it to there if that is in fact where it's supposed to be.

/cc @pmorie 
/cc @JeremyOT