### PR TITLE
sig-security: Add teams for sig-security repo

### DIFF
--- a/config/kubernetes/sig-security/teams.yaml
+++ b/config/kubernetes/sig-security/teams.yaml
@@ -18,3 +18,15 @@ teams:
         - IanColdwater
         - tabbysable
         privacy: closed
+  sig-security-admins:
+    description: Admin access to sig-security repo
+    members:
+    - IanColdwater
+    - tabbysable
+    privacy: closed
+  sig-security-maintainers:
+    description: Write access to sig-security repo
+    members:
+    - IanColdwater
+    - tabbysable
+    privacy: closed


### PR DESCRIPTION
ref: #2923

/area github-repo
/assign @IanColdwater @tabbysable 