### PR TITLE
Add 1.21 Docs Shadows to GitHub teams

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -350,6 +350,7 @@ teams:
     - bene2k1
     - bradtopol
     - celestehorgan
+    - ChandaniM123 # 1.21 RT Docs Shadow
     - claudiajkang
     - cstoku
     - dianaabv
@@ -367,11 +368,13 @@ teams:
     - kbarnard10
     - lledru
     - msheldyakov
+    - mvortizr # 1.21 RT Docs Shadow
     - nasa9084
     - ngtuna
     - onlydole
     - oussemos
     - perriea
+    - pi-victor # 1.21 RT Docs Shadow
     - potapy4
     - raelga
     - Rajakavitha1

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -252,6 +252,7 @@ teams:
         - arunmk # 1.21 Enhancements Shadow
         - bai # 1.20 RT Lead Shadow
         - celestehorgan # 1.20 Release Notes Shadow
+        - ChandaniM123 # 1.21 Docs Shadow
         - chris-short # 1.20 Communications Shadow
         - cpanato # Release Manager
         - desponda # 1.21 Bug Triage Shadow
@@ -273,12 +274,14 @@ teams:
         - mkorbi # 1.21 CI Signal Shadow
         - monzelmasry # 1.21 Bug Triage Shadow
         - morrislaw # 1.20 Enhancements Shadow
+        - mvortizr # 1.21 Docs Shadow
         - n3wscott # 1.21 CI Signal Shadow
         - onlydole # subproject owner / 1.21 Emeritus Advisor
         - palnabarun # 1.20 RT Lead Shadow
+        - pi-victor # 1.21 Docs Shadow
         - priyankah21 # 1.21 CI Signal Shadow
         - puerco # Release Manager
-        - reylejano # 1.20 Docs Lead
+        - reylejano # 1.21 Docs Lead
         - s278gupt # 1.21 CI Signal Shadow
         - salaxander # 1.20 Communications Shadow
         - saschagrunert # subproject owner
@@ -288,6 +291,7 @@ teams:
         - somtochiama # 1.20 Docs Shadow
         - soniasingla # 1.20 Release Notes Shadow
         - tanjacky # 1.20 Release Notes Shadow
+        - tengqm # 1.21 Docs Shadow
         - thejoycekung # 1.21 CI Signal Lead
         - tpepper # subproject owner
         - wilsonehusin # 1.21 Release Notes Lead


### PR DESCRIPTION
Add 1.21 Docs Shadows to `website-milestone-maintainers` in  sig-docs/teams.yaml and `release-team` in sig-release/teams.yaml GitHub teams

/assign @palnabarun @kikisdeliveryservice @savitharaghunathan @bai

/hold for feedback if shadows should be added to the `website-milestone-maintainers` team. 
I think they should have the ability to add the 1.21 milestone on kubernetes/website PRs.