### PR TITLE
Add Pensu to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -388,6 +388,7 @@ members:
 - pasqualet
 - PatrickLang
 - pbnj
+- Pensu
 - phanimarupaka
 - phenixblue
 - philips


### PR DESCRIPTION
Needed for https://github.com/kubernetes-sigs/contributor-tweets/pull/30  They are already a member of @kubernetes and also part of the contribex marketing sub-project

/assign @Pensu 