### PR TITLE
Update SIG-docs-ja reviewers

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -152,9 +152,9 @@ teams:
     members:
     - bells17
     - inductor
+    - kakts
     - makocchi-git
     - nasa9084
-    - oke-py
     privacy: closed
   sig-docs-ko-owners:
     description: Approvers for Korean content


### PR DESCRIPTION
Updated teams.yaml according to OWNER_ALIAS on k/website.
https://github.com/kubernetes/website/pull/24922

@kakts is already an org member so there's no issue for this PR.