### PR TITLE
Add divya-mohan0209 to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -143,6 +143,7 @@ members:
 - dims
 - DirectXMan12
 - displague
+- divya-mohan0209
 - Divya063
 - divyenpatel
 - djzager


### PR DESCRIPTION
For https://github.com/kubernetes-sigs/contributor-playground/pull/586

Divya is already a member of @kubernetes 

/assign @divya-mohan0209 @palnabarun 