### PR TITLE
Add arahamad to kubernetes, kubernetes-client orgs

### DIFF
--- a/config/kubernetes-client/org.yaml
+++ b/config/kubernetes-client/org.yaml
@@ -18,6 +18,7 @@ admins:
 members:
 - akshaymankar
 - ameukam
+- arahamad
 - bgrant0607
 - brendandburns
 - caesarxuchao

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -83,6 +83,7 @@ members:
 - aojea
 - aoxn
 - apelisse
+- arahamad
 - aramase
 - ArangoGutierrez
 - aravindhp


### PR DESCRIPTION
fixes: #2850

Note: original org membership was in kubernetes-sigs.
While policy documentation has not been updated yet, steering has +1'ed making org membership 'universal'. You are joining Kubernetes the project as a whole, and not a specific org.