### PR TITLE
Update cluster-api-provider aws maintainer list

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -75,6 +75,7 @@ teams:
     - luxas
     - randomvariable
     - richardcase
+    - sedefsavas
     - timothysc
     - vincepri
     privacy: closed
@@ -87,6 +88,7 @@ teams:
     - ingvagabund
     - randomvariable
     - richardcase
+    - sedefsavas
     - timothysc
     - vincepri
     privacy: closed


### PR DESCRIPTION
A change to the  cluster-api-provider aws maintainers/admins.

For reference, [current CAPA maintainers.](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/master/OWNERS_ALIASES#L22)

/cc @randomvariable
/cc @richardcase 