### PR TITLE
michmike vacating sig-windows chair position

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -96,10 +96,10 @@ aliases:
     - hpandeycodeit
     - tashimi
   sig-windows-leads:
-    - benmoss
+    - jsturtevant
     - ddebroy
     - marosset
-    - michmike
+    - jayunit100
   wg-api-expression-leads:
     - apelisse
     - kwiesmueller


### PR DESCRIPTION
as per https://github.com/kubernetes/community/pull/5386, i am stepping down from sig-windows chair.
updating with the new chairs and TLs for sig-windows

ref https://github.com/kubernetes/org/pull/2416

Signed-off-by: Michael Michael <michmike@cs.stanford.edu>
