### PR TITLE
Product Security Committee rename

### DIFF
--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,6 +1,6 @@
 # Defined below are the security contacts for this repo.
 #
-# They are the contact point for the Product Security Committee to reach out
+# They are the contact point for the Security Response Committee to reach out
 # to for triaging and handling of incoming issues.
 #
 # The below names agree to abide by the

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1808,7 +1808,7 @@ teams:
     - timothysc
     - wojtek-t
     privacy: closed
-  product-security-committee:
+  security-response-committee:
     description: Please report security issues to https://kubernetes.io/security
     members:
     - cjcullen


### PR DESCRIPTION
This is pull request is part of the process to rename the product
security commitee to the security response commmitee.

Please see [the community
issue](https://github.com/kubernetes/community/pull/5597/files)

Signed-off-by: Luke Hinds <lhinds@redhat.com>