### PR TITLE
remove sig-docs privileges for 1.22 team.

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -24,7 +24,6 @@ teams:
     - kbarnard10
     - kbhawkey
     - onlydole
-    - pi-victor
     - reylejano
     - savitharaghunathan
     - sftim
@@ -353,13 +352,10 @@ teams:
     - abuisine
     - aisonaku
     - annajung
-    - ashnehete # 1.22 RT Docs Shadow
     - awkif
     - bene2k1
     - bradtopol
-    - carlisia # 1.22 RT Docs Shadow
     - celestehorgan
-    - chrisnegus # 1.22 RT Docs Shadow
     - claudiajkang
     - cstoku
     - dianaabv
@@ -389,7 +385,6 @@ teams:
     - rekcah78
     - remyleone
     - reylejano
-    - ritpanjw # 1.22 RT Docs Shadow
     - rlenferink
     - SataQiu
     - savitharaghunathan


### PR DESCRIPTION
i will remain in website-milestone-maintainers a bit longer till the new docs lead is added

Signed-off-by: Victor Palade <victor@cloudflavor.io>

/cc @kubernetes/sig-docs-leads 