### PR TITLE
Request temporary write access to website repo for the 1.21 release

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -339,6 +339,7 @@ teams:
     - potapy4 # L10n: Russian
     - raelga # L10n: Spanish
     - remyleone # L10n: French
+    - reylejano #1.21 Release Docs Lead
     - rikatz # L10n: Portuguese
     - rlenferink # L10n: German
     - SataQiu # L10n: Chinese


### PR DESCRIPTION
Requesting temporary write access to the website repo for the 1.21 release per the [Release Docs Handbook](https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/docs/Release-Timeline.md#request-for-temporary-write-access-to-website-repo)

/assign @jimangel @irvifa @kbarnard10 