### PR TITLE
Replace skilxn-go with Ye-Tian-Zero

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -931,7 +931,6 @@ members:
 - sjenning
 - sjpotter
 - sjug
-- skilxn-go
 - SlickNik
 - Smana
 - smarterclayton
@@ -1056,6 +1055,7 @@ members:
 - YangLu1031
 - yastij
 - ydcool
+- Ye-Tian-Zero
 - yguo0905
 - yifan-gu
 - yissachar


### PR DESCRIPTION
This fixes peribolos: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-org-peribolos/1324535322997952512

The GitHub user https://github.com/skilxn-go renamed their username to @Ye-Tian-Zero. The rename broke peribolos. 
Ref: https://github.com/kubernetes/org/issues/1607 

/assign @palnabarun 
fyi @Ye-Tian-Zero