### PR TITLE
sig-release: Update k/repo-infra teams

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -167,8 +167,11 @@ teams:
     members:
     - BenTheElder
     - clarketm
+    - cpanato
     - justaugustus
     - mikedanese
+    - puerco
+    - saschagrunert
     privacy: closed
   repo-infra-maintainers:
     description: Write access to the repo-infra repo
@@ -177,8 +180,12 @@ teams:
     members:
     - BenTheElder
     - clarketm
+    - cpanato
     - justaugustus
     - mikedanese
+    - puerco
+    - saschagrunert
+    - xmudrii
     privacy: closed
   sig-release:
     description: SIG Release members. Explicitly lists SIG Release Chairs,


### PR DESCRIPTION
- Add @kubernetes/sig-release-admins to @kubernetes/repo-infra-admins 
- Add @kubernetes/release-managers to @kubernetes/repo-infra-maintainers

Signed-off-by: Stephen Augustus <foo@auggie.dev>

ref: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1626257726146700?thread_ts=1626164119.119300&cid=CJH2GBF7Y

/assign @saschagrunert @cpanato @puerco 
/area release-eng