### PR TITLE
Add celanthe to k-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -84,6 +84,7 @@ members:
 - caseydavenport
 - castrojo
 - CecileRobertMichon
+- celanthe
 - celestehorgan
 - chadswen
 - chaosaffe


### PR DESCRIPTION
I am a current Member of Kubernetes, and would like to be added to K-SIGs to start on the path towards becoming a Reviewer.