### PR TITLE
Welcome new SIG Instrumentation contributors

### DIFF
--- a/config/kubernetes/sig-instrumentation/teams.yaml
+++ b/config/kubernetes/sig-instrumentation/teams.yaml
@@ -25,12 +25,17 @@ teams:
     - brancz
     - coffeepac
     - dashpole
+    - dgrisonnet
+    - dims
     - DirectXMan12
     - ehashman
+    - erain
     - lilic
     - logicalhan
     - RainbowMango
     - s-urbaniak
     - serathius
     - tariq1890
+    - YoyinZyc
+    - yuzhiquan
     privacy: closed


### PR DESCRIPTION
All members on this list have been identified as regular SIG Instrumentation contributors over the past year. We would like to thank and welcome all of you to the GitHub team!

cc @kubernetes/sig-instrumentation-leads 