### PR TITLE
Promote NMCs to approvers for active orgs

### DIFF
--- a/config/kubernetes-client/OWNERS
+++ b/config/kubernetes-client/OWNERS
@@ -11,5 +11,8 @@ approvers:
   - mrbobbytables
   - nikhita
   - spiffxp
+  - ameukam
+  - palnabarun
+  - savitharaghunathan
 emeritus_approvers:
   - calebamiles

--- a/config/kubernetes-csi/OWNERS
+++ b/config/kubernetes-csi/OWNERS
@@ -11,5 +11,8 @@ approvers:
   - mrbobbytables
   - nikhita
   - spiffxp
+  - ameukam
+  - palnabarun
+  - savitharaghunathan
 emeritus_approvers:
   - calebamiles

--- a/config/kubernetes-sigs/OWNERS
+++ b/config/kubernetes-sigs/OWNERS
@@ -11,5 +11,8 @@ approvers:
   - mrbobbytables
   - nikhita
   - spiffxp
+  - ameukam
+  - palnabarun
+  - savitharaghunathan
 emeritus_approvers:
   - calebamiles

--- a/config/kubernetes/OWNERS
+++ b/config/kubernetes/OWNERS
@@ -11,5 +11,8 @@ approvers:
   - mrbobbytables
   - nikhita
   - spiffxp
+  - ameukam
+  - palnabarun
+  - savitharaghunathan
 emeritus_approvers:
   - calebamiles


### PR DESCRIPTION
The current New Membership Coordinators have been _amazing_ at working through all the incoming membership requests. They've also been very careful around adding new members and have not been hesitant to ask questions when in doubt.

I think it's time we promote @ameukam @palnabarun and @savitharaghunathan to approvers! :tada: :tada: :tada: 

We also discussed this in the GitHub Management today and there were lots of +1s!

/hold
for ack by other approvers

/cc @kubernetes/owners 
/assign @cblecker @mrbobbytables @spiffxp 

