### PR TITLE
.github: add link to repo donation rules in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/repo-create.md
+++ b/.github/ISSUE_TEMPLATE/repo-create.md
@@ -8,6 +8,7 @@ assignees: ''
 ---
 
 ### New Repo, Staging Repo, or migrate existing
+<!-- Rules for migrating existing repos - https://git.k8s.io/community/github-management/kubernetes-repositories.md#rules-for-donated-repositories -->
 e.g. new repository
 
 ### Requested name for new repository


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2589#issuecomment-809548423

While this link is also mentioned in the "Approvals" section, most
folks don't read it. So this commit explicitly mentions it in a comment
in the issue template.

/assign @mrbobbytables 
cc @cblecker @spiffxp 