### PR TITLE
sig-release: Update container-image-promoter teams

### DIFF
--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -20,21 +20,21 @@ teams:
   k8s-container-image-promoter-admins:
     description: admin access to k8s-container-image-promoter
     members:
-    - calebamiles
     - dims
-    - hh
     - justaugustus
+    - justinsb
     - listx
+    - saschagrunert
     - tpepper
     privacy: closed
   k8s-container-image-promoter-maintainers:
     description: write access to k8s-container-image-promoter
     members:
-    - calebamiles
     - dims
-    - hh
     - justaugustus
+    - justinsb
     - listx
+    - saschagrunert
     - tpepper
     privacy: closed
   mdtoc-admins:


### PR DESCRIPTION
- Remove Caleb, HH
- Add Justin SB, Sascha

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

Part of CIP repo improvements: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/266

/assign @saschagrunert @tpepper 
cc: @listx @kubernetes/release-engineering 