### PR TITLE
Remove makoscafee from docs teams

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -23,7 +23,6 @@ teams:
     - jimangel
     - kbarnard10
     - kbhawkey
-    - makoscafee
     - onlydole
     - sftim
     - steveperry-53
@@ -45,7 +44,6 @@ teams:
     - jimangel
     - kbarnard10
     - kbhawkey
-    - makoscafee
     - onlydole
     - Rajakavitha1
     - sftim
@@ -227,7 +225,6 @@ teams:
     - jimangel
     - kbarnard10
     - kbhawkey
-    - makoscafee
     - mistyhacks
     - Rajakavitha1
     - steveperry-53
@@ -376,7 +373,6 @@ teams:
     - jygastaud
     - kbarnard10
     - lledru
-    - MAKOSCAFEE
     - msheldyakov
     - nasa9084
     - ngtuna


### PR DESCRIPTION
This PR removes @makoscafee from SIG Docs teams by updating k/org with changes from https://github.com/kubernetes/website/pull/23631.

/assign @jimangel @kbarnard10 