### PR TITLE
Fix: move kube-scheduler-simulator-admins and kube-scheduler-simulator-maintainers to sig/scheduling

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -125,19 +125,6 @@ teams:
     - mcluseau
     - thockin
     privacy: closed
-  kube-scheduler-simulator-admins:
-    description: Admin access to the kube-scheduler-simulator
-    members:
-    - adtac
-    - alculquicondor
-    - Huang-Wei
-    privacy: closed
-  kube-scheduler-simulator-maintainers:
-    description: Write access to the kube-scheduler-simulator
-    members:
-    # - sanposhiho # pending org membership
-    - Huang-Wei # team needs a member, can remove once sanposhito added
-    privacy: closed
   network-policy-api-admins:
     description: Admin access to the network-policy-api repo
     members:

--- a/config/kubernetes-sigs/sig-scheduling/teams.yaml
+++ b/config/kubernetes-sigs/sig-scheduling/teams.yaml
@@ -47,6 +47,7 @@ teams:
   kube-scheduler-simulator-maintainers:
     description: Write access to the kube-scheduler-simulator
     members:
+    - adtac
     - sanposhiho
     privacy: closed
   poseidon-admins:

--- a/config/kubernetes-sigs/sig-scheduling/teams.yaml
+++ b/config/kubernetes-sigs/sig-scheduling/teams.yaml
@@ -37,6 +37,18 @@ teams:
     members:
     - k82cn
     privacy: closed
+  kube-scheduler-simulator-admins:
+    description: Admin access to the kube-scheduler-simulator
+    members:
+    - adtac
+    - alculquicondor
+    - Huang-Wei
+    privacy: closed
+  kube-scheduler-simulator-maintainers:
+    description: Write access to the kube-scheduler-simulator
+    members:
+    - sanposhiho
+    privacy: closed
   poseidon-admins:
     description: Admin access to the poseidon repo
     members:


### PR DESCRIPTION
Hi team. 

This PR
- moves kube-scheduler-simulator-admins and kube-scheduler-simulator-maintainers to sig/scheduling (#2921)
- adds sanposhiho to kube-scheduler-simulator-maintainers (#2919 )

Fixes #2921
Fixes #2919