### PR TITLE
teams: refresh wg-k8s-infra teams

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -114,7 +114,7 @@ aliases:
     - cindyxing
     - dejanb
   wg-k8s-infra-leads:
-    - bartsmykla
+    - ameukam
     - dims
     - spiffxp
   wg-multitenancy-leads:

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -38,7 +38,7 @@ teams:
     - spiffxp # WG K8s Infra Lead
     members:
     - alejandrox1 # subproject owner
-    - bartsmykla # WG K8s Infra Lead
+    - ameukam # WG K8s Infra Lead
     - dims # WG K8s Infra Lead
     - hasheddan # subproject owner
     - justaugustus # subproject owner / maintainer

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1503,29 +1503,6 @@ teams:
     - davidopp
     - kad
     privacy: closed
-  k8s-infra-team:
-    description: ""
-    maintainers:
-    - cblecker
-    - idvoretskyi
-    - spiffxp
-    members:
-    - amwat
-    - BenTheElder
-    - brendandburns
-    - dims
-    - ixdy
-    - shyamjvs
-    - thockin
-    privacy: closed
-  k8s.io-maintainers:
-    description: Write access to the k8s.io repo
-    members:
-    - dims
-    - ixdy
-    - lavalamp
-    - thockin
-    privacy: closed
   klog-admins:
     description: Admin access to the klog repo
     members:

--- a/config/kubernetes/wg-k8s-infra/OWNERS
+++ b/config/kubernetes/wg-k8s-infra/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - wg-k8s-infra-leads
+approvers:
+  - wg-k8s-infra-leads
+labels:
+  - wg/k8s-infra

--- a/config/kubernetes/wg-k8s-infra/teams.yaml
+++ b/config/kubernetes/wg-k8s-infra/teams.yaml
@@ -1,32 +1,58 @@
 teams:
-  k8s-infra-team:
+  wg-k8s-infra:
     description:
     maintainers:
     - cblecker
     - idvoretskyi
+    - nikhita
     - spiffxp
     members:
-    - amwat
+    - ameukam
     - BenTheElder
-    - brendandburns
+    - BobyMCbobs
+    - chewong
+    - claudiubelu
+    - cpanato
     - dims
+    - hasheddan
+    - hh
     - ixdy
-    - shyamjvs
+    - justinsb
+    - listx
+    - munnerz
+    - Riaankl
+    - rikatz
+    - stp-ip
     - thockin
     privacy: closed
+    teams:
+      wg-k8s-infra-leads:
+        description: wg-k8s-infra chairs and technical leads
+        maintainers:
+        - spiffxp
+        members:
+        - ameukam
+        - dims
+        privacy: closed
   k8s.io-admins:
     description: Admin access to the k8s.io repo
+    maintainers:
+    - cblecker
+    - nikhita
+    - spiffxp
     members:
+    - ameukam
     - dims
-    - ixdy
-    - lavalamp
     - thockin
     privacy: closed
   k8s.io-maintainers:
     description: Write access to the k8s.io repo
+    maintainers:
+    - cblecker
+    - nikhita
+    - spiffxp
     members:
+    - ameukam
     - dims
-    - ixdy
-    - lavalamp
     - thockin
     privacy: closed

--- a/config/kubernetes/wg-k8s-infra/teams.yaml
+++ b/config/kubernetes/wg-k8s-infra/teams.yaml
@@ -14,6 +14,14 @@ teams:
     - shyamjvs
     - thockin
     privacy: closed
+  k8s.io-admins:
+    description: Admin access to the k8s.io repo
+    members:
+    - dims
+    - ixdy
+    - lavalamp
+    - thockin
+    privacy: closed
   k8s.io-maintainers:
     description: Write access to the k8s.io repo
     members:

--- a/config/kubernetes/wg-k8s-infra/teams.yaml
+++ b/config/kubernetes/wg-k8s-infra/teams.yaml
@@ -1,0 +1,24 @@
+teams:
+  k8s-infra-team:
+    description:
+    maintainers:
+    - cblecker
+    - idvoretskyi
+    - spiffxp
+    members:
+    - amwat
+    - BenTheElder
+    - brendandburns
+    - dims
+    - ixdy
+    - shyamjvs
+    - thockin
+    privacy: closed
+  k8s.io-maintainers:
+    description: Write access to the k8s.io repo
+    members:
+    - dims
+    - ixdy
+    - lavalamp
+    - thockin
+    privacy: closed


### PR DESCRIPTION
Prompted by wg-k8s-infra leads rotation: https://github.com/kubernetes/community/pull/5633

But tried to pay down some org debt and refresh members while I was here

See commits for details