### PR TITLE
Add self as admin for efs and fsx and remove inactive

### DIFF
--- a/config/kubernetes-sigs/sig-aws/teams.yaml
+++ b/config/kubernetes-sigs/sig-aws/teams.yaml
@@ -30,9 +30,9 @@ teams:
   aws-fsx-csi-driver-admins:
     description: admin access to aws-fsx-csi-driver
     members:
-    - d-nishi
     - justinsb
     - leakingtapan
+    - wongma7
     privacy: closed
   aws-fsx-csi-driver-maintainers:
     description: write access to aws-fsx-csi-driver
@@ -46,9 +46,9 @@ teams:
   aws-efs-csi-driver-admins:
     description: admin access to aws-efs-csi-driver
     members:
-    - d-nishi
     - justinsb
     - leakingtapan
+    - wongma7
     privacy: closed
   aws-efs-csi-driver-maintainers:
     description: write access to aws-efs-csi-driver


### PR DESCRIPTION
Similar to https://github.com/kubernetes/org/pull/2482 for ebs 

(main reason I want more permissions is to configure coveralls threshold or maybe disable it altogether because it currently blocks PRs too often e.g. https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/470. I already did it in ebs e.g. https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/912#issuecomment-853699031)