### PR TITLE
Adding `vladimirvivien` as admin to e2e-framework repo

### DIFF
--- a/config/kubernetes-sigs/sig-testing/teams.yaml
+++ b/config/kubernetes-sigs/sig-testing/teams.yaml
@@ -21,6 +21,7 @@ teams:
     - alejandrox1
     - andrewsykim
     - BenTheElder
+    - vladimirvivien
     privacy: closed
   e2e-framework-maintainers:
     description: write access to e2e-framework


### PR DESCRIPTION
Primarily to be able to change `e2e-framework` repo's main branch name from `master` to main.