### PR TITLE
cluster-api-provider-digitalocean: Update team membership

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -134,6 +134,7 @@ teams:
     - cpanato
     - MorrisLaw
     - prksu
+    - timoreimann
     - timothysc
     privacy: closed
   cluster-api-provider-docker-admins:

--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -126,7 +126,6 @@ teams:
     - luxas
     - roberthbailey
     - timothysc
-    - xmudrii
     privacy: closed
   cluster-api-provider-digitalocean-maintainers:
     description: Write access to the cluster-api-provider-digitalocean repo
@@ -135,7 +134,6 @@ teams:
     - MorrisLaw
     - prksu
     - timothysc
-    - xmudrii
     privacy: closed
   cluster-api-provider-docker-admins:
     description: admin access to cluster-api-provider-docker repo

--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -123,6 +123,7 @@ teams:
   cluster-api-provider-digitalocean-admins:
     description: Admin access to the cluster-api-provider-digitalocean repo
     members:
+    - cpanato
     - luxas
     - roberthbailey
     - timothysc


### PR DESCRIPTION
As per https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/234#issuecomment-779840516:

* I'm stepping down as a project maintainer
* @timoreimann is promoted to a project maintainer

This PR:

* Removes me from the `cluster-api-provider-digitalocean-admin` and the `cluster-api-provider-digitalocean-maintainers` teams
* Adds @cpanato to the `cluster-api-provider-digitalocean-admin` team
* Adds @timoreimann to the `cluster-api-provider-digitalocean-maintainers` team

/assign @cblecker @dims 
/cc @cpanato @MorrisLaw @prksu @timoreimann 