### PR TITLE
chore: update with additional CAPA maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -73,6 +73,8 @@ teams:
     - detiber
     - justinsb
     - luxas
+    - randomvariable
+    - richardcase
     - timothysc
     - vincepri
     privacy: closed
@@ -84,6 +86,7 @@ teams:
     - detiber
     - ingvagabund
     - randomvariable
+    - richardcase
     - timothysc
     - vincepri
     privacy: closed


### PR DESCRIPTION
A change to the CAPA maintainers/admins.

For reference, [current CAPA mainatiners](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/master/OWNERS_ALIASES#L22).

/cc @randomvariable 