### PR TITLE
updating SIG Docs co-chairs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -40,9 +40,7 @@ aliases:
     - mrbobbytables
     - nikhita
   sig-docs-leads:
-    - irvifa
     - jimangel
-    - kbarnard10
     - kbhawkey
     - onlydole
     - sftim

--- a/config/kubernetes-sigs/sig-docs/teams.yaml
+++ b/config/kubernetes-sigs/sig-docs/teams.yaml
@@ -2,14 +2,11 @@ teams:
   reference-docs-admins:
     description: admin access to the reference-docs repo
     members:
-    - irvifa
     - jimangel
-    - kbarnard10
     privacy: closed
   reference-docs-maintainers:
     description: write access to the reference-docs repo
     members:
-    - irvifa
     - kbhawkey
     - onlydole
     - sftim

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -19,9 +19,7 @@ teams:
     - annajung
     - bradtopol
     - celestehorgan
-    - irvifa
     - jimangel
-    - kbarnard10
     - kbhawkey
     - onlydole
     - pi-victor
@@ -37,7 +35,6 @@ teams:
     - celestehorgan
     - daminisatya
     - jimangel
-    - kbarnard10
     - kbhawkey
     - onlydole
     - rajeshdeshpande02
@@ -104,7 +101,6 @@ teams:
     description: Approvers for Indonesian content
     members:
     - girikuncoro
-    - irvifa
     privacy: closed
   sig-docs-id-reviews:
     description: PR reviews for Indonesian content
@@ -112,7 +108,6 @@ teams:
     - danninov
     - girikuncoro
     - habibrosyad
-    - irvifa
     - phanama
     - wahyuoi
     privacy: closed
@@ -170,9 +165,7 @@ teams:
   sig-docs-leads:
     description: Chairs and tech leads for SIG Docs
     members:
-    - irvifa
     - jimangel
-    - kbarnard10
     - kbhawkey
     - onlydole
     - sftim
@@ -211,9 +204,7 @@ teams:
     - bradtopol
     - cody-clark
     - gochist
-    - irvifa
     - jimangel
-    - kbarnard10
     - kbhawkey
     - Rajakavitha1
     - stewart-yu
@@ -299,9 +290,7 @@ teams:
     previously:
     - kubernetes-website-admins
     members:
-    - irvifa
     - jimangel
-    - kbarnard10
     privacy: closed
   website-maintainers:
     description: Write access to the website repo
@@ -319,12 +308,10 @@ teams:
     - huynguyennovem # L10n: Vietnamese
     - ianychoi # L10n: Korean
     - inductor # L10n: Japanese
-    - irvifa # L10n: Indonesian
     - jailton # L10n: Portuguese
     - jcjesus # L10n: Portuguese
     - jhonmike # L10n: Portuguese
     - jimangel # L10n: English
-    - kbarnard10 # L10n: English
     - mfilocha # L10n: Polish
     - mittalyashu # L10n: Hindi
     - msheldyakov # L10n: Russian
@@ -365,12 +352,10 @@ teams:
     - gochist
     - huynguyennovem
     - inductor
-    - irvifa
     - jcjesus
     - jimangel
     - juandiegopalomino
     - jygastaud
-    - kbarnard10
     - lledru
     - msheldyakov
     - nasa9084


### PR DESCRIPTION
Updating SIG Docs chairs.

Ref: https://github.com/kubernetes/website/issues/29354

/cc @parispittman @sftim 