### PR TITLE
Add Chris Kim as Krew maintainer

### DIFF
--- a/config/kubernetes-sigs/sig-cli/teams.yaml
+++ b/config/kubernetes-sigs/sig-cli/teams.yaml
@@ -35,6 +35,7 @@ teams:
     members:
     - ahmetb
     - corneliusweig
+    - chriskim06
     - pwittrock
     - seans3
     - soltysh
@@ -44,6 +45,7 @@ teams:
     members:
     - ahmetb
     - corneliusweig
+    - chriskim06
     - pwittrock
     - seans3
     - soltysh
@@ -53,6 +55,7 @@ teams:
     members:
     - ahmetb
     - corneliusweig
+    - chriskim06
     - pwittrock
     - seans3
     - soltysh
@@ -62,6 +65,7 @@ teams:
     members:
     - ahmetb
     - corneliusweig
+    - chriskim06
     - pwittrock
     - seans3
     - soltysh

--- a/config/kubernetes-sigs/sig-cli/teams.yaml
+++ b/config/kubernetes-sigs/sig-cli/teams.yaml
@@ -34,8 +34,8 @@ teams:
     description: admin access to krew
     members:
     - ahmetb
-    - corneliusweig
     - chriskim06
+    - corneliusweig
     - pwittrock
     - seans3
     - soltysh
@@ -44,8 +44,8 @@ teams:
     description: write access to krew
     members:
     - ahmetb
-    - corneliusweig
     - chriskim06
+    - corneliusweig
     - pwittrock
     - seans3
     - soltysh
@@ -54,8 +54,8 @@ teams:
     description: admin access to krew-index
     members:
     - ahmetb
-    - corneliusweig
     - chriskim06
+    - corneliusweig
     - pwittrock
     - seans3
     - soltysh
@@ -64,8 +64,8 @@ teams:
     description: write access to krew-index
     members:
     - ahmetb
-    - corneliusweig
     - chriskim06
+    - corneliusweig
     - pwittrock
     - seans3
     - soltysh


### PR DESCRIPTION
Chris has been taking on a pretty active role in Krew over the past 6 months. He was the primary driver of implementing decentralized plugin repositories in krew ([meta-issue](https://github.com/kubernetes-sigs/krew/issues/566), [issues & PRs](https://github.com/kubernetes-sigs/krew/issues?q=label%3Aarea%2Fmulti-index+author%3Achriskim06+)).
Since the successful launch of this feature he continued his work on krew through PR reviews and [fixes](https://github.com/kubernetes-sigs/krew/issues?q=author%3Achriskim06+created%3A%3E%3D2020-08-19+).

Chris should therefore have maintainer rights for krew, so that he can continue his work more efficiently.

@chriskim06
@ahmetb