### PR TITLE
Remove 1.20 shadows from sig docs teams

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -313,7 +313,6 @@ teams:
     members:
     - aisonaku # L10n: Russian
     - alexbrand # L10n: Spanish
-    - annajung # 1.20 RT Docs Lead temporary access for the release
     - Bradamant3 # L10n: English
     - bradtopol # L10n: English
     - ClaudiaJKang # L10n: Korean
@@ -354,7 +353,7 @@ teams:
     - abuisine
     - aisonaku
     - alexbrand
-    - annajung # 1.20 RT Docs Lead
+    - annajung
     - awkif
     - bene2k1
     - bradtopol
@@ -362,7 +361,6 @@ teams:
     - claudiajkang
     - cstoku
     - dianaabv
-    - eagleusb # 1.20 RT Docs Shadow
     - femrtnz
     - girikuncoro
     - gochist
@@ -375,7 +373,6 @@ teams:
     - juandiegopalomino
     - jygastaud
     - kbarnard10
-    - kcmartin # 1.20 RT Docs Shadow
     - lledru
     - msheldyakov
     - nasa9084
@@ -389,13 +386,12 @@ teams:
     - rbenzair
     - rekcah78
     - remyleone
-    - reylejano # 1.20 RT Docs Shadow
+    - reylejano # 1.21 RT Docs Lead
     - rlenferink
     - SataQiu
     - savitharaghunathan
     - sftim
     - smana
-    - somtochiama # 1.20 RT Docs Shadow
     - steveperry-53
     - tanjunchen
     - tengqm


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

- Remove me from `website-maintainers`
- Remove 1.20 shadows except for Rey (1.21 lead) from `website-milestone-maintainers`

cc @kubernetes/sig-docs-leads @reylejano 