### PR TITLE
steering: update OWNERS_ALIASES and teams

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -162,10 +162,10 @@ aliases:
     - cblecker
     - derekwaynecarr
     - dims
-    - lachie83
+    - liggitt
+    - mrbobbytables
     - nikhita
     - parispittman
-    - spiffxp
 ## BEGIN CUSTOM CONTENT
   provider-aws:
     - d-nishi

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1762,12 +1762,12 @@ teams:
     description: Kubernetes Steering Committee
     maintainers:
     - cblecker
+    - mrbobbytables
     - nikhita
-    - spiffxp
     members:
     - derekwaynecarr
     - dims
-    - lachie83
+    - liggitt
     - parispittman
     privacy: closed
   ubuntu-image:


### PR DESCRIPTION
Update membership with the results of the 2020 SC election.

/committee steering

ref: https://github.com/kubernetes/steering/issues/180