### PR TITLE
Fix reylejano's username

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -854,7 +854,7 @@ members:
 - RenaudWasTaken
 - rendhalver
 - resouer
-- reylejano-rxm
+- reylejano
 - rf232
 - rficcaglia
 - Riaankl

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -388,7 +388,7 @@ teams:
     - rbenzair
     - rekcah78
     - remyleone
-    - reylejano-rxm # 1.20 RT Docs Shadow
+    - reylejano # 1.20 RT Docs Shadow
     - rlenferink
     - SataQiu
     - savitharaghunathan

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -269,7 +269,7 @@ teams:
         - onlydole # subproject owner
         - palnabarun # 1.20 RT Lead Shadow
         - puerco # Release Manager
-        - reylejano-rxm # 1.20 Docs Shadow
+        - reylejano # 1.20 Docs Shadow
         - robertkielty # 1.20 CI Signal Lead
         - salaxander # 1.20 Communications Shadow
         - saschagrunert # subproject owner


### PR DESCRIPTION
Fixes https://github.com/kubernetes/org/issues/2348

https://github.com/reylejano-rxm does not exist anymore and they have
changed their username to https://github.com/reylejano.

Ref:
- https://github.com/kubernetes/org/issues/1555
- https://github.com/kubernetes/org/issues/2348

This fixes peribolos - https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-org-peribolos/1332512581797023744

/assign @palnabarun 
fyi @reylejano