### PR TITLE
Added self as maintainer for aws-ebs-csi-driver

### DIFF
--- a/config/kubernetes-sigs/sig-aws/teams.yaml
+++ b/config/kubernetes-sigs/sig-aws/teams.yaml
@@ -13,6 +13,7 @@ teams:
     - gnufied
     - jsafrane
     - leakingtapan
+    - nirmalaagash
     - vdhanan
     - wongma7
     privacy: closed


### PR DESCRIPTION
Added self as maintainer for aws-ebs-csi-driver. Includes membership https://github.com/kubernetes/org/issues/2968