### PR TITLE
Add sbueringer to cluster-api-provider-openstack-admins

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -214,6 +214,7 @@ teams:
     - dims
     - luxas
     - roberthbailey
+    - sbueringer
     - timothysc
     privacy: closed
   cluster-api-provider-openstack-maintainers:


### PR DESCRIPTION
I just found out via the issue above that actually none of the maintainers of CAPO 
has admin access to the CAPO repository. It would be nice to get that.

I don't know how the general policy in the ClusterAPI project is regarding this rights.
So feel free to reject the request :)


xref: https://github.com/kubernetes/org/issues/2580