### PR TITLE
Add YuikoTakada to kubernetes-sigs member

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -570,6 +570,7 @@ members:
 - yuanchen8911
 - yuanying
 - yue9944882
+- YuikoTakada
 - yujuhong
 - yujunz
 - zacharysarah


### PR DESCRIPTION
YuikoTakada is already member of kubernetes org.
To join her to mentors at upstream training in Japan, add her to kubernetes-sigs member.