### PR TITLE
sig-release: Add n3wscott to zeitgeist-maintainers

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -358,6 +358,7 @@ members:
 - MushuEE
 - mylesagray
 - mytunguyen
+- n3wscott
 - nader-ziada
 - nan-yu
 - ncdc

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -103,6 +103,7 @@ teams:
     members:
     - alejandrox1
     - justaugustus
+    - n3wscott
     - Pluies
     - saschagrunert
     - tpepper


### PR DESCRIPTION
- Add n3wscott to kubernetes-sigs org (fixes: https://github.com/kubernetes/org/issues/2299)
- sig-release: Add n3wscott to zeitgeist-maintainers

cc: @n3wscott @kubernetes/release-engineering 