### PR TITLE
Remove GitHub teams for mutating-trace-admission-controller

### DIFF
--- a/config/kubernetes-sigs/sig-instrumentation/teams.yaml
+++ b/config/kubernetes-sigs/sig-instrumentation/teams.yaml
@@ -39,22 +39,6 @@ teams:
     - s-urbaniak
     - serathius
     privacy: closed
-  mutating-trace-admission-controller:
-    description: Parent team for mutating-trace-admission-controller repo (maintainers, admins)
-    members:
-    - calebamiles
-    privacy: closed
-    teams:
-      mutating-trace-admission-controller-admins:
-        description: Admin access to the mutating-trace-admission-controller repo
-        members:
-        - calebamiles
-        privacy: closed
-      mutating-trace-admission-controller-maintainers:
-        description: Write access to the mutating-trace-admission-controller repo
-        members:
-        - calebamiles
-        privacy: closed
   prometheus-adapter-admins:
     description: Admin access to the prometheus-adapter repo
     members:


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2527

/assign @palnabarun 