### PR TITLE
Adding Daneyon as a Service APIs maintainer

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -107,6 +107,7 @@ teams:
     description: Write access to the service-apis repo
     members:
     - bowei
+    - danehans
     - hbagdi
     - jpeach
     - robscott


### PR DESCRIPTION
This is a follow up to https://github.com/kubernetes/org/pull/2118. 

/sig network
/cc @danehans @hbagdi @jpeach
/assign @bowei