### PR TITLE
Remove myself as a SIG CLI admin

### DIFF
--- a/config/kubernetes-sigs/sig-cli/teams.yaml
+++ b/config/kubernetes-sigs/sig-cli/teams.yaml
@@ -6,7 +6,6 @@ teams:
     - pwittrock
     - seans3
     - soltysh
-    - zacharysarah # temporary, remove after 15 Nov 2020
     privacy: closed
   cli-experimental-maintainers:
     description: write access to cli-experimental


### PR DESCRIPTION
With the Netlify site integration added and a [PR opened to add the site](https://github.com/kubernetes/org/pull/2287), I'm removing myself from SIG CLI admins [as specified](https://github.com/kubernetes/org/pull/2286). 

/assign @pwittrock 