### PR TITLE
add timoreimann as admin for cluster-api-provider-digitalocean

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -126,6 +126,7 @@ teams:
     - cpanato
     - luxas
     - roberthbailey
+    - timoreimann
     - timothysc
     privacy: closed
   cluster-api-provider-digitalocean-maintainers:


### PR DESCRIPTION
Adding @timoreimann as admin to the cluster-api-provider-digitalocean repo to have a backup maintainer in case I'm not available 

Timo is maintainer of CAPDO and also works for DO

