### PR TITLE
Remove cluster-api-bootstrap-provider-kubeadm teams

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -38,25 +38,6 @@ teams:
     - timothysc
     - vincepri
     privacy: closed
-  cluster-api-bootstrap-provider-kubeadm-admins:
-    descrption: admin acccess to cluster-api-bootstrap-provider-kubeadm
-    members:
-    - chuckha
-    - justinsb
-    - luxas
-    - timothysc
-    - vincepri
-    privacy: closed
-  cluster-api-bootstrap-provider-kubeadm-maintainers:
-    descrption: write acccess to cluster-api-bootstrap-provider-kubeadm
-    members:
-    - chuckha
-    - detiber
-    - justinsb
-    - luxas
-    - SataQiu
-    - timothysc
-    privacy: closed
   cluster-api-provider-aws-admins:
     description: admin access to cluster-api-provider-aws
     members:


### PR DESCRIPTION
Removes teams after archival of repo

ref: #2845

/cc @vincepri @neolit123 @timothysc

/area github-repo