### PR TITLE
docs/release team provisioning: Add members for v1.22 Release Docs.

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -352,10 +352,13 @@ teams:
     - abuisine
     - aisonaku
     - annajung
+    - ashnehete # 1.22 RT Docs Shadow
     - awkif
     - bene2k1
     - bradtopol
+    - carlisia # 1.22 RT Docs Shadow
     - celestehorgan
+    - chrisnegus # 1.22 RT Docs Shadow
     - claudiajkang
     - cstoku
     - dianaabv
@@ -385,6 +388,7 @@ teams:
     - rekcah78
     - remyleone
     - reylejano
+    - ritpanjw # 1.22 RT Docs Shadow
     - rlenferink
     - SataQiu
     - savitharaghunathan

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -250,10 +250,13 @@ teams:
         - ams0 # 1.21 Bug Triage Shadow
         - annajung # 1.22 RT Lead Shadow
         - arunmk # 1.21 Enhancements Shadow
+        - ashnehete # 1.22 Release Docs Shadow
         - bai # 1.20 RT Lead Shadow
+        - carlisia # 1.22 Release Docs Shadow
         - celestehorgan # 1.20 Release Notes Shadow
         - ChandaniM123 # 1.21 Docs Shadow
         - chris-short # 1.20 Communications Shadow
+        - chrisnegus # 1.22 Release Docs Shadow
         - cpanato # Release Manager
         - desponda # 1.21 Bug Triage Shadow
         - divya-mohan0209 # 1.22 RT Lead Shadow
@@ -285,6 +288,7 @@ teams:
         - puerco # Release Manager
         - ramrodo # 1.22 CI Signal Shadow
         - reylejano # 1.21 Docs Lead
+        - ritpanjw # 1.22 Release Docs Shadow
         - salaxander # 1.20 Communications Shadow
         - saschagrunert # subproject owner
         - savitharaghunathan # 1.22 RT Lead


### PR DESCRIPTION
Add users for v1.22 Release team as part of the sig-release team and
website-milestone-maintainers (gives them access to set /milestone
for PRs to k/website as part of their workflow for RT).

Signed-off-by: Victor Palade <victor@cloudflavor.io>

/assign @savitharaghunathan 
~/hold for [@ritpanjw access to the org to be resolved](https://github.com/kubernetes/org/issues/2665#issuecomment-828222961)~