### PR TITLE
Temporary admin permissions to set up a site in Netlify

### DIFF
--- a/config/kubernetes-sigs/sig-cli/teams.yaml
+++ b/config/kubernetes-sigs/sig-cli/teams.yaml
@@ -6,6 +6,7 @@ teams:
     - pwittrock
     - seans3
     - soltysh
+    - zacharysarah # temporary, remove after 15 Nov 2020
     privacy: closed
   cli-experimental-maintainers:
     description: write access to cli-experimental


### PR DESCRIPTION
Opened in consultation with @pwittrock. 

This PR gives me admin rights to the `cli-experimental` repo in order to set up a custom domain for the repo in Netlify.

Permissions are temporary and should be removed no later than 15 November 2020.

/assign @pwittrock 