### PR TITLE
add tam7t to kubernetes org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1010,6 +1010,7 @@ members:
 - szuecs
 - tabbysable
 - tallclair
+- tam7t
 - tamalsaha
 - tanjacky
 - tanjing2020


### PR DESCRIPTION
I am already a member of kubernetes-sig (https://github.com/kubernetes/org/issues/2317) and need kubernetes membership for prow and image promotion.