### PR TITLE
Add seanschneeweiss to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -507,6 +507,7 @@ members:
 - screeley44
 - seanmalloy
 - seans3
+- seanschneeweiss
 - sedefsavas
 - serathius
 - serbrech


### PR DESCRIPTION
Add @seanschneeweiss as a member of kubernetes-sigs org as discussed in #2725. 