### PR TITLE
Add GitHub team for prometheus-adapter

### DIFF
--- a/config/kubernetes-sigs/sig-instrumentation/teams.yaml
+++ b/config/kubernetes-sigs/sig-instrumentation/teams.yaml
@@ -55,3 +55,10 @@ teams:
         members:
         - calebamiles
         privacy: closed
+  prometheus-adapter-admins:
+    description: Admin access to the prometheus-adapter repo
+    members:
+    - brancz
+    - DirectXMan12
+    - s-urbaniak
+    privacy: closed


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2182

Only adding the admins GitHub team since the list of folks with admin and write access is the same.

/assign @mrbobbytables 