### PR TITLE
Add thejoycekung and verolop to release-team

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -289,7 +289,9 @@ teams:
         - sladyn98 # 1.22 Release Notes Shadow
         - soniasingla # 1.22 CI Signal Shadow
         - supriya-premkumar # 1.22 Enhancements Shadow
+        - thejoycekung # 1.22 Branch Manager Shadow
         - tpepper # subproject owner
+        - verolop # 1.22 Branch Manager Shadow
         - voigt # 1.22 Bug Triage Shadow
         - xmudrii # Release Manager
         privacy: closed


### PR DESCRIPTION
This PR adds Joyce and Verónica (@thejoycekung and @Verolop ), Branch Manager shadows for the v1.22 cycle  to the release team group.

/assign @kubernetes/sig-release-leads 

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>