### PR TITLE
capg/github-team: add cpanato to the admin group of capg

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -153,6 +153,7 @@ teams:
   cluster-api-provider-gcp-admins:
     description: admin access to cluster-api-provider-gcp
     members:
+    - cpanato
     - justinsb
     - luxas
     - roberthbailey


### PR DESCRIPTION
I'm maintaining the project for some time, and I need admin access to set up some items in the repo.

/assign @dims @detiber @fabriziopandini 