### PR TITLE
SIG Release: Spring cleaning

### DIFF
--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -2,33 +2,27 @@ teams:
   downloadkubernetes-admins:
     description: admin access to downloadkubernetes
     members:
-    - alejandrox1 # subproject owner
     - hasheddan # subproject owner
     - justaugustus # subproject owner
     - saschagrunert # subproject owner
-    - tpepper # subproject owner
     privacy: closed
   downloadkubernetes-maintainers:
     description: write access to downloadkubernetes
     members:
-    - alejandrox1 # subproject owner
     - chuckha
     - hasheddan # subproject owner
     - justaugustus # subproject owner
     - mauilion
     - saschagrunert # subproject owner
-    - tpepper # subproject owner
     privacy: closed
   image-promoter-admins:
     description: admin access to k8s-container-image-promoter
     members:
-    - alejandrox1 # subproject owner
     - hasheddan # subproject owner
     - justaugustus # subproject owner / maintainer
     - justinsb # maintainer
     - listx # maintainer
     - saschagrunert # subproject owner
-    - tpepper # subproject owner
     privacy: closed
     previously:
     - k8s-container-image-promoter-admins
@@ -37,7 +31,6 @@ teams:
     maintainers:
     - spiffxp # WG K8s Infra Lead
     members:
-    - alejandrox1 # subproject owner
     - ameukam # WG K8s Infra Lead
     - dims # WG K8s Infra Lead
     - hasheddan # subproject owner
@@ -45,18 +38,15 @@ teams:
     - justinsb # maintainer
     - listx # maintainer
     - saschagrunert # subproject owner
-    - tpepper # subproject owner
     privacy: closed
     previously:
     - k8s-container-image-promoter-maintainers
   mdtoc-admins:
     description: admin access to mdtoc
     members:
-    - alejandrox1 # subproject owner
     - hasheddan # subproject owner
     - justaugustus # subproject owner
     - saschagrunert # subproject owner
-    - tpepper # subproject owner
     privacy: closed
   release-engineering:
     description: Members of the Release Engineering subproject, including
@@ -81,22 +71,18 @@ teams:
   release-notes-admins:
     description: admin access to release-notes
     members:
-    - alejandrox1 # subproject owner
     - hasheddan # subproject owner
     - jeefy
     - justaugustus # subproject owner
     - saschagrunert # subproject owner
-    - tpepper # subproject owner
     privacy: closed
   release-notes-maintainers:
     description: write access to release-notes
     members:
-    - alejandrox1 # subproject owner
     - hasheddan # subproject owner
     - jeefy
     - justaugustus # subproject owner
     - saschagrunert # subproject owner
-    - tpepper # subproject owner
     privacy: closed
   release-sdk-admins:
     description: admin access to release-sdk
@@ -133,21 +119,17 @@ teams:
   zeitgeist-admins:
     description: admin access to zeitgeist
     members:
-    - alejandrox1 # subproject owner
     - hasheddan # subproject owner
     - justaugustus # subproject owner
     - saschagrunert # subproject owner
-    - tpepper # subproject owner
     privacy: closed
   zeitgeist-maintainers:
     description: write access to zeitgeist
     members:
-    - alejandrox1 # subproject owner
     - hasheddan # subproject owner
     - justaugustus # subproject owner
     - n3wscott
     - Pluies
     - saschagrunert # subproject owner
-    - tpepper # subproject owner
     - yastij
     privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -214,15 +214,6 @@ teams:
     - tpepper
     privacy: closed
     teams:
-      licensing:
-        description: Members of the Licensing subproject.
-        maintainers:
-        - nikhita # subproject owner
-        members:
-        - dims # subproject owner
-        - justaugustus # subproject owner
-        - swinslow # subproject owner
-        privacy: closed
       release-engineering:
         description: Members of the Release Engineering subproject, including
           Release Managers, Release Manager Associates, and Build Admins.

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -161,6 +161,26 @@ teams:
     - mfojtik
     - sttts
     privacy: closed
+  repo-infra-admins:
+    description: Admin access to the repo-infra repo
+    maintainers:
+    - fejta
+    members:
+    - BenTheElder
+    - clarketm
+    - justaugustus
+    - mikedanese
+    privacy: closed
+  repo-infra-maintainers:
+    description: Write access to the repo-infra repo
+    maintainers:
+    - fejta
+    members:
+    - BenTheElder
+    - clarketm
+    - justaugustus
+    - mikedanese
+    privacy: closed
   sig-release:
     description: SIG Release members. Explicitly lists SIG Release Chairs,
       Technical Leads, Program Managers, and any active SIG contributors that

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -78,7 +78,7 @@ teams:
     - jrsapi # 1.22 Enhancements Shadow
     - jsafrane # Storage
     - jsturtevant # Windows
-    - justaugustus # Azure / PM / Release
+    - justaugustus # Release
     - justinsb # AWS / Cluster Lifecycle
     - k8s-release-robot # Release
     - khenidak # Azure
@@ -170,7 +170,6 @@ teams:
     - nikhita
     - spiffxp
     members:
-    - alejandrox1 # Technical Lead
     - alenkacz
     - BenTheElder
     - castrojo
@@ -244,7 +243,6 @@ teams:
       release-team:
         description: Members of the current Release Team and subproject owners.
         members:
-        - alejandrox1 # subproject owner
         - annajung # 1.22 RT Lead Shadow
         - ashnehete # 1.22 Release Docs Shadow
         - carlisia # 1.22 Release Docs Shadow
@@ -323,7 +321,6 @@ teams:
       sig-release-admins:
         description: Admins for SIG Release repositories
         members:
-        - alejandrox1 # Technical Lead
         - hasheddan # Technical Lead
         - jeremyrickard # Technical Lead
         - justaugustus # Chair
@@ -333,7 +330,6 @@ teams:
         description: |
           Chairs, Technical Leads, and Program Managers for SIG Release
         members:
-        - alejandrox1 # Technical Lead
         - hasheddan # Technical Lead
         - jeremyrickard # Technical Lead
         - justaugustus # Chair
@@ -344,7 +340,6 @@ teams:
         description: |
           Grants access to maintain SIG Release project boards
         members:
-        - alejandrox1 # Technical Lead
         - hasheddan # Technical Lead
         - jeremyrickard # Technical Lead
         - justaugustus # Chair

--- a/config/kubernetes/sig-testing/teams.yaml
+++ b/config/kubernetes/sig-testing/teams.yaml
@@ -90,23 +90,3 @@ teams:
     members:
     - taragu
     privacy: closed
-  repo-infra-admins:
-    description: Admin access to the repo-infra repo
-    maintainers:
-    - fejta
-    members:
-    - BenTheElder
-    - clarketm
-    - justaugustus
-    - mikedanese
-    privacy: closed
-  repo-infra-maintainers:
-    description: Write access to the repo-infra repo
-    maintainers:
-    - fejta
-    members:
-    - BenTheElder
-    - clarketm
-    - justaugustus
-    - mikedanese
-    privacy: closed


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/org/pull/2743, after noticing a few more teams needed sprucing up.

- Offboarding cleanup for @tpepper and @alejandrox1 
- Transfer k/repo-infra team ownership to SIG Release (ref: https://github.com/kubernetes/community/pull/4985)
- Remove GitHub team for archived licensing subproject (ref: https://github.com/kubernetes/community/pull/5400)

/assign @saschagrunert @hasheddan @jeremyrickard 
cc: @kubernetes/sig-release-leads 