### PR TITLE
Remove wg-machine-learning from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -119,10 +119,6 @@ aliases:
     - quinton-hoole
     - tpepper
     - youngnick
-  wg-machine-learning-leads:
-    - k82cn
-    - kow3ns
-    - vishh
   wg-multitenancy-leads:
     - srampal
     - tashimi


### PR DESCRIPTION
wg-machine-learning has been retired

ref: https://github.com/kubernetes/community/issues/5034