### PR TITLE
SIG Docs chair transition 2020

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -39,12 +39,12 @@ aliases:
     - mrbobbytables
     - nikhita
   sig-docs-leads:
+    - irvifa
     - jimangel
     - kbarnard10
     - kbhawkey
     - onlydole
     - sftim
-    - zacharysarah
   sig-instrumentation-leads:
     - brancz
     - dashpole

--- a/config/kubernetes-sigs/sig-docs/teams.yaml
+++ b/config/kubernetes-sigs/sig-docs/teams.yaml
@@ -2,9 +2,9 @@ teams:
   reference-docs-admins:
     description: admin access to the reference-docs repo
     members:
+    - irvifa
     - jimangel
     - kbarnard10
-    - zacharysarah
     privacy: closed
   reference-docs-maintainers:
     description: write access to the reference-docs repo

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -53,7 +53,6 @@ teams:
     - stewart-yu
     - tengqm
     - xiangpengzhao
-    - zacharysarah
     - zparnold
     privacy: closed
   sig-docs-es-owners:
@@ -181,12 +180,12 @@ teams:
   sig-docs-leads:
     description: Chairs and tech leads for SIG Docs
     members:
+    - irvifa
     - jimangel
     - kbarnard10
     - kbhawkey
     - onlydole
     - sftim
-    - zacharysarah
     privacy: closed
   sig-docs-pl-owners:
     description: Approvers for Polish content
@@ -307,9 +306,9 @@ teams:
     previously:
     - kubernetes-website-admins
     members:
+    - irvifa
     - jimangel
     - kbarnard10
-    - zacharysarah
     privacy: closed
   website-maintainers:
     description: Write access to the website repo


### PR DESCRIPTION
ref: https://github.com/kubernetes/website/issues/23797

## 🟢 OK TO MERGE 🟢 

Don't merge this PR until all conditions are true:
- [x] all governance pieces of #23797 are approved
- [x] Date equal to or later than September 15th, 2020

## Description

This PR updates repo permissions and contacts for @irvifa becoming a chair and @zacharysarah transitioning to chair emeritus.

/assign @irvifa @jimangel @kbarnard10 