### PR TITLE
sig-testing: update test-infra teams

### DIFF
--- a/config/kubernetes/sig-testing/teams.yaml
+++ b/config/kubernetes/sig-testing/teams.yaml
@@ -65,6 +65,7 @@ teams:
     - chases2
     - cjwagner
     - e-blackwelder
+    - k8s-infra-ci-robot
     - listx
     - michelle192837
     - mpherman2

--- a/config/kubernetes/sig-testing/teams.yaml
+++ b/config/kubernetes/sig-testing/teams.yaml
@@ -65,7 +65,6 @@ teams:
     - chases2
     - cjwagner
     - e-blackwelder
-    - Katharine
     - listx
     - michelle192837
     - mpherman2
@@ -81,7 +80,6 @@ teams:
     - BenTheElder
     - cjwagner
     - ixdy
-    - Katharine
     - krzyzacy
     - michelle192837
     - stevekuznetsov


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/test-infra/issues/21137
- Related to: https://github.com/kubernetes/enhancements/issues/2539
- Followup to: https://github.com/kubernetes/test-infra/pull/23602

We need to give k8s-infra-ci-robot admin access to the kubernetes/test-infra repo to be able to label PRs created via generic-autobumper

Also prune a team member who has since moved on from the project