### PR TITLE
Add GitHub teams for network-policy-api

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -18,6 +18,7 @@ admins:
 members:
 - aaroniscode
 - aaronlevy
+- abhiraut
 - adelina-t
 - Adirio
 - adohe

--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -124,3 +124,9 @@ teams:
     - mcluseau
     - thockin
     privacy: closed
+  network-policy-api-admins:
+    description: Admin access to the network-policy-api repo
+    members:
+    - abhiraut
+    - rikatz
+    privacy: closed


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2678

Also adds @abhiraut to @kubernetes-sigs, they are already a member of @kubernetes. 

/assign @palnabarun 