### PR TITLE
Update SIG leadership and Release Managers (promotions, new members, retirement)

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -51,8 +51,8 @@ aliases:
     - ehashman
     - logicalhan
   sig-multicluster-leads:
+    - jeremyot
     - pmorie
-    - quinton-hoole
   sig-network-leads:
     - caseydavenport
     - dcbw
@@ -62,9 +62,9 @@ aliases:
     - derekwaynecarr
   sig-release-leads:
     - alejandrox1
+    - hasheddan
     - justaugustus
     - saschagrunert
-    - tpepper
   sig-scalability-leads:
     - mm4tt
     - shyamjvs
@@ -72,6 +72,9 @@ aliases:
   sig-scheduling-leads:
     - Huang-Wei
     - ahg-g
+  sig-security-leads:
+    - iancoldwater
+    - tabbysable
   sig-service-catalog-leads:
     - jberkhahn
     - jhvhs
@@ -102,7 +105,6 @@ aliases:
   wg-component-standard-leads:
     - mtaufen
     - stealthybox
-    - sttts
   wg-data-protection-leads:
     - xing-yang
     - yuxiangqian
@@ -125,6 +127,10 @@ aliases:
   wg-policy-leads:
     - ericavonb
     - hannibalhuang
+  wg-reliability-leads:
+    - deads2k
+    - stevekuznetsov
+    - wojtek-t
   ug-big-data-leads:
     - erikerlandson
     - foxish

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -87,8 +87,6 @@ teams:
     - hasheddan # subproject owner
     - jeefy
     - justaugustus # subproject owner
-    - marpaia
-    - onyiny-ang
     - saschagrunert # subproject owner
     - tpepper # subproject owner
     privacy: closed
@@ -99,8 +97,6 @@ teams:
     - hasheddan # subproject owner
     - jeefy
     - justaugustus # subproject owner
-    - marpaia
-    - onyiny-ang
     - saschagrunert # subproject owner
     - tpepper # subproject owner
     privacy: closed

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -2,29 +2,33 @@ teams:
   downloadkubernetes-admins:
     description: admin access to downloadkubernetes
     members:
-    - alejandrox1
-    - justaugustus
-    - saschagrunert
-    - tpepper
+    - alejandrox1 # subproject owner
+    - hasheddan # subproject owner
+    - justaugustus # subproject owner
+    - saschagrunert # subproject owner
+    - tpepper # subproject owner
     privacy: closed
   downloadkubernetes-maintainers:
     description: write access to downloadkubernetes
     members:
-    - alejandrox1
+    - alejandrox1 # subproject owner
     - chuckha
-    - justaugustus
+    - hasheddan # subproject owner
+    - justaugustus # subproject owner
     - mauilion
-    - saschagrunert
-    - tpepper
+    - saschagrunert # subproject owner
+    - tpepper # subproject owner
     privacy: closed
   image-promoter-admins:
     description: admin access to k8s-container-image-promoter
     members:
+    - alejandrox1 # subproject owner
+    - hasheddan # subproject owner
     - justaugustus # subproject owner / maintainer
-    - justinsb # maintainer
-    - listx # maintainer
     - saschagrunert # subproject owner
     - tpepper # subproject owner
+    - justinsb # maintainer
+    - listx # maintainer
     privacy: closed
     previously:
     - k8s-container-image-promoter-admins
@@ -33,8 +37,10 @@ teams:
     maintainers:
     - spiffxp # WG K8s Infra Lead
     members:
+    - alejandrox1 # subproject owner
     - bartsmykla # WG K8s Infra Lead
     - dims # WG K8s Infra Lead
+    - hasheddan # subproject owner
     - justaugustus # subproject owner / maintainer
     - justinsb # maintainer
     - listx # maintainer
@@ -46,66 +52,76 @@ teams:
   mdtoc-admins:
     description: admin access to mdtoc
     members:
-    - alejandrox1
-    - justaugustus
-    - saschagrunert
-    - tpepper
+    - alejandrox1 # subproject owner
+    - hasheddan # subproject owner
+    - justaugustus # subproject owner
+    - saschagrunert # subproject owner
+    - tpepper # subproject owner
     privacy: closed
   release-engineering:
     description: Members of the Release Engineering subproject, including
       Release Managers and Release Manager Associates.
     members:
+    - ameukam # Release Manager Associate
     - cpanato # Release Manager
-    - dougm # Release Manager
     - feiskyer # Release Manager
     - gianarb # Release Manager Associate
-    - hasheddan # Release Manager
-    - hoegaarden # Release Manager
+    - hasheddan # subproject owner / Release Manager
     - idealhack # Release Manager
     - jimangel # Release Manager Associate
     - justaugustus # subproject owner / Release Manager
     - markyjackson-taulia # Release Manager Associate
     - mkorbi # Release Manager Associate
     - onlydole # Release Manager Associate
-    - puerco # Release Manager Associate
+    - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager
     - sethmccombs # Release Manager Associate
-    - tpepper # subproject owner / Release Manager
+    - tpepper # subproject owner
     - Verolop # Release Manager Associate
     - xmudrii # Release Manager
     privacy: closed
   release-notes-admins:
     description: admin access to release-notes
     members:
+    - alejandrox1 # subproject owner
+    - hasheddan # subproject owner
     - jeefy
+    - justaugustus # subproject owner
     - marpaia
     - onyiny-ang
+    - saschagrunert # subproject owner
+    - tpepper # subproject owner
     privacy: closed
   release-notes-maintainers:
     description: write access to release-notes
     members:
+    - alejandrox1 # subproject owner
+    - hasheddan # subproject owner
     - jeefy
-    - justaugustus
+    - justaugustus # subproject owner
     - marpaia
     - onyiny-ang
-    - tpepper
+    - saschagrunert # subproject owner
+    - tpepper # subproject owner
     privacy: closed
   zeitgeist-admins:
     description: admin access to zeitgeist
     members:
-    - alejandrox1
-    - justaugustus
-    - saschagrunert
-    - tpepper
+    - alejandrox1 # subproject owner
+    - hasheddan # subproject owner
+    - justaugustus # subproject owner
+    - saschagrunert # subproject owner
+    - tpepper # subproject owner
     privacy: closed
   zeitgeist-maintainers:
     description: write access to zeitgeist
     members:
-    - alejandrox1
-    - justaugustus
+    - alejandrox1 # subproject owner
+    - hasheddan # subproject owner
+    - justaugustus # subproject owner
     - n3wscott
     - Pluies
-    - saschagrunert
-    - tpepper
+    - saschagrunert # subproject owner
+    - tpepper # subproject owner
     - yastij
     privacy: closed

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -25,10 +25,10 @@ teams:
     - alejandrox1 # subproject owner
     - hasheddan # subproject owner
     - justaugustus # subproject owner / maintainer
-    - saschagrunert # subproject owner
-    - tpepper # subproject owner
     - justinsb # maintainer
     - listx # maintainer
+    - saschagrunert # subproject owner
+    - tpepper # subproject owner
     privacy: closed
     previously:
     - k8s-container-image-promoter-admins

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -12,7 +12,6 @@ teams:
     - justaugustus
     - MushuEE
     - saschagrunert
-    - tpepper
     privacy: closed
   milestone-maintainers:
     description: Contributors who can use `/milestone` or `/status` commands on
@@ -181,7 +180,7 @@ teams:
     - saschagrunert # Technical Lead
     - savitharaghunathan
     - soggiest
-    - tpepper # Chair
+    - tpepper
     privacy: closed
     teams:
       licensing:
@@ -313,7 +312,6 @@ teams:
         - alejandrox1 # Technical Lead
         - justaugustus # Chair
         - saschagrunert # Technical Lead
-        - tpepper # Chair
         privacy: closed
       sig-release-leads:
         description: |
@@ -323,7 +321,6 @@ teams:
         - justaugustus # Chair
         - LappleApple # Program Manager
         - saschagrunert # Technical Lead
-        - tpepper # Chair
         privacy: closed
       sig-release-pms:
         description: |
@@ -333,5 +330,4 @@ teams:
         - justaugustus # Chair
         - LappleApple # Program Manager
         - saschagrunert # Technical Lead
-        - tpepper # Chair
         privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -52,7 +52,6 @@ teams:
     - deads2k # API Machinery / Auth
     - derekwaynecarr # Architecture / Node
     - dims # Architecture / Release
-    - dougm # Release Manager
     - droslean # 1.20 Bug Triage Shadow
     - ehashman # Instrumentation
     - enj # Auth
@@ -64,7 +63,6 @@ teams:
     - frapposelli # VMware
     - gianarb # Release Manager Associate
     - hasheddan # Release Manager / 1.20 RT Lead Shadow
-    - hoegaarden # Release Manager
     - hpandeycodeit # Usability
     - Huang-Wei # Scheduling
     - idealhack # Release Manager
@@ -201,11 +199,9 @@ teams:
         members:
         - ameukam # Release Manager Associate
         - cpanato # Release Manager
-        - dougm # Release Manager
         - feiskyer # Release Manager
         - gianarb # Release Manager Associate
         - hasheddan # Release Manager
-        - hoegaarden # Release Manager
         - idealhack # Release Manager
         - jimangel # Release Manager Associate
         - justaugustus # subproject owner / Release Manager
@@ -215,7 +211,7 @@ teams:
         - puerco # Release Manager
         - saschagrunert # subproject owner / Release Manager
         - sethmccombs # Release Manager Associate
-        - tpepper # subproject owner / Release Manager
+        - tpepper # subproject owner
         - Verolop # Release Manager Associate
         - xmudrii # Release Manager
         privacy: closed
@@ -227,16 +223,13 @@ teams:
               who are not actively doing this job.
             members:
             - cpanato
-            - dougm
             - feiskyer
             - hasheddan
-            - hoegaarden
             - idealhack
             - justaugustus
             - k8s-release-robot
             - puerco
             - saschagrunert
-            - tpepper
             - xmudrii
             privacy: closed
             previously:
@@ -286,7 +279,7 @@ teams:
         - soniasingla # 1.20 Release Notes Shadow
         - tanjacky # 1.20 Release Notes Shadow
         - thejoycekung # 1.20 CI Signal Shadow
-        - tpepper # subproject owner / Release Manager
+        - tpepper # subproject owner
         - wilsonehusin # 1.20 Release Notes Shadow
         - xmudrii # Release Manager
         privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -9,6 +9,7 @@ teams:
     members:
     - amwat
     - BenTheElder
+    - hasheddan
     - justaugustus
     - MushuEE
     - saschagrunert
@@ -61,7 +62,7 @@ teams:
     - foxish # Big Data
     - frapposelli # VMware
     - gianarb # Release Manager Associate
-    - hasheddan # Release Manager / 1.20 RT Lead Shadow
+    - hasheddan # Release
     - hpandeycodeit # Usability
     - Huang-Wei # Scheduling
     - idealhack # Release Manager
@@ -116,7 +117,7 @@ teams:
     - rajakavitha1 # Usability
     - robertkielty # 1.20 CI Signal Lead
     - saad-ali # Storage
-    - saschagrunert # Release Manager
+    - saschagrunert # Release
     - savitharaghunathan # 1.20 RT Lead Shadow
     - sayanchowdhury # 1.20 Bug Triage Shadow
     - seans3 # CLI
@@ -164,6 +165,7 @@ teams:
     - BenTheElder
     - castrojo
     - dims
+    - hasheddan # Technical Lead
     - ixdy
     - jberkus
     - jdumars
@@ -177,7 +179,7 @@ teams:
     - onyiny-ang
     - palnabarun
     - rawkode
-    - saschagrunert # Technical Lead
+    - saschagrunert # Chair
     - savitharaghunathan
     - soggiest
     - tpepper
@@ -200,7 +202,7 @@ teams:
         - cpanato # Release Manager
         - feiskyer # Release Manager
         - gianarb # Release Manager Associate
-        - hasheddan # Release Manager
+        - hasheddan # subproject owner / Release Manager
         - idealhack # Release Manager
         - jimangel # Release Manager Associate
         - justaugustus # subproject owner / Release Manager
@@ -248,7 +250,7 @@ teams:
         - eddiezane # 1.20 CI Signal Shadow
         - erismaster # 1.20 Bug Triage Shadow
         - guineveresaenger # subproject owner
-        - hasheddan # Release Manager / 1.20 RT Lead Shadow
+        - hasheddan # subproject owner
         - hkamel # 1.20 CI Signal Shadow
         - jameslaverack # 1.20 Release Notes Lead
         - jeremyrickard # 1.20 RT Lead
@@ -269,7 +271,7 @@ teams:
         - reylejano-rxm # 1.20 Docs Shadow
         - robertkielty # 1.20 CI Signal Lead
         - salaxander # 1.20 Communications Shadow
-        - saschagrunert # Release Manager
+        - saschagrunert # subproject owner
         - savitharaghunathan # 1.20 RT Lead Shadow
         - sayanchowdhury # 1.20 Bug Triage Shadow
         - scrapcodes # 1.20 CI Signal Shadow
@@ -300,7 +302,7 @@ teams:
               as a notification group. Remove org members who are not current
               Release Team Leads.
             members:
-            - hasheddan #  1.20 RT Lead Shadow
+            - hasheddan # 1.20 RT Lead Shadow
             - jeremyrickard # 1.20 RT Lead
             - lachie83 # 1.20 Emeritus Adviser
             - palnabarun # 1.20 RT Lead Shadow
@@ -310,24 +312,27 @@ teams:
         description: Admins for SIG Release repositories
         members:
         - alejandrox1 # Technical Lead
+        - hasheddan # Technical Lead
         - justaugustus # Chair
-        - saschagrunert # Technical Lead
+        - saschagrunert # Chair
         privacy: closed
       sig-release-leads:
         description: |
           Chairs, Technical Leads, and Program Managers for SIG Release
         members:
         - alejandrox1 # Technical Lead
+        - hasheddan # Technical Lead
         - justaugustus # Chair
         - LappleApple # Program Manager
-        - saschagrunert # Technical Lead
+        - saschagrunert # Chair
         privacy: closed
       sig-release-pms:
         description: |
           Grants access to maintain SIG Release project boards
         members:
         - alejandrox1 # Technical Lead
+        - hasheddan # Technical Lead
         - justaugustus # Chair
         - LappleApple # Program Manager
-        - saschagrunert # Technical Lead
+        - saschagrunert # Chair
         privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -30,6 +30,7 @@ teams:
     - adisky # OpenStack
     - ahg-g # Scheduling
     - alejandrox1 # Testing
+    - ameukam # Release Manager Associate
     - andrewsykim # Cloud Provider
     - annajung # 1.20 Docs Lead
     - bai # 1.20 Bug Triage Lead
@@ -198,6 +199,7 @@ teams:
         description: Members of the Release Engineering subproject, including
           Release Managers, Release Manager Associates, and Build Admins.
         members:
+        - ameukam # Release Manager Associate
         - cpanato # Release Manager
         - dougm # Release Manager
         - feiskyer # Release Manager

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -111,7 +111,7 @@ teams:
     - phillels # ContribEx
     - pmorie # Multicluster
     - prydonius # Apps
-    - puerco # Release Manager Associate
+    - puerco # Release Manager
     - pwittrock # CLI
     - quinton-hoole # Multicluster
     - RainbowMango # Instrumentation
@@ -210,7 +210,7 @@ teams:
         - markyjackson-taulia # Release Manager Associate
         - mkorbi # Release Manager Associate
         - onlydole # Release Manager Associate
-        - puerco # Release Manager Associate
+        - puerco # Release Manager
         - saschagrunert # subproject owner / Release Manager
         - sethmccombs # Release Manager Associate
         - tpepper # subproject owner / Release Manager
@@ -232,6 +232,7 @@ teams:
             - idealhack
             - justaugustus
             - k8s-release-robot
+            - puerco
             - saschagrunert
             - tpepper
             - xmudrii
@@ -270,6 +271,7 @@ teams:
         - morrislaw # 1.20 Enhancements Shadow
         - onlydole # subproject owner
         - palnabarun # 1.20 RT Lead Shadow
+        - puerco # Release Manager
         - reylejano-rxm # 1.20 Docs Shadow
         - robertkielty # 1.20 CI Signal Lead
         - salaxander # 1.20 Communications Shadow


### PR DESCRIPTION
The access portion of: https://github.com/kubernetes/sig-release/pull/1331

- Promote @puerco to full-fledged Release Manager
- Add @ameukam as Release Manager Associate
- Tim, @hoegaarden, and @dougm retire as Release Managers
- @tpepper is now Emeritus Chair
  ...but remains as subproject owner!
- @hasheddan joins as SIG TL and Senior Release Manager
- @saschagrunert moves from TL to Chair
- Sync SIG Release k-sigs teams from k org config
- Drop inactive maintainers
- OWNERS: Sync aliases from k/community

/assign @cblecker @mrbobbytables 
/cc @saschagrunert @hasheddan 
cc: @kubernetes/sig-release-leads @kubernetes/release-engineering 