### PR TITLE
Add Shell32-natsu as a member of kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -443,6 +443,7 @@ members:
 - shashidharatd
 - shawn-hurley
 - sheerun
+- Shell32-Natsu
 - shivi28
 - shu-mutou
 - sidharthsurana


### PR DESCRIPTION
Hi, according to this [guide](https://github.com/kubernetes/community/blob/master/community-membership.md#kubernetes-ecosystem) I open this PR to add myself to kubernetes sigs org to 

- PRs reviewed / authored
  - https://github.com/kubernetes-sigs/kustomize/pulls?q=is%3Apr+is%3Aclosed+author%3AShell32-Natsu
- Issues responded to
  - https://github.com/kubernetes-sigs/kustomize/issues?q=is%3Aissue+mentions%3A%40me+
- SIG projects I am involved with
  - kustomize