### PR TITLE
sig-release: Update Release Manager groups

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -326,6 +326,7 @@ members:
 - mirwan
 - misterikkit
 - mkimuram
+- mkorbi
 - mkumatag
 - Monkeyanator
 - monopole

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -53,6 +53,7 @@ teams:
     - cpanato # Release Manager
     - dougm # Release Manager
     - feiskyer # Release Manager
+    - gianarb # Release Manager Associate
     - hasheddan # Release Manager
     - hoegaarden # subproject owner / Release Manager
     - idealhack # Release Manager
@@ -60,6 +61,9 @@ teams:
     - justaugustus # subproject owner / Build Admin / Release Manager
     - listx # Build Admin / Image promoter admin
     - markyjackson-taulia # Release Manager Associate
+    - mkorbi # Release Manager Associate
+    - onlydole # Release Manager Associate
+    - puerco # Release Manager Associate
     - saschagrunert # Release Manager
     - sethmccombs # Release Manager Associate
     - tpepper # subproject owner / Build Admin / Release Manager

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -64,7 +64,7 @@ teams:
     - sethmccombs # Release Manager Associate
     - tpepper # subproject owner / Build Admin / Release Manager
     - Verolop # Release Manager Associate
-    - xmudrii # Release Manager Associate
+    - xmudrii # Release Manager
     - yodahekinsew # Image promoter contributor (ref: https://github.com/kubernetes/org/pull/1938)
     privacy: closed
   release-notes-admins:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -46,6 +46,7 @@ teams:
     - floreks # UI
     - foxish # Big Data
     - frapposelli # VMware
+    - gianarb # Release Manager Associate
     - hasheddan # Release Manager / 1.20 RT Lead Shadow
     - hoegaarden # Release Manager
     - hpandeycodeit # Usability
@@ -82,17 +83,20 @@ teams:
     - mborsz # Scalability
     - michmike # Windows
     - mikedanese # Auth
+    - mkorbi # Release Manager Associate
     - mm4tt # Scalability
     - msau42 # Storage
     - mszostok # Service Catalog
     - mwielgus # Autoscaling
     - neolit123 # Cluster Lifecycle
+    - onlydole # Release Manager Associate
     - oxddr # Scalability
     - palnabarun # 1.20 RT Lead Shadow
     - parispittman # ContribEx
     - phillels # ContribEx
     - pmorie # Multicluster
     - prydonius # Apps
+    - puerco # Release Manager Associate
     - pwittrock # CLI
     - quinton-hoole # Multicluster
     - RainbowMango # Instrumentation
@@ -179,6 +183,7 @@ teams:
         - cpanato # Release Manager
         - dougm # Release Manager
         - feiskyer # Release Manager
+        - gianarb # Release Manager Associate
         - hasheddan # Release Manager
         - hoegaarden # subproject owner / Release Manager
         - idealhack # Release Manager
@@ -186,7 +191,10 @@ teams:
         - justaugustus # subproject owner / Build Admin / Release Manager
         - listx # Build Admin
         - markyjackson-taulia # Release Manager Associate
+        - mkorbi # Release Manager Associate
+        - onlydole # Release Manager Associate
         - ps882 # Build Admin
+        - puerco # Release Manager Associate
         - saschagrunert # Release Manager
         - sethmccombs # Release Manager Associate
         - sumitranr # Build Admin

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -117,7 +117,7 @@ teams:
     - vllry # Usability
     - wojtek-t # Scalability
     - xing-yang # Storage
-    - xmudrii # Release Manager Associate
+    - xmudrii # Release Manager
     - zacharysarah # Docs
     privacy: closed
     previously:
@@ -192,7 +192,7 @@ teams:
         - sumitranr # Build Admin
         - tpepper # subproject owner / Build Admin / Release Manager
         - Verolop # Release Manager Associate
-        - xmudrii # Release Manager Associate
+        - xmudrii # Release Manager
         privacy: closed
         teams:
           build-admins:
@@ -230,6 +230,7 @@ teams:
             - k8s-release-robot
             - saschagrunert
             - tpepper
+            - xmudrii
             privacy: closed
             previously:
             - kubernetes-release-managers
@@ -255,6 +256,7 @@ teams:
         - saschagrunert # Release Manager
         - savitharaghunathan # 1.20 RT Lead Shadow
         - tpepper # subproject owner / Release Manager
+        - xmudrii # Release Manager
         privacy: closed
         teams:
           ci-signal:


### PR DESCRIPTION
Part of onboarding issues for @xmudrii, @puerco, @mkorbi, @gianarb, and @onlydole: https://github.com/kubernetes/sig-release/issues/1226, https://github.com/kubernetes/sig-release/issues/1227

/assign @nikhita @mrbobbytables 
/cc  @tpepper @saschagrunert @alejandrox1
cc: @kubernetes/release-engineering 