### PR TITLE
Update username rename: s/GreenApple10/chuntaochen

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -202,6 +202,7 @@ members:
 - christopherhein
 - chrisz100
 - chuckha
+- chuntaochen
 - chymy
 - cici37
 - CindyXing
@@ -390,7 +391,6 @@ members:
 - gracenng
 - granular-ryanbonham
 - grayluck
-- GreenApple10
 - grobie
 - grodrigues3
 - guineveresaenger


### PR DESCRIPTION
peribolos is broken right now - https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-org-peribolos/1398588539746127872

```
 {"client":"github","component":"peribolos","file":"external/io_k8s_test_infra/prow/github/client.go:526","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"UpdateOrgMembership(kubernetes, greenapple10, false)","time":"2021-05-29T10:43:23Z"}
{"component":"peribolos","error":"status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/orgs#set-organization-membership-for-a-user\"}","file":"external/io_k8s_test_infra/prow/cmd/peribolos/main.go:517","func":"main.configureOrgMembers.func1","level":"warning","msg":"UpdateOrgMembership(kubernetes, greenapple10, false) failed","time":"2021-05-29T10:43:33Z"}
{"component":"peribolos","file":"external/io_k8s_test_infra/prow/cmd/peribolos/main.go:508","func":"main.configureOrgMembers.func1","level":"info","msg":"Waiting for haoshuwei to accept invitation to kubernetes","time":"2021-05-29T10:43:33Z"}
{"component":"peribolos","file":"external/io_k8s_test_infra/prow/cmd/peribolos/main.go:508","func":"main.configureOrgMembers.func1","level":"info","msg":"Waiting for aut0r3v to accept invitation to kubernetes","time":"2021-05-29T10:43:33Z"}
{"component":"peribolos","file":"external/io_k8s_test_infra/prow/cmd/peribolos/main.go:508","func":"main.configureOrgMembers.func1","level":"info","msg":"Waiting for skrishna-unix to accept invitation to kubernetes","time":"2021-05-29T10:43:33Z"}
{"component":"peribolos","file":"external/io_k8s_test_infra/prow/cmd/peribolos/main.go:508","func":"main.configureOrgMembers.func1","level":"info","msg":"Waiting for faezeazimi to accept invitation to kubernetes","time":"2021-05-29T10:43:33Z"}
{"client":"github","component":"peribolos","file":"external/io_k8s_test_infra/prow/github/client.go:526","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"RemoveOrgMembership(kubernetes, chuntaochen)","time":"2021-05-29T10:43:33Z"}
{"component":"peribolos","file":"external/io_k8s_test_infra/prow/cmd/peribolos/main.go:201","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure kubernetes members: 1 errors: [status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/orgs#set-organization-membership-for-a-user\"}]","time":"2021-05-29T10:43:35Z"} 
```

@chuntaochen was added in https://github.com/kubernetes/org/issues/2704

