### PR TITLE
Retire from my role as Release Associate

### DIFF
--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -65,7 +65,6 @@ teams:
     - ameukam # Release Manager Associate
     - cpanato # Release Manager
     - feiskyer # Release Manager
-    - gianarb # Release Manager Associate
     - hasheddan # subproject owner / Release Manager
     - idealhack # Release Manager
     - jimangel # Release Manager Associate

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -64,7 +64,6 @@ teams:
     - floreks # UI
     - foxish # Big Data
     - frapposelli # VMware
-    - gianarb # Release Manager Associate
     - hasheddan # Release
     - hpandeycodeit # Usability
     - Huang-Wei # Scheduling
@@ -209,7 +208,6 @@ teams:
         - ameukam # Release Manager Associate
         - cpanato # Release Manager
         - feiskyer # Release Manager
-        - gianarb # Release Manager Associate
         - hasheddan # subproject owner / Release Manager
         - idealhack # Release Manager
         - jimangel # Release Manager Associate


### PR DESCRIPTION
Hey! After a few iterations in sig-release and after a few months helping
as an Associate, I am stepping back.

I recently spoke with a couple of teammates in the sig release and I value
the title I am holding, and I am sure other people from the community
want to contribute as an Associate. Now I have a better idea about how to
contribute and I don't need a title for that.