### PR TITLE
Moving windows-testing admin/maintainer groups under sig-windows/teams.yaml

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -685,17 +685,3 @@ teams:
     - msau42
     - saad-ali
     privacy: closed
-  windows-testing-admins:
-    description: Admin access to the windows-testing repo
-    members:
-    - adelina-t
-    - michmike
-    - PatrickLang
-    privacy: closed
-  windows-testing-maintainers:
-    description: Write access to the windows-testing repo
-    members:
-    - adelina-t
-    - michmike
-    - PatrickLang
-    privacy: closed

--- a/config/kubernetes-sigs/sig-windows/teams.yaml
+++ b/config/kubernetes-sigs/sig-windows/teams.yaml
@@ -43,3 +43,18 @@ teams:
     - jsturtevant
     - michmike
     privacy: closed
+  windows-testing-admins:
+    description: Admin access to the windows-testing repo
+    members:
+    - adelina-t
+    - marosset
+    - michmike
+    privacy: closed
+  windows-testing-maintainers:
+    description: Write access to the windows-testing repo
+    members:
+    - adelina-t
+    - jsturtevant
+    - marosset
+    - michmike
+    privacy: closed


### PR DESCRIPTION
Moving windows-testing admins/maintainers groups from config/kuberntees-sigs/org.yaml to config/kubernetes-sigs/sig-windows/teams.yaml to keep things tidy.