### PR TITLE
Setup SIG Testing subteams

### DIFF
--- a/config/kubernetes/sig-testing/teams.yaml
+++ b/config/kubernetes/sig-testing/teams.yaml
@@ -28,26 +28,35 @@ teams:
     - timothysc
     - xiangpengzhao
     privacy: closed
-  sig-testing-pr-reviews:
-    description: sig-testing PR reviews
-    maintainers:
-    - fejta
-    - spiffxp
-    members:
-    - akutz
-    - amwat
-    - BenTheElder
-    - chases2
-    - cjwagner
-    - clarketm
-    - ixdy
-    - Katharine
-    - krzyzacy
-    - michelle192837
-    - mithrav
-    - mkumatag
-    - stevekuznetsov
-    privacy: closed
+    teams:
+      sig-testing-leads:
+        description: sig-testing chairs and technical leads
+        maintainers:
+        - spiffxp
+        members:
+        - BenTheElder
+        - stevekuznetsov
+        privacy: closed
+      sig-testing-pr-reviews:
+        description: sig-testing PR reviews
+        maintainers:
+        - fejta
+        - spiffxp
+        members:
+        - akutz
+        - amwat
+        - BenTheElder
+        - chases2
+        - cjwagner
+        - clarketm
+        - ixdy
+        - Katharine
+        - krzyzacy
+        - michelle192837
+        - mithrav
+        - mkumatag
+        - stevekuznetsov
+        privacy: closed
   test-infra-admins:
     description: admin access to test-infra
     maintainers:


### PR DESCRIPTION
specifically:

- add sig-testing/sig-testing-leads
- move sig-testing-pr-reviews under sig-testing

---

META: this was mostly a PR to verify what creating a new PR from an old local clone looks like following a rename of this repo's default branch