### PR TITLE
Renaming Service APIs to Gateway API

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -97,14 +97,16 @@ teams:
     - dcbw
     - thockin
     privacy: closed
-  service-apis-admins:
-    description: Admin access to the service-apis repo
+  gateway-api-admins:
+    description: Admin access to the gateway-api repo
     members:
     - bowei
     - thockin
     privacy: closed
-  service-apis-maintainers:
-    description: Write access to the service-apis repo
+    previously:
+    - service-apis-admins
+  gateway-api-maintainers:
+    description: Write access to the gateway-api repo
     members:
     - bowei
     - danehans
@@ -114,4 +116,5 @@ teams:
     - thockin
     privacy: closed
     previously:
+    - service-apis-maintainers
     - service-apis-amintainers


### PR DESCRIPTION
This accompanies https://github.com/kubernetes-sigs/service-apis/pull/541 and related discussion in https://github.com/kubernetes-sigs/service-apis/issues/536. Not quite sure what the correct order of operations here is.