### PR TITLE
Add 1.20 Release Docs team to website milestone maintainer team

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -355,6 +355,7 @@ teams:
     - abuisine
     - aisonaku
     - alexbrand
+    - annajung # 1.20 RT Docs Lead
     - awkif
     - bene2k1
     - bradtopol
@@ -362,6 +363,7 @@ teams:
     - claudiajkang
     - cstoku
     - dianaabv
+    - eagleusb # 1.20 RT Docs Shadow
     - femrtnz
     - girikuncoro
     - gochist
@@ -374,6 +376,7 @@ teams:
     - juandiegopalomino
     - jygastaud
     - kbarnard10
+    - kcmartin # 1.20 RT Docs Shadow
     - lledru
     - msheldyakov
     - nasa9084
@@ -387,11 +390,13 @@ teams:
     - rbenzair
     - rekcah78
     - remyleone
+    - reylejano-rxm # 1.20 RT Docs Shadow
     - rlenferink
     - SataQiu
     - savitharaghunathan
     - sftim
     - smana
+    - somtochiama # 1.20 RT Docs Shadow
     - steveperry-53
     - tanjunchen
     - tengqm


### PR DESCRIPTION
As part of the onboarding process for the 1.20 release team, adding 1.20 Docs Shadows and Lead to website milestone maintainers
/sig docs
cc @reylejano-rxm @SomtochiAma @eagleusb @kcmartin 

/assign @jimangel @sftim @irvifa 