### PR TITLE
add tanjunchen to sig-docs-zh team

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -252,6 +252,7 @@ teams:
     members:
     - hanjiayao
     - SataQiu
+    - tanjunchen
     - tengqm
     - xiangpengzhao
     - xichengliudui
@@ -264,6 +265,7 @@ teams:
     - idealhack
     - pigletfly
     - SataQiu
+    - tanjunchen
     - tengqm
     - xiangpengzhao
     - xichengliudui
@@ -391,6 +393,7 @@ teams:
     - sftim
     - smana
     - steveperry-53
+    - tanjunchen
     - tengqm
     - tfogo
     - truongnh1992


### PR DESCRIPTION
I want to join the sig-docs-zh team: 

I've become reviewer for zh docs.
I have worked for website for a long time.
So far, I have participated in website pr(460+) and issue (15+).
I hope I can have more permissions to make more contributions to the zh localization of the website.
https://github.com/kubernetes/website/pulls?q=is%3Apr+assignee%3Atanjunchen+is%3Aclosed   196 
https://github.com/kubernetes/website/pulls?q=is%3Apr+author%3Atanjunchen+is%3Aclosed  106
https://github.com/kubernetes/website/pulls?q=is%3Apr+reviewed-by%3A%40me+    132
https://github.com/kubernetes/website/issues?q=is%3Aopen+is%3Aissue++tanjunchen+  16 
such as https://github.com/kubernetes/website/issues/17649、https://github.com/kubernetes/website/issues/18411

/cc @tengqm 