### PR TITLE
sig-architecture: Update Enhancements teams

### DIFF
--- a/config/kubernetes/sig-architecture/teams.yaml
+++ b/config/kubernetes/sig-architecture/teams.yaml
@@ -43,6 +43,7 @@ teams:
     - johnbelamaric # subproject owner / 1.19 RT Enhancements Shadow
     - justaugustus # subproject owner
     - kikisdeliveryservice # 1.19 RT Enhancements Shadow
+    - LappleApple # subproject owner
     - msedzins # 1.19 RT Enhancements Shadow
     - palnabarun # 1.19 RT Enhancements Lead
     privacy: closed
@@ -55,6 +56,7 @@ teams:
         - jeremyrickard # subproject owner
         - johnbelamaric # subproject owner
         - justaugustus # subproject owner
+        - LappleApple # subproject owner
         privacy: closed
       enhancements-maintainers:
         description: Contributors with write access to k/enhancements
@@ -64,6 +66,7 @@ teams:
         - jeremyrickard # subproject owner
         - johnbelamaric # subproject owner
         - justaugustus # subproject owner
+        - LappleApple # subproject owner
         previously:
         - features-maintainers
         privacy: closed

--- a/config/kubernetes/sig-architecture/teams.yaml
+++ b/config/kubernetes/sig-architecture/teams.yaml
@@ -38,14 +38,16 @@ teams:
     maintainers:
     - mrbobbytables # subproject owner
     members:
-    - harshanarayana # 1.19 RT Enhancements Shadow
     - jeremyrickard # subproject owner
-    - johnbelamaric # subproject owner / 1.19 RT Enhancements Shadow
+    - johnbelamaric # subproject owner
     - justaugustus # subproject owner
-    - kikisdeliveryservice # 1.19 RT Enhancements Shadow
+    - kendallroden # 1.20 Enhancements Shadow
+    - kikisdeliveryservice # 1.20 Enhancements Lead
+    - kinarashah # 1.20 Enhancements Shadow
     - LappleApple # subproject owner
-    - msedzins # 1.19 RT Enhancements Shadow
-    - palnabarun # 1.19 RT Enhancements Lead
+    - mikejoh # 1.20 Enhancements Shadow
+    - MorrisLaw # 1.20 Enhancements Shadow
+    - palnabarun
     privacy: closed
     teams:
       enhancements-admins:


### PR DESCRIPTION
- Add Lauri Apple as an Enhancements subproject owner
- Update Enhancements teams for 1.20 release cycle

/assign @dims @johnbelamaric @derekwaynecarr 
cc: @kubernetes/enhancements @LappleApple @kikisdeliveryservice 

ref: https://groups.google.com/g/kubernetes-sig-architecture/c/_LcElBQ0uc8, https://kubernetes.slack.com/archives/C5P3FE08M/p1601585313029600, https://github.com/kubernetes/enhancements/pull/2077