### PR TITLE
Edit description for milestone-maintainers to reflect triage access

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -16,9 +16,7 @@ teams:
     privacy: closed
   milestone-maintainers:
     description: Contributors who can use `/milestone` or `/status` commands on
-      issues/PRs. This team also grants write access to the
-      kubernetes/enhancements repo to allow editing of descriptions for
-      Enhancement tracking issues.
+      issues/PRs and have triage access to the kubernetes/enhancements repo
     maintainers:
     - cblecker # ContribEx
     - fejta # Testing


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

`milestone-maintainers` was downgraded to `Triage` role and no longer have `Write` access to the k/enhancements repo. Updating the description to reflect the latest change. 


ref: https://github.com/kubernetes/enhancements/issues/590#issuecomment-760635910