### PR TITLE
Remove inactive members

### DIFF
--- a/config/kubernetes/provider-aws/teams.yaml
+++ b/config/kubernetes/provider-aws/teams.yaml
@@ -2,14 +2,11 @@ teams:
   provider-aws-misc:
     description: ""
     members:
-    - d-nishi
-    - jsafrane
-    - kris-nova
-    - leakingtapan
-    - mcrute
+    - andrewsykim
+    - justinsb
     - micahhausler
     - nckturner
-    - sethpollack
+    - wongma7
     privacy: closed
     previously:
     - sig-aws-misc

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -30,7 +30,6 @@ teams:
     - chrigl # OpenStack
     - cpanato # Release Manager
     - craiglpeters # Azure
-    - d-nishi # AWS
     - dashpole # Instrumentation
     - dcbw # Network
     - dchen1107 # Node
@@ -68,7 +67,6 @@ teams:
     - khenidak # Azure
     - kikisdeliveryservice # 1.20 RT Enhancements Lead
     - kow3ns # Apps
-    - kris-nova # AWS
     - lavalamp # API Machinery
     - liggitt # Auth / Release
     - lingxiankong # OpenStack
@@ -86,6 +84,7 @@ teams:
     - msau42 # Storage
     - mszostok # Service Catalog
     - mwielgus # Autoscaling
+    - nckturner # AWS
     - neolit123 # Cluster Lifecycle
     - oxddr # Scalability
     - palnabarun # 1.20 RT Lead Shadow


### PR DESCRIPTION
Remove inactive members and add new members.
    
Inactive is defined as:
- no recent contributions to the AWS cloud provider
- not attending sig-cloud-provider meetings
- not attenting provider-aws meetings
    
Adding team members from AWS and/or sig-cloud-provider:
- @wongma7
- @nckturner
- @andrewsykim


/cc @andrewsykim @cheftako 