### PR TITLE
Add seanmalloy to external-dns-maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -60,6 +60,7 @@ teams:
     - linki
     - njuettner
     - Raffo
+    - seanmalloy
     privacy: closed
     previously:
     - maintainers-external-dns


### PR DESCRIPTION
The external-dns project needs additonal maintainers with write access
so that GitHub actions for first time contributors can be approved.
time.

ref: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks