### PR TITLE
Revert "EasyCLA commit test"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,3 @@ To report any sensitive information, please email the private github@kubernetes.
 
 Participation in the Kubernetes community is governed by the
 [Kubernetes Code of Conduct](code-of-conduct.md).
-
-<!-- To be reverted: EasyCLA commit test. -->


### PR DESCRIPTION
This reverts commit 79fd5855f986371fc58d173b9dce32c75159ee91.

Test completed, with [EasyCLA being set as an optional context](https://github.com/kubernetes/test-infra/pull/23634) It was non-blocking 👍 

ref: #2977