### PR TITLE
Add GitHub team for kubectl-check-ownerreferences

### DIFF
--- a/config/kubernetes-sigs/sig-api-machinery/teams.yaml
+++ b/config/kubernetes-sigs/sig-api-machinery/teams.yaml
@@ -153,6 +153,13 @@ teams:
     - mengqiy
     - vincepri
     privacy: closed
+  kubectl-check-ownerreferences-admins:
+    description: Admin access to kubectl-check-ownerreferences
+    members:
+    - caesarxuchao
+    - deads2k
+    - liggitt
+    privacy: closed
   kubernetes/sig-api-machinery:
     description: Parent team for all SIG API Machinery subteams (approvers, reviewers,
       admins)


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2350

Adding just the admins team because the list of folks with admin and write access is the same.

/assign @mrbobbytables 