### PR TITLE
Add cici37 to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -122,6 +122,7 @@ members:
 - christopherhein
 - chuckha
 - chymy
+- cici37
 - clarketm
 - clarklee92
 - claudiubelu


### PR DESCRIPTION
I have been mainly involved in release-notes project and be responsible for updating relnotes.k8s.io as 1.23 release team release notes lead.