### PR TITLE
Add 1.21 Enhancements team to github enhancements team

### DIFF
--- a/config/kubernetes/sig-architecture/teams.yaml
+++ b/config/kubernetes/sig-architecture/teams.yaml
@@ -38,15 +38,16 @@ teams:
     maintainers:
     - mrbobbytables # subproject owner
     members:
+    - annajung # 1.21 Enhancements Lead
+    - arunmk # 1.21 Enhancements Shadow
+    - jameslaverack # 1.21 Enhancements Shadow
     - jeremyrickard # subproject owner
     - johnbelamaric # subproject owner
+    - jrsapi # 1.21 Enhancements Shadow
     - justaugustus # subproject owner
-    - kendallroden # 1.20 Enhancements Shadow
+    - kendallroden # 1.21 Enhancements Shadow
     - kikisdeliveryservice # 1.20 Enhancements Lead
-    - kinarashah # 1.20 Enhancements Shadow
     - LappleApple # subproject owner
-    - mikejoh # 1.20 Enhancements Shadow
-    - MorrisLaw # 1.20 Enhancements Shadow
     - palnabarun
     privacy: closed
     teams:


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

- Add 1.21 Enhancements team to `sig-architecture` github team `enhancements`
- Remove 1.20 Shadows from the `enhancements` team

/assign @palnabarun @savitharaghunathan @kikisdeliveryservice @bai 

note: This was missed in the previous PR https://github.com/kubernetes/org/pull/2442. I will do a follow-up to add this step to the enhancements role handbook as well. 