### PR TITLE
SIG Instrumentation members cleanup

### DIFF
--- a/config/kubernetes/sig-instrumentation/teams.yaml
+++ b/config/kubernetes/sig-instrumentation/teams.yaml
@@ -24,19 +24,13 @@ teams:
     - andyxning
     - brancz
     - coffeepac
-    - danielqsj
     - dashpole
     - DirectXMan12
     - ehashman
-    - kawych
     - lilic
-    - loburm
     - logicalhan
-    - piosz
     - RainbowMango
-    - serathius
     - s-urbaniak
+    - serathius
     - tariq1890
-    - x13n
-    - zouyee
     privacy: closed

--- a/config/kubernetes/sig-instrumentation/teams.yaml
+++ b/config/kubernetes/sig-instrumentation/teams.yaml
@@ -1,10 +1,29 @@
 teams:
-  sig-instrumentation-api-reviews:
+  sig-instrumentation-leads:
+    description: ""
+    members:
+    - brancz
+    - dashpole
+    - ehashman
+    - logicalhan
+    privacy: closed
+  sig-instrumentation-approvers:
+    description: ""
+    members:
+    - brancz
+    - dashpole
+    - ehashman
+    - logicalhan
+    - RainbowMango
+    - serathius
+    privacy: closed
+  sig-instrumentation-members:
     description: ""
     members:
     - 44past4
     - andyxning
     - brancz
+    - coffeepac
     - danielqsj
     - dashpole
     - DirectXMan12
@@ -15,141 +34,9 @@ teams:
     - logicalhan
     - piosz
     - RainbowMango
-    - s-urbaniak
     - serathius
+    - s-urbaniak
     - tariq1890
     - x13n
     - zouyee
-    privacy: closed
-  sig-instrumentation-bugs:
-    description: ""
-    members:
-    - 44past4
-    - andyxning
-    - brancz
-    - coffeepac
-    - danielqsj
-    - dashpole
-    - DirectXMan12
-    - ehashman
-    - kawych
-    - lilic
-    - loburm
-    - logicalhan
-    - piosz
-    - RainbowMango
-    - s-urbaniak
-    - serathius
-    - tariq1890
-    - x13n
-    - zouyee
-    privacy: closed
-  sig-instrumentation-feature-requests:
-    description: ""
-    members:
-    - 44past4
-    - andyxning
-    - brancz
-    - danielqsj
-    - dashpole
-    - DirectXMan12
-    - ehashman
-    - kawych
-    - lilic
-    - loburm
-    - logicalhan
-    - piosz
-    - RainbowMango
-    - s-urbaniak
-    - serathius
-    - tariq1890
-    - x13n
-    privacy: closed
-  sig-instrumentation-misc:
-    description: ""
-    members:
-    - 44past4
-    - andyxning
-    - brancz
-    - coffeepac
-    - danielqsj
-    - dashpole
-    - DirectXMan12
-    - ehashman
-    - kawych
-    - lilic
-    - loburm
-    - logicalhan
-    - piosz
-    - RainbowMango
-    - s-urbaniak
-    - serathius
-    - tariq1890
-    - x13n
-    privacy: closed
-  sig-instrumentation-pr-reviews:
-    description: ""
-    members:
-    - 44past4
-    - andyxning
-    - brancz
-    - coffeepac
-    - danielqsj
-    - dashpole
-    - DirectXMan12
-    - ehashman
-    - kawych
-    - lilic
-    - loburm
-    - logicalhan
-    - piosz
-    - RainbowMango
-    - s-urbaniak
-    - serathius
-    - tariq1890
-    - x13n
-    - zouyee
-    privacy: closed
-  sig-instrumentation-proposals:
-    description: ""
-    members:
-    - 44past4
-    - andyxning
-    - brancz
-    - danielqsj
-    - dashpole
-    - DirectXMan12
-    - ehashman
-    - kawych
-    - lilic
-    - loburm
-    - logicalhan
-    - piosz
-    - RainbowMango
-    - s-urbaniak
-    - serathius
-    - tariq1890
-    - x13n
-    privacy: closed
-  sig-instrumentation-test-failures:
-    description: ""
-    members:
-    - 44past4
-    - andyxning
-    - brancz
-    - coffeepac
-    - danielqsj
-    - dashpole
-    - DirectXMan12
-    - ehashman
-    - kawych
-    - lilic
-    - loburm
-    - logicalhan
-    - piosz
-    - RainbowMango
-    - s-urbaniak
-    - serathius
-    - tariq1890
-    - x13n
     privacy: closed


### PR DESCRIPTION
This PR:
- pares down instrumentation to just three GitHub teams: leads, approvers (as defined in k/k/OWNERS_ALIASES), and members
- removes all inactive members

I am defining "inactive" as [<50 contributions on devstats for the past year](https://k8s.devstats.cncf.io/d/13/developer-activity-counts-by-repository-group?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=All&var-country_name=All) **and** does not attend [regular SIG meetings](https://docs.google.com/document/d/1FE4AQ8B49fYbKhfg4Tx0cui1V0eI4o3PxoqQPUwNEiU/edit#).

This is part of our SIG review for our annual report. I will be following this up with a PR to add active members who aren't yet on the list.

/cc @logicalhan 