### PR TITLE
Going emeritus, removing myself from WGs and SIGs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -124,7 +124,6 @@ aliases:
     - celestehorgan
     - jdumars
     - justaugustus
-    - zacharysarah
   wg-policy-leads:
     - ericavonb
     - hannibalhuang

--- a/config/kubernetes-sigs/wg-naming/teams.yaml
+++ b/config/kubernetes-sigs/wg-naming/teams.yaml
@@ -5,7 +5,6 @@ teams:
     - celestehorgan
     - jdumars
     - justaugustus
-    - zacharysarah
     privacy: closed
     teams:
       wg-naming-leads:
@@ -14,5 +13,4 @@ teams:
         - celestehorgan
         - jdumars
         - justaugustus
-        - zacharysarah
         privacy: closed

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -26,7 +26,6 @@ teams:
     - onlydole
     - sftim
     - tengqm
-    - zacharysarah
     - zparnold
     privacy: closed
   sig-docs-en-reviews:
@@ -45,7 +44,6 @@ teams:
     - sftim
     - stewart-yu
     - tengqm
-    - zacharysarah
     - zparnold
     privacy: closed
   sig-docs-es-owners:
@@ -223,7 +221,6 @@ teams:
     - stewart-yu
     - tengqm
     - tfogo
-    - zacharysarah
     - zparnold
     privacy: closed
   sig-docs-pt-owners:
@@ -347,7 +344,6 @@ teams:
     - truongnh1992 # L10n: Vietnamese
     - xichengliudui # L10n: Chinese
     - yagonobre # L10n: Portuguese
-    - zacharysarah # L10n: English
     - zhangxiaoyu-zidif # L10n: Chinese
     privacy: closed
   website-milestone-maintainers:
@@ -403,7 +399,6 @@ teams:
     - xichengliudui
     - yastij
     - ysyukr
-    - zacharysarah
     - zhangxiaoyu-zidif
     - zparnold
     privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -147,7 +147,6 @@ teams:
     - wojtek-t # Scalability
     - xing-yang # Storage
     - xmudrii # Release Manager
-    - zacharysarah # Docs
     privacy: closed
     previously:
     - kubernetes-milestone-maintainers

--- a/config/kubernetes/wg-naming/teams.yaml
+++ b/config/kubernetes/wg-naming/teams.yaml
@@ -5,7 +5,6 @@ teams:
     - celestehorgan
     - jdumars
     - justaugustus
-    - zacharysarah
     privacy: closed
     teams:
       wg-naming-leads:
@@ -14,5 +13,4 @@ teams:
         - celestehorgan
         - jdumars
         - justaugustus
-        - zacharysarah
         privacy: closed


### PR DESCRIPTION
This PR removes myself as a lead of WG-Naming and member of SIG Docs teams as part of going emeritus.

Related PRs:
- https://github.com/kubernetes/community/pull/5733