### PR TITLE
Update GitHub username for medmedchiheb

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -702,9 +702,9 @@ members:
 - mayankshah1607
 - mbbroberg
 - mborsz
+- mcbenjemaa
 - mcluseau
 - mcrute
-- medmedchiheb
 - medyagh
 - melodychn
 - mengjiao-liu


### PR DESCRIPTION
This fixes peribolos: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-org-peribolos/1402695359720853504
related - https://github.com/kubernetes/org/issues/925

```
 {"client":"github","component":"peribolos","file":"external/io_k8s_test_infra/prow/github/client.go:526","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"UpdateOrgMembership(kubernetes, medmedchiheb, false)","time":"2021-06-09T18:37:29Z"}
{"component":"peribolos","error":"status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/orgs#set-organization-membership-for-a-user\"}","file":"external/io_k8s_test_infra/prow/cmd/peribolos/main.go:517","func":"main.configureOrgMembers.func1","level":"warning","msg":"UpdateOrgMembership(kubernetes, medmedchiheb, false) failed","time":"2021-06-09T18:37:36Z"} 
```

cc @mcbenjemaa
/assign @palnabarun 