### PR TITLE
Add fpetkovski as a kube-state-metrics maintainer

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1652,6 +1652,7 @@ teams:
     description: Write access to the kube-state-metrics repo
     members:
     - brancz
+    - fpetkovski
     - lilic
     - mrueg
     - tariq1890


### PR DESCRIPTION
This commit adds fpetkovski as a maintainer to kube-state-metrics.