### PR TITLE
updating Korean website milestone maintainers

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -382,6 +382,7 @@ teams:
     - rlenferink
     - SataQiu
     - savitharaghunathan
+    - seokho-son
     - sftim
     - smana
     - tanjunchen


### PR DESCRIPTION
Adding Seokho Son as a website milestone maintainer to support the KO localization efforts.

/sig docs
/cc @seokho-son