### PR TITLE
add cluster/ approvers to kubernetes-maintainers

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1668,6 +1668,7 @@ teams:
     maintainers:
     - cblecker
     - fejta
+    - spiffxp
     - thelinuxfoundation
     members:
     - apelisse
@@ -1676,6 +1677,7 @@ teams:
     - brendandburns
     - bsalamat
     - caesarxuchao
+    - cheftako
     - childsb
     - cjcullen
     - davidopp


### PR DESCRIPTION
we are looking into using blockade for PRs that touch `cluster/` in a
similar manner that is used for kubernetes/release - someone will need
to manually remove the blockade label before a PR is allowed to merge

these two cluster/ approvers aren't part of the kubernetes-maintainers
team and so would not have the power to do so