### PR TITLE
add kmova as admin to nfs provisioner projects

### DIFF
--- a/config/kubernetes-sigs/sig-storage/teams.yaml
+++ b/config/kubernetes-sigs/sig-storage/teams.yaml
@@ -114,6 +114,7 @@ teams:
     description: Admin access to nfs-subdir-external-provisioner
     members:
     - jsafrane
+    - kmova
     - msau42
     - saad-ali
     - xing-yang
@@ -122,6 +123,7 @@ teams:
     description: Admin access to nfs-ganesha-server-and-external-provisioner
     members:
     - jsafrane
+    - kmova
     - msau42
     - saad-ali
     - xing-yang


### PR DESCRIPTION
This PR adds kmova as admin to the following projects:
- kubernetes-sigs/nfs-subdir-external-provisioner
- kubernetes-sigs/nfs-ganesha-server-and-external-provisioner

Fixes: https://github.com/kubernetes/org/issues/2389

/cc @msau42 @xing-yang @saad-ali @jsafrane 

Signed-off-by: kmova <kiran.mova@mayadata.io>