### PR TITLE
Add dims as k8s maintainer

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1621,6 +1621,7 @@ teams:
     - dchen1107
     - deads2k
     - derekwaynecarr
+    - dims
     - eparis
     - erictune
     - feiskyer


### PR DESCRIPTION
I was wondering why @derekwaynecarr was able to edit my PR to update a release note and i could not edit other's PR and found this group.

Also, we may need to prune this group at some point (cc @kubernetes/owners)

Signed-off-by: Davanum Srinivas <davanum@gmail.com>