### PR TITLE
SIG Release cleanups

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -60,7 +60,6 @@ aliases:
     - derekwaynecarr
   sig-release-leads:
     - cpanato
-    - hasheddan
     - jeremyrickard
     - justaugustus
     - puerco

--- a/config/kubernetes-sigs/sig-node/teams.yaml
+++ b/config/kubernetes-sigs/sig-node/teams.yaml
@@ -16,7 +16,6 @@ teams:
   security-profiles-operator-admins:
     description: Admin access to security-profiles-operator repo
     members:
-    - hasheddan
     - pjbgf
     - saschagrunert
     privacy: closed
@@ -25,7 +24,6 @@ teams:
   security-profiles-operator-maintainers:
     description: Write access to security-profiles-operator repo
     members:
-    - hasheddan
     - pjbgf
     - saschagrunert
     privacy: closed

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -2,23 +2,32 @@ teams:
   downloadkubernetes-admins:
     description: admin access to downloadkubernetes
     members:
+    - cpanato # subproject owner
+    - jeremyrickard # subproject owner
     - justaugustus # subproject owner
+    - puerco # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
   downloadkubernetes-maintainers:
     description: write access to downloadkubernetes
     members:
     - chuckha
+    - cpanato # subproject owner
+    - jeremyrickard # subproject owner
     - justaugustus # subproject owner
     - mauilion
+    - puerco # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
   image-promoter-admins:
     description: admin access to k8s-container-image-promoter
     members:
+    - cpanato # subproject owner
+    - jeremyrickard # subproject owner
     - justaugustus # subproject owner / maintainer
     - justinsb # maintainer
     - listx # maintainer
+    - puerco # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
     previously:
@@ -29,10 +38,13 @@ teams:
     - spiffxp # WG K8s Infra Lead
     members:
     - ameukam # WG K8s Infra Lead
+    - cpanato # subproject owner
     - dims # WG K8s Infra Lead
+    - jeremyrickard # subproject owner
     - justaugustus # subproject owner / maintainer
     - justinsb # maintainer
     - listx # maintainer
+    - puerco # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
     previously:
@@ -40,7 +52,10 @@ teams:
   mdtoc-admins:
     description: admin access to mdtoc
     members:
+    - cpanato # subproject owner
+    - jeremyrickard # subproject owner
     - justaugustus # subproject owner
+    - puerco # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
   release-engineering:
@@ -48,13 +63,14 @@ teams:
       Release Managers and Release Manager Associates.
     members:
     - ameukam # Release Manager Associate
-    - cpanato # Release Manager
+    - cpanato # subproject owner / Release Manager
+    - jeremyrickard # subproject owner
     - jimangel # Release Manager Associate
     - justaugustus # subproject owner / Release Manager
     - mkorbi # Release Manager Associate
     - onlydole # Release Manager Associate
     - palnabarun # Release Manager Associate
-    - puerco # Release Manager
+    - puerco # subproject owner / Release Manager
     - saschagrunert # subproject owner / Release Manager
     - sethmccombs # Release Manager Associate
     - thejoycekung # Release Manager Associate
@@ -65,57 +81,77 @@ teams:
   release-notes-admins:
     description: admin access to release-notes
     members:
+    - cpanato # subproject owner
     - jeefy
+    - jeremyrickard # subproject owner
     - justaugustus # subproject owner
+    - puerco # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
   release-notes-maintainers:
     description: write access to release-notes
     members:
+    - cpanato # subproject owner
     - jeefy
+    - jeremyrickard # subproject owner
     - justaugustus # subproject owner
+    - puerco # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
   release-sdk-admins:
     description: admin access to release-sdk
     members:
-    - jeremyrickard
-    - justaugustus
-    - saschagrunert
+    - cpanato # subproject owner
+    - jeremyrickard # subproject owner
+    - justaugustus # subproject owner
+    - puerco # subproject owner
+    - saschagrunert # subproject owner
     privacy: closed
   release-sdk-maintainers:
     description: write access to release-sdk
     members:
-    - jeremyrickard
-    - justaugustus
-    - saschagrunert
+    - cpanato # subproject owner
+    - jeremyrickard # subproject owner
+    - justaugustus # subproject owner
+    - puerco # subproject owner
+    - saschagrunert # subproject owner
     privacy: closed
   release-utils-admins:
     description: admin access to release-utils
     members:
-    - jeremyrickard
-    - justaugustus
-    - saschagrunert
+    - cpanato # subproject owner
+    - jeremyrickard # subproject owner
+    - justaugustus # subproject owner
+    - puerco # subproject owner
+    - saschagrunert # subproject owner
     privacy: closed
   release-utils-maintainers:
     description: write access to release-utils
     members:
-    - jeremyrickard
-    - justaugustus
-    - saschagrunert
+    - cpanato # subproject owner
+    - jeremyrickard # subproject owner
+    - justaugustus # subproject owner
+    - puerco # subproject owner
+    - saschagrunert # subproject owner
     privacy: closed
   zeitgeist-admins:
     description: admin access to zeitgeist
     members:
+    - cpanato # subproject owner
+    - jeremyrickard # subproject owner
     - justaugustus # subproject owner
+    - puerco # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
   zeitgeist-maintainers:
     description: write access to zeitgeist
     members:
+    - cpanato # subproject owner
+    - jeremyrickard # subproject owner
     - justaugustus # subproject owner
     - n3wscott
     - Pluies
+    - puerco # subproject owner
     - saschagrunert # subproject owner
     - yastij
     privacy: closed

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -11,11 +11,9 @@ teams:
   downloadkubernetes-maintainers:
     description: write access to downloadkubernetes
     members:
-    - chuckha
     - cpanato # subproject owner
     - jeremyrickard # subproject owner
     - justaugustus # subproject owner
-    - mauilion
     - puerco # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
@@ -25,7 +23,6 @@ teams:
     - cpanato # subproject owner
     - jeremyrickard # subproject owner
     - justaugustus # subproject owner / maintainer
-    - justinsb # maintainer
     - listx # maintainer
     - puerco # subproject owner
     - saschagrunert # subproject owner
@@ -42,7 +39,6 @@ teams:
     - dims # WG K8s Infra Lead
     - jeremyrickard # subproject owner
     - justaugustus # subproject owner / maintainer
-    - justinsb # maintainer
     - listx # maintainer
     - puerco # subproject owner
     - saschagrunert # subproject owner
@@ -82,7 +78,6 @@ teams:
     description: admin access to release-notes
     members:
     - cpanato # subproject owner
-    - jeefy
     - jeremyrickard # subproject owner
     - justaugustus # subproject owner
     - puerco # subproject owner
@@ -92,7 +87,6 @@ teams:
     description: write access to release-notes
     members:
     - cpanato # subproject owner
-    - jeefy
     - jeremyrickard # subproject owner
     - justaugustus # subproject owner
     - puerco # subproject owner
@@ -153,5 +147,4 @@ teams:
     - Pluies
     - puerco # subproject owner
     - saschagrunert # subproject owner
-    - yastij
     privacy: closed

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -31,12 +31,8 @@ teams:
     - k8s-container-image-promoter-admins
   image-promoter-maintainers:
     description: write access to k8s-container-image-promoter
-    maintainers:
-    - spiffxp # WG K8s Infra Lead
     members:
-    - ameukam # WG K8s Infra Lead
     - cpanato # subproject owner
-    - dims # WG K8s Infra Lead
     - jeremyrickard # subproject owner
     - justaugustus # subproject owner / maintainer
     - listx # maintainer

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -2,7 +2,6 @@ teams:
   downloadkubernetes-admins:
     description: admin access to downloadkubernetes
     members:
-    - hasheddan # subproject owner
     - justaugustus # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
@@ -10,7 +9,6 @@ teams:
     description: write access to downloadkubernetes
     members:
     - chuckha
-    - hasheddan # subproject owner
     - justaugustus # subproject owner
     - mauilion
     - saschagrunert # subproject owner
@@ -18,7 +16,6 @@ teams:
   image-promoter-admins:
     description: admin access to k8s-container-image-promoter
     members:
-    - hasheddan # subproject owner
     - justaugustus # subproject owner / maintainer
     - justinsb # maintainer
     - listx # maintainer
@@ -33,7 +30,6 @@ teams:
     members:
     - ameukam # WG K8s Infra Lead
     - dims # WG K8s Infra Lead
-    - hasheddan # subproject owner
     - justaugustus # subproject owner / maintainer
     - justinsb # maintainer
     - listx # maintainer
@@ -44,7 +40,6 @@ teams:
   mdtoc-admins:
     description: admin access to mdtoc
     members:
-    - hasheddan # subproject owner
     - justaugustus # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
@@ -54,7 +49,6 @@ teams:
     members:
     - ameukam # Release Manager Associate
     - cpanato # Release Manager
-    - hasheddan # subproject owner / Release Manager
     - jimangel # Release Manager Associate
     - justaugustus # subproject owner / Release Manager
     - mkorbi # Release Manager Associate
@@ -71,7 +65,6 @@ teams:
   release-notes-admins:
     description: admin access to release-notes
     members:
-    - hasheddan # subproject owner
     - jeefy
     - justaugustus # subproject owner
     - saschagrunert # subproject owner
@@ -79,7 +72,6 @@ teams:
   release-notes-maintainers:
     description: write access to release-notes
     members:
-    - hasheddan # subproject owner
     - jeefy
     - justaugustus # subproject owner
     - saschagrunert # subproject owner
@@ -87,7 +79,6 @@ teams:
   release-sdk-admins:
     description: admin access to release-sdk
     members:
-    - hasheddan
     - jeremyrickard
     - justaugustus
     - saschagrunert
@@ -95,7 +86,6 @@ teams:
   release-sdk-maintainers:
     description: write access to release-sdk
     members:
-    - hasheddan
     - jeremyrickard
     - justaugustus
     - saschagrunert
@@ -103,7 +93,6 @@ teams:
   release-utils-admins:
     description: admin access to release-utils
     members:
-    - hasheddan
     - jeremyrickard
     - justaugustus
     - saschagrunert
@@ -111,7 +100,6 @@ teams:
   release-utils-maintainers:
     description: write access to release-utils
     members:
-    - hasheddan
     - jeremyrickard
     - justaugustus
     - saschagrunert
@@ -119,14 +107,12 @@ teams:
   zeitgeist-admins:
     description: admin access to zeitgeist
     members:
-    - hasheddan # subproject owner
     - justaugustus # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
   zeitgeist-maintainers:
     description: write access to zeitgeist
     members:
-    - hasheddan # subproject owner
     - justaugustus # subproject owner
     - n3wscott
     - Pluies

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -31,7 +31,6 @@ teams:
     - alejandrox1 # Testing
     - ameukam # Release Manager Associate
     - andrewsykim # Cloud Provider
-    - annajung # 1.22 RT Lead Shadow
     - BenTheElder # Testing
     - bgrant0607 # Architecture
     - bradamant3 # Docs
@@ -50,19 +49,15 @@ teams:
     - deads2k # API Machinery / Auth
     - derekwaynecarr # Architecture / Node
     - dims # Architecture / Release
-    - divya-mohan0209 # 1.22 RT Lead Shadow
     - eddiezane # CLI
     - ehashman # Instrumentation
     - encodeflush # 1.23 CI Signal Lead
     - enj # Auth
-    - erismaster # 1.22 RT Lead Shadow
     - fabriziopandini # Cluster Lifecycle
     - feiskyer # Azure
     - floreks # UI
     - foxish # Big Data
     - frapposelli # VMware
-    - gracenng # 1.22 Enhancements Shadow
-    - guineveresaenger # 1.22 Emeritus Advisor
     - hpandeycodeit # Usability
     - Huang-Wei # Scheduling
     - jameslaverack # 1.23 RT Lead Shadow
@@ -72,7 +67,6 @@ teams:
     - jberkus # Release
     - jdumars # Architecture / PM
     - jeremyrickard # Release / 1.23 Emeritus Adviser
-    - jgavinray # 1.22 Bug Triage Shadow
     - jimangel # Docs / Release Manager Associate
     - jlbutler # 1.23 Docs Lead
     - johnbelamaric # Architecture
@@ -84,7 +78,6 @@ teams:
     - k8s-release-robot # Release
     - karenhchu # 1.23 Release Comms Lead
     - khenidak # Azure
-    - kikisdeliveryservice # 1.22 RT Lead Shadow
     - KnVerey # CLI - Kustomize
     - kow3ns # Apps
     - lavalamp # API Machinery
@@ -106,13 +99,11 @@ teams:
     - mwielgus # Autoscaling
     - nckturner # AWS
     - neolit123 # Cluster Lifecycle
-    - notchairmk # 1.22 Bug Triage Shadow
-    - onlydole # Release Manager Associate / 1.21 Emeritus Advisor
+    - onlydole # Release Manager Associate
     - oxddr # Scalability
     - palnabarun # Release Manager Associate
     - parispittman # ContribEx
     - phillels # ContribEx
-    - pmmalinov01 # 1.22 Release Notes Lead
     - pmorie # Multicluster
     - prydonius # Apps
     - puerco # Release Manager
@@ -125,18 +116,14 @@ teams:
     - salaxander # 1.23 Enhancements Lead
     - saschagrunert # Release
     - SataQiu # Cluster Lifecycle
-    - savitharaghunathan # 1.22 RT Lead
     - seans3 # CLI
     - serathius # Instrumentation
     - sethmccombs # Release Manager Associate
-    - sfotony # 1.22 Bug Triage Shadow
     - shu-mutou # UI
     - shyamjvs # Scalability
-    - simcard0000 # 1.22 Release Notes Shadow
     - soltysh # CLI
     - spzala # IBM Cloud
     - stevekuznetsov # Testing
-    - supriya-premkumar # 1.22 Enhancements Shadow
     - tallclair # Auth
     - tashimi # Usability
     - thejoycekung # Release Manager Associate
@@ -262,47 +249,24 @@ teams:
       release-team:
         description: Members of the current Release Team and subproject owners.
         members:
-        - annajung # 1.22 RT Lead Shadow
         - cici37 # 1.23 Release Notes Lead
         - cpanato # subproject owner / Technical Lead
-        - Damans227 # 1.22 Release Notes Shadow
-        - divya-mohan0209 # 1.22 RT Lead Shadow
         - encodeflush # 1.23 CI Signal Lead
-        - erismaster # 1.22 RT Lead Shadow
-        - gracenng # 1.22 Enhancements Shadow
-        - guineveresaenger # subproject owner / 1.22 EA
         - jameslaverack # 1.23 RT Lead Shadow
         - jeremyrickard # subproject owner / Technical Lead
-        - jgavinray # 1.22 Bug Triage Shadow
         - jlbutler # 1.23 Docs Lead
         - jrsapi # 1.23 RT Lead Shadow
         - justaugustus # subproject owner / Chair
         - karenhchu # 1.23 Release Comms Lead
-        - kikisdeliveryservice # 1.22 RT Lead Shadow
-        - kunal-kushwaha # 1.22 Release Comms Shadow
-        - lachie83 # subproject owner / 1.20 Emeritus Advisor
-        - lambdanis # 1.22 CI Signal Shadow
         - mkorbi # 1.23 RT Lead Shadow
         - monzelmasry # 1.23 RT Lead Shadow
-        - notchairmk # 1.22 Bug Triage Shadow
-        - onlydole # subproject owner
-        - palnabarun # subproject owner
-        - pmmalinov01 # 1.22 Release Notes Lead
+        - onlydole # subproject owner (1.19 RT Lead)
+        - palnabarun # subproject owner (1.21 RT Lead)
         - puerco # subproject owner / Technical Lead
-        - rajula96reddy # 1.22 Release Comms Shadow
-        - ramrodo # 1.22 CI Signal Shadow
-        - reylejano # 1.23 RT Lead
+        - reylejano # subproject owner (1.23 RT Lead)
         - salaxander # 1.23 Enhancements Lead
         - saschagrunert # subproject owner / Chair
-        - savitharaghunathan # 1.22 RT Lead
-        - sfotony # 1.22 Bug Triage Shadow
-        - simcard0000 # 1.22 Release Notes Shadow
-        - skrishna-unix # 1.22 Release Comms Shadow
-        - sladyn98 # 1.22 Release Notes Shadow
-        - soniasingla # 1.22 CI Signal Shadow
-        - supriya-premkumar # 1.22 Enhancements Shadow
-        - thejoycekung # 1.22 Branch Manager Shadow
-        - verolop # 1.22 Branch Manager Shadow
+        - savitharaghunathan # subproject owner (1.22 RT Lead)
         - voigt # 1.23 Bug Triage Lead
         - xmudrii # Release Manager
         privacy: closed
@@ -312,10 +276,6 @@ teams:
               cycle.
             members:
             - encodeflush # 1.23 CI Signal Lead
-            - lambdanis # 1.22 CI Signal Shadow
-            - mkorbi # 1.22 CI Signal Lead
-            - ramrodo # 1.22 CI Signal Shadow
-            - soniasingla # 1.22 CI Signal Shadow
             privacy: closed
           release-team-leads:
             description: Release Team Leads for the current Kubernetes release

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -9,8 +9,10 @@ teams:
     members:
     - amwat
     - BenTheElder
+    - cpanato
     - justaugustus
     - MushuEE
+    - puerco
     - saschagrunert
     privacy: closed
   milestone-maintainers:
@@ -227,13 +229,13 @@ teams:
           Release Managers, Release Manager Associates, and Build Admins.
         members:
         - ameukam # Release Manager Associate
-        - cpanato # Release Manager
+        - cpanato # subproject owner / Release Manager
         - jimangel # Release Manager Associate
         - justaugustus # subproject owner / Release Manager
         - mkorbi # Release Manager Associate
         - onlydole # Release Manager Associate
         - palnabarun # Release Manager Associate
-        - puerco # Release Manager
+        - puerco # subproject owner / Release Manager
         - saschagrunert # subproject owner / Release Manager
         - sethmccombs # Release Manager Associate
         - thejoycekung # Release Manager Associate
@@ -262,7 +264,7 @@ teams:
         members:
         - annajung # 1.22 RT Lead Shadow
         - cici37 # 1.23 Release Notes Lead
-        - cpanato # Release Manager
+        - cpanato # subproject owner / Technical Lead
         - Damans227 # 1.22 Release Notes Shadow
         - divya-mohan0209 # 1.22 RT Lead Shadow
         - encodeflush # 1.23 CI Signal Lead
@@ -270,11 +272,11 @@ teams:
         - gracenng # 1.22 Enhancements Shadow
         - guineveresaenger # subproject owner / 1.22 EA
         - jameslaverack # 1.23 RT Lead Shadow
-        - jeremyrickard # Tech Lead / 1.23 EA
+        - jeremyrickard # subproject owner / Technical Lead
         - jgavinray # 1.22 Bug Triage Shadow
         - jlbutler # 1.23 Docs Lead
         - jrsapi # 1.23 RT Lead Shadow
-        - justaugustus # subproject owner
+        - justaugustus # subproject owner / Chair
         - karenhchu # 1.23 Release Comms Lead
         - kikisdeliveryservice # 1.22 RT Lead Shadow
         - kunal-kushwaha # 1.22 Release Comms Shadow
@@ -286,12 +288,12 @@ teams:
         - onlydole # subproject owner
         - palnabarun # subproject owner
         - pmmalinov01 # 1.22 Release Notes Lead
-        - puerco # Release Manager
+        - puerco # subproject owner / Technical Lead
         - rajula96reddy # 1.22 Release Comms Shadow
         - ramrodo # 1.22 CI Signal Shadow
         - reylejano # 1.23 RT Lead
         - salaxander # 1.23 Enhancements Lead
-        - saschagrunert # subproject owner
+        - saschagrunert # subproject owner / Chair
         - savitharaghunathan # 1.22 RT Lead
         - sfotony # 1.22 Bug Triage Shadow
         - simcard0000 # 1.22 Release Notes Shadow

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -9,7 +9,6 @@ teams:
     members:
     - amwat
     - BenTheElder
-    - hasheddan
     - justaugustus
     - MushuEE
     - saschagrunert
@@ -62,7 +61,6 @@ teams:
     - frapposelli # VMware
     - gracenng # 1.22 Enhancements Shadow
     - guineveresaenger # 1.22 Emeritus Advisor
-    - hasheddan # Release
     - hpandeycodeit # Usability
     - Huang-Wei # Scheduling
     - jameslaverack # 1.23 RT Lead Shadow
@@ -203,7 +201,6 @@ teams:
     - castrojo
     - cpanato # Technical Lead
     - dims
-    - hasheddan # Technical Lead
     - ixdy
     - jberkus
     - jdumars
@@ -231,7 +228,6 @@ teams:
         members:
         - ameukam # Release Manager Associate
         - cpanato # Release Manager
-        - hasheddan # subproject owner / Release Manager
         - jimangel # Release Manager Associate
         - justaugustus # subproject owner / Release Manager
         - mkorbi # Release Manager Associate
@@ -253,7 +249,6 @@ teams:
               who are not actively doing this job.
             members:
             - cpanato
-            - hasheddan
             - justaugustus
             - k8s-release-robot
             - puerco
@@ -274,7 +269,6 @@ teams:
         - erismaster # 1.22 RT Lead Shadow
         - gracenng # 1.22 Enhancements Shadow
         - guineveresaenger # subproject owner / 1.22 EA
-        - hasheddan # subproject owner
         - jameslaverack # 1.23 RT Lead Shadow
         - jeremyrickard # Tech Lead / 1.23 EA
         - jgavinray # 1.22 Bug Triage Shadow
@@ -339,7 +333,6 @@ teams:
         description: Admins for SIG Release repositories
         members:
         - cpanato # Technical Lead
-        - hasheddan # Technical Lead
         - jeremyrickard # Technical Lead
         - justaugustus # Chair
         - puerco # Technical Lead
@@ -350,7 +343,6 @@ teams:
           Chairs, Technical Leads, and Program Managers for SIG Release
         members:
         - cpanato # Technical Lead
-        - hasheddan # Technical Lead
         - jeremyrickard # Technical Lead
         - justaugustus # Chair
         - LappleApple # Program Manager
@@ -362,7 +354,6 @@ teams:
           Grants access to maintain SIG Release project boards
         members:
         - cpanato # Technical Lead
-        - hasheddan # Technical Lead
         - jeremyrickard # Technical Lead
         - justaugustus # Chair
         - LappleApple # Program Manager

--- a/config/kubernetes/sig-scalability/teams.yaml
+++ b/config/kubernetes/sig-scalability/teams.yaml
@@ -2,7 +2,8 @@ teams:
   sig-scalability:
     description: SIG Scalability
     members:
-    - alejandrox1 # SIG Release Technical Lead
+    - cpanato # SIG Release Technical Lead / Release Manager
+    - jeremyrickard # SIG Release Technical Lead
     - jkaniuk
     - jprzychodzen
     - justaugustus # SIG Release Chair / Release Manager
@@ -11,10 +12,10 @@ teams:
     - mm4tt
     - onlydole # 1.19 Release Team Lead
     - oxddr
+    - puerco # SIG Release Technical Lead / Release Manager
     - saschagrunert # SIG Release Technical Lead / Release Manager
     - shyamjvs
     - tosi3k
-    - tpepper # SIG Release Chair / Release Manager
     - wojtek-t
     privacy: closed
     teams:

--- a/config/kubernetes/sig-scalability/teams.yaml
+++ b/config/kubernetes/sig-scalability/teams.yaml
@@ -3,7 +3,6 @@ teams:
     description: SIG Scalability
     members:
     - alejandrox1 # SIG Release Technical Lead
-    - hasheddan # 1.19 CI Signal Lead / Release Manager
     - jkaniuk
     - jprzychodzen
     - justaugustus # SIG Release Chair / Release Manager

--- a/config/kubernetes/wg-k8s-infra/teams.yaml
+++ b/config/kubernetes/wg-k8s-infra/teams.yaml
@@ -40,7 +40,6 @@ teams:
     - claudiubelu
     - cpanato
     - dims
-    - hasheddan
     - hh
     - ixdy
     - justinsb


### PR DESCRIPTION
- @hasheddan is now Emeritus (https://github.com/kubernetes/sig-release/issues/1667)
  Leaving Dan in as an org member, but he's emeritus from all other
  held roles.
- Update references for Chairs/Technical Leads
- Remove previous Release Team members
- Prune inactive subproject maintainers
  - https://github.com/kubernetes-sigs/downloadkubernetes:
    - @chuckha
    - @mauilion
  - https://github.com/kubernetes-sigs/k8s-container-image-promoter:
    - @justinsb
  - https://github.com/kubernetes-sigs/release-notes:
    - @jeefy
  - https://github.com/kubernetes-sigs/zeitgeist:
    - @yastij
- Drop CIP maintainer access for @kubernetes/wg-k8s-infra-leads
  WG K8s Infra is transitioning to SIG: https://github.com/kubernetes/community/pull/5928
  As part of that, we refine access to this repo to maintainers and
  @kubernetes/release-engineering subproject owners.

Signed-off-by: Stephen Augustus <foo@auggie.dev>