### PR TITLE
Add GitHub team for work-api repo

### DIFF
--- a/config/kubernetes-sigs/sig-multicluster/teams.yaml
+++ b/config/kubernetes-sigs/sig-multicluster/teams.yaml
@@ -42,3 +42,9 @@ teams:
     - JeremyOT
     - pmorie
     privacy: closed
+  work-api-admins:
+    description: Admin access for the work-api repo
+    members:
+    - jeremyot
+    - pmorie
+    privacy: closed


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2468

https://github.com/qiujian16 is not a kubernetes/k-sigs GitHub org member and would need to apply for membership.

/assign @mrbobbytables 