### PR TITLE
Add coffeepac and monotek to k8s-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -118,6 +118,7 @@ members:
 - cmurphy
 - codenrhoden
 - coderanger
+- coffeepac
 - cofyc
 - copejon
 - corneliusweig
@@ -382,6 +383,7 @@ members:
 - mkumatag
 - Monkeyanator
 - monopole
+- monotek
 - mook-as
 - morengab
 - MorrisLaw


### PR DESCRIPTION
To fix issue with https://github.com/kubernetes-sigs/instrumentation-addons/pull/1

Both are already Kubernetes members.