### PR TITLE
Update SIG Release teams

### DIFF
--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -49,27 +49,24 @@ teams:
     description: Members of the Release Engineering subproject, including
       Release Managers and Release Manager Associates.
     members:
-    - calebamiles # subproject owner
     - cpanato # Release Manager
     - dougm # Release Manager
     - feiskyer # Release Manager
     - gianarb # Release Manager Associate
     - hasheddan # Release Manager
-    - hoegaarden # subproject owner / Release Manager
+    - hoegaarden # Release Manager
     - idealhack # Release Manager
     - jimangel # Release Manager Associate
-    - justaugustus # subproject owner / Build Admin / Release Manager
-    - listx # Build Admin / Image promoter admin
+    - justaugustus # subproject owner / Release Manager
     - markyjackson-taulia # Release Manager Associate
     - mkorbi # Release Manager Associate
     - onlydole # Release Manager Associate
     - puerco # Release Manager Associate
-    - saschagrunert # Release Manager
+    - saschagrunert # subproject owner / Release Manager
     - sethmccombs # Release Manager Associate
-    - tpepper # subproject owner / Build Admin / Release Manager
+    - tpepper # subproject owner / Release Manager
     - Verolop # Release Manager Associate
     - xmudrii # Release Manager
-    - yodahekinsew # Image promoter contributor (ref: https://github.com/kubernetes/org/pull/1938)
     privacy: closed
   release-notes-admins:
     description: admin access to release-notes

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -17,26 +17,32 @@ teams:
     - saschagrunert
     - tpepper
     privacy: closed
-  k8s-container-image-promoter-admins:
+  image-promoter-admins:
     description: admin access to k8s-container-image-promoter
     members:
-    - dims
-    - justaugustus
-    - justinsb
-    - listx
-    - saschagrunert
-    - tpepper
+    - justaugustus # subproject owner / maintainer
+    - justinsb # maintainer
+    - listx # maintainer
+    - saschagrunert # subproject owner
+    - tpepper # subproject owner
     privacy: closed
-  k8s-container-image-promoter-maintainers:
+    previously:
+    - k8s-container-image-promoter-admins
+  image-promoter-maintainers:
     description: write access to k8s-container-image-promoter
+    maintainers:
+    - spiffxp # WG K8s Infra Lead
     members:
-    - dims
-    - justaugustus
-    - justinsb
-    - listx
-    - saschagrunert
-    - tpepper
+    - bartsmykla # WG K8s Infra Lead
+    - dims # WG K8s Infra Lead
+    - justaugustus # subproject owner / maintainer
+    - justinsb # maintainer
+    - listx # maintainer
+    - saschagrunert # subproject owner
+    - tpepper # subproject owner
     privacy: closed
+    previously:
+    - k8s-container-image-promoter-maintainers
   mdtoc-admins:
     description: admin access to mdtoc
     members:

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -84,7 +84,6 @@ teams:
   release-notes-maintainers:
     description: write access to release-notes
     members:
-    - calebamiles
     - jeefy
     - justaugustus
     - marpaia

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -23,7 +23,6 @@ teams:
     - bgrant0607 # Architecture
     - bradamant3 # Docs
     - brancz # Instrumentation
-    - calebamiles # Release / PM
     - cantbewong # VMware
     - caseydavenport # Network
     - cheftako # Cloud Provider
@@ -147,7 +146,6 @@ teams:
     members:
     - alenkacz
     - BenTheElder
-    - calebamiles
     - castrojo
     - dims
     - ixdy

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -180,27 +180,22 @@ teams:
         description: Members of the Release Engineering subproject, including
           Release Managers, Release Manager Associates, and Build Admins.
         members:
-        - aleksandra-malinowska # Build Admin
-        - calebamiles # subproject owner
         - cpanato # Release Manager
         - dougm # Release Manager
         - feiskyer # Release Manager
         - gianarb # Release Manager Associate
         - hasheddan # Release Manager
-        - hoegaarden # subproject owner / Release Manager
+        - hoegaarden # Release Manager
         - idealhack # Release Manager
         - jimangel # Release Manager Associate
-        - justaugustus # subproject owner / Build Admin / Release Manager
-        - listx # Build Admin
+        - justaugustus # subproject owner / Release Manager
         - markyjackson-taulia # Release Manager Associate
         - mkorbi # Release Manager Associate
         - onlydole # Release Manager Associate
-        - ps882 # Build Admin
         - puerco # Release Manager Associate
-        - saschagrunert # Release Manager
+        - saschagrunert # subproject owner / Release Manager
         - sethmccombs # Release Manager Associate
-        - sumitranr # Build Admin
-        - tpepper # subproject owner / Build Admin / Release Manager
+        - tpepper # subproject owner / Release Manager
         - Verolop # Release Manager Associate
         - xmudrii # Release Manager
         privacy: closed
@@ -209,19 +204,15 @@ teams:
             description: Kubernetes Build Admins are the current set of
               Googlers with access to publish packages (debs/rpms) on behalf of
               the Kubernetes project. This team is a notification-only group,
-              which includes the SIG Release Chairs for continuity.
+              which includes the SIG Release Chairs/TLs for continuity.
             maintainers:
             - spiffxp
             members:
-            - aleksandra-malinowska
             - amwat
             - BenTheElder
-            - calebamiles
             - justaugustus
-            - listx
             - MushuEE
-            - ps882
-            - sumitranr
+            - saschagrunert
             - tpepper
             privacy: closed
           release-managers:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -137,13 +137,16 @@ teams:
     - mfojtik
     - sttts
     privacy: closed
-  sig-release: # explicitly lists active folks that are not already members of a nested team
-    description: SIG Release Members
+  sig-release:
+    description: SIG Release members. Explicitly lists SIG Release Chairs,
+      Technical Leads, Program Managers, and any active SIG contributors that
+      are not already members of a nested team.
     maintainers:
     - mrbobbytables
     - nikhita
     - spiffxp
     members:
+    - alejandrox1 # Technical Lead
     - alenkacz
     - BenTheElder
     - castrojo
@@ -153,16 +156,18 @@ teams:
     - jdumars
     - jeefy
     - jeremyrickard
-    - justaugustus
+    - justaugustus # Chair
+    - LappleApple # Program Manager
     - liggitt
     - mariantalla
     - nikopen
     - onyiny-ang
     - palnabarun
     - rawkode
+    - saschagrunert # Technical Lead
     - savitharaghunathan
     - soggiest
-    - tpepper
+    - tpepper # Chair
     privacy: closed
     teams:
       licensing:
@@ -292,28 +297,28 @@ teams:
       sig-release-admins:
         description: Admins for SIG Release repositories
         members:
-        - alejandrox1
-        - justaugustus
-        - saschagrunert
-        - tpepper
+        - alejandrox1 # Technical Lead
+        - justaugustus # Chair
+        - saschagrunert # Technical Lead
+        - tpepper # Chair
         privacy: closed
       sig-release-leads:
         description: |
           Chairs, Technical Leads, and Program Managers for SIG Release
         members:
-        - alejandrox1
-        - justaugustus
-        - LappleApple
-        - saschagrunert
-        - tpepper
+        - alejandrox1 # Technical Lead
+        - justaugustus # Chair
+        - LappleApple # Program Manager
+        - saschagrunert # Technical Lead
+        - tpepper # Chair
         privacy: closed
       sig-release-pms:
         description: |
           Grants access to maintain SIG Release project boards
         members:
-        - alejandrox1
-        - justaugustus
-        - LappleApple
-        - saschagrunert
-        - tpepper
+        - alejandrox1 # Technical Lead
+        - justaugustus # Chair
+        - LappleApple # Program Manager
+        - saschagrunert # Technical Lead
+        - tpepper # Chair
         privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -244,7 +244,6 @@ teams:
         - alejandrox1 # subproject owner
         - annajung # 1.20 RT Docs Lead
         - bai # 1.20 RT Bug Triage Lead
-        - claurence # subproject owner
         - cpanato # Release Manager
         - eagleusb # 1.20 RT Docs Shadow
         - eddiezane # 1.20 RT CI Signal Shadow 


### PR DESCRIPTION
- Update membership for @kubernetes/release-engineering teams
- Update image promoter teams
  - Simplify image promoter team names
  - Add comments on members
  - Restrict repo admin to RelEng subproject owners + repo maintainers
  - Include all WG K8s Infra leads in maintainers team
- Drop Caleb's remaining privs
- Update member comments on top-level SIG teams
- Rotate previous RT subproject owners

/assign @saschagrunert @hasheddan @cpanato @xmudrii 
cc: @kubernetes/sig-release-leads @kubernetes/release-team-leads 

Companion to https://github.com/kubernetes/sig-release/pull/1303 and https://github.com/kubernetes/release/pull/1656.