### PR TITLE
remove temporary access for pi-victor from website-maintainers

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -334,7 +334,6 @@ teams:
     - nasa9084 # L10n: Japanese
     - ngtuna # L10n: Vietnamese
     - nvtkaszpir # L10n: Polish
-    - pi-victor # 1.22 RT Docs lead temporary access for the release
     - potapy4 # L10n: Russian
     - raelga # L10n: Spanish
     - remyleone # L10n: French


### PR DESCRIPTION
Reverts kubernetes/org#2860