### PR TITLE
Remove temporary write access to website repo for 1.21 for Rey

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -339,7 +339,6 @@ teams:
     - potapy4 # L10n: Russian
     - raelga # L10n: Spanish
     - remyleone # L10n: French
-    - reylejano #1.21 Release Docs Lead
     - rikatz # L10n: Portuguese
     - rlenferink # L10n: German
     - SataQiu # L10n: Chinese


### PR DESCRIPTION
This PR removes @reylejano's temporary write access to the website repo for the 1.21 release

/hold until 1.21 is released, scheduled for 4/8/2021
/assign @jimangel @irvifa @kbarnard10