### PR TITLE
Update SIG Release teams

### DIFF
--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -17,6 +17,15 @@ teams:
     - puerco # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
+  mdtoc-admins:
+    description: admin access to mdtoc
+    members:
+    - cpanato # subproject owner
+    - jeremyrickard # subproject owner
+    - justaugustus # subproject owner
+    - puerco # subproject owner
+    - saschagrunert # subproject owner
+    privacy: closed
   promo-tools-admins:
     description: admin access to promo-tools
     members:
@@ -43,15 +52,6 @@ teams:
     previously:
     - image-promoter-maintainers
     - k8s-container-image-promoter-maintainers
-  mdtoc-admins:
-    description: admin access to mdtoc
-    members:
-    - cpanato # subproject owner
-    - jeremyrickard # subproject owner
-    - justaugustus # subproject owner
-    - puerco # subproject owner
-    - saschagrunert # subproject owner
-    privacy: closed
   release-engineering:
     description: Members of the Release Engineering subproject, including
       Release Managers and Release Manager Associates.

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -26,6 +26,15 @@ teams:
     - puerco # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
+  mdtoc-maintainers:
+    description: write access to mdtoc
+    members:
+    - cpanato # subproject owner
+    - jeremyrickard # subproject owner
+    - justaugustus # subproject owner
+    - puerco # subproject owner
+    - saschagrunert # subproject owner
+    privacy: closed
   promo-tools-admins:
     description: admin access to promo-tools
     members:

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -17,8 +17,8 @@ teams:
     - puerco # subproject owner
     - saschagrunert # subproject owner
     privacy: closed
-  image-promoter-admins:
-    description: admin access to k8s-container-image-promoter
+  promo-tools-admins:
+    description: admin access to promo-tools
     members:
     - cpanato # subproject owner
     - jeremyrickard # subproject owner
@@ -28,9 +28,10 @@ teams:
     - saschagrunert # subproject owner
     privacy: closed
     previously:
+    - image-promoter-admins
     - k8s-container-image-promoter-admins
-  image-promoter-maintainers:
-    description: write access to k8s-container-image-promoter
+  promo-tools-maintainers:
+    description: write access to promo-tools
     members:
     - cpanato # subproject owner
     - jeremyrickard # subproject owner
@@ -40,6 +41,7 @@ teams:
     - saschagrunert # subproject owner
     privacy: closed
     previously:
+    - image-promoter-maintainers
     - k8s-container-image-promoter-maintainers
   mdtoc-admins:
     description: admin access to mdtoc

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -76,14 +76,14 @@ teams:
     - jsturtevant # Windows
     - justaugustus # Release
     - justinsb # AWS / Cluster Lifecycle
-    # - jyotimahapatra # 1.23 Bug Triage Shadow (not in K8s org)
+    - jyotimahapatra # 1.23 Bug Triage Shadow
     - k8s-release-robot # Release
     - karenhchu # 1.23 Release Comms Lead
     - kevindelgado # 1.23 Enhancements Shadow
     - khenidak # Azure
     - KnVerey # CLI - Kustomize
     - kow3ns # Apps
-    # - lauralorenz # 1.23 Enhancements Shadow (not in K8s org)
+    - lauralorenz # 1.23 Enhancements Shadow
     - lavalamp # API Machinery
     - liggitt # Auth / Release
     - lingxiankong # OpenStack
@@ -101,10 +101,10 @@ teams:
     - msau42 # Storage
     - mszostok # Service Catalog
     - mwielgus # Autoscaling
-    # - nannancy # 1.23 Bug Triage Shadow (not in K8s org)
+    - nannancy # 1.23 Bug Triage Shadow
     - nckturner # AWS
     - neolit123 # Cluster Lifecycle
-    # - NilimaC04 # 1.23 Bug Triage Shadow (not in K8s org)
+    - NilimaC04 # 1.23 Bug Triage Shadow
     - onlydole # Release Manager Associate
     - oxddr # Scalability
     - palnabarun # Release Manager Associate
@@ -138,7 +138,7 @@ teams:
     - thejoycekung # Release Manager Associate
     - thockin # Network
     - timothysc # Cluster Lifecycle / Testing
-    # - varshaprasad96 # 1.23 Bug Triage Shadow (not in K8s org)
+    - varshaprasad96 # 1.23 Bug Triage Shadow
     - verolop # Release Manager Associate
     - vllry # Usability
     - voigt # 1.23 Bug Triage Lead
@@ -259,8 +259,8 @@ teams:
       release-team:
         description: Members of the current Release Team and subproject owners.
         members:
-        # - AuraSinis # 1.23 Release Notes Shadow (not in K8s org)
-        # - calvh # 1.23 CI Signal Shadow (not in K8s org)
+        - AuraSinis # 1.23 Release Notes Shadow
+        - calvh # 1.23 CI Signal Shadow
         - cccswann # 1.23 Release Comms Shadow
         - chrisnegus # 1.23 Docs Shadow
         - cici37 # 1.23 Release Notes Lead
@@ -273,23 +273,23 @@ teams:
         - jlbutler # 1.23 Docs Lead
         - jrsapi # 1.23 RT Lead Shadow
         - justaugustus # subproject owner / Chair
-        # - jyotimahapatra # 1.23 Bug Triage Shadow (not in K8s org)
+        - jyotimahapatra # 1.23 Bug Triage Shadow
         - karenhchu # 1.23 Release Comms Lead
         - kaslin # 1.23 Release Comms Shadow 
         - katcosgrove # 1.23 Release Comms Shadow
         - kevindelgado # 1.23 Enhancements Shadow
-        # - lauralorenz # 1.23 Enhancements Shadow (not in K8s org)
-        # - leonardpahlke # 1.23 CI Signal Shadow (not in K8s org)
-        # - mehabhalodiya # 1.23 Docs Shadow (not in K8s org)
+        - lauralorenz # 1.23 Enhancements Shadow
+        - leonardpahlke # 1.23 CI Signal Shadow
+        - mehabhalodiya # 1.23 Docs Shadow
         - mickeyboxell # 1.23 Release Comms Shadow
         - mkorbi # 1.23 RT Lead Shadow
         - monzelmasry # 1.23 RT Lead Shadow
-        # - nannancy # 1.23 Bug Triage Shadow (not in K8s org)
+        - nannancy # 1.23 Bug Triage Shadow
         - nate-double-u # 1.23 Docs Shadow
-        # - NilimaC04 # 1.23 Bug Triage Shadow (not in K8s org)
+        - NilimaC04 # 1.23 Bug Triage Shadow
         - onlydole # subproject owner (1.19 RT Lead)
         - palnabarun # subproject owner (1.21 RT Lead)
-        # - parul5sahoo # 1.23 Release Notes Shadow (not in K8s org)
+        - parul5sahoo # 1.23 Release Notes Shadow
         - Priyankasaggu11929 # 1.23 Enhancements Shadow
         - puerco # subproject owner / Technical Lead
         - rajula96reddy # 1.23 CI Signal Shadow
@@ -298,12 +298,12 @@ teams:
         - RinkiyaKeDad # 1.23 CI Signal Shadow
         - ritpanjw # 1.23 Bug Triage Shadow
         - salaxander # 1.23 Enhancements Lead
-        # - sam-cogan # 1.23 Release Notes Shadow (not in K8s org)
+        - sam-cogan # 1.23 Release Notes Shadow
         - saschagrunert # subproject owner / Chair
         - savitharaghunathan # subproject owner (1.22 RT Lead)
-        # - simrangupta234 # 1.23 CI Signal Shadow (not in K8s org)
+        - simrangupta234 # 1.23 CI Signal Shadow
         - supriya-premkumar # 1.23 Enhancements Shadow
-        # - varshaprasad96 # 1.23 Bug Triage Shadow (not in K8s org)
+        - varshaprasad96 # 1.23 Bug Triage Shadow
         - voigt # 1.23 Bug Triage Lead
         - xmudrii # Release Manager
         privacy: closed
@@ -312,12 +312,12 @@ teams:
             description: Members of the CI Signal team for the current release
               cycle.
             members:
-            # - calvh # 1.23 CI Signal Shadow (not in K8s org)
+            - calvh # 1.23 CI Signal Shadow
             - encodeflush # 1.23 CI Signal Lead
-            # - leonardpahlke # 1.23 CI Signal Shadow (not in K8s org)
+            - leonardpahlke # 1.23 CI Signal Shadow
             - rajula96reddy # 1.23 CI Signal Shadow
             - RinkiyaKeDad # 1.23 CI Signal Shadow
-            # - simrangupta234 # 1.23 CI Signal Shadow (not in K8s org)
+            - simrangupta234 # 1.23 CI Signal Shadow
             privacy: closed
           release-team-leads:
             description: Release Team Leads for the current Kubernetes release

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -139,7 +139,7 @@ teams:
     - thockin # Network
     - timothysc # Cluster Lifecycle / Testing
     - varshaprasad96 # 1.23 Bug Triage Shadow
-    - verolop # Release Manager Associate
+    - Verolop # Release Manager
     - vllry # Usability
     - voigt # 1.23 Bug Triage Lead
     - wilsonehusin # Release Manager Associate
@@ -184,6 +184,7 @@ teams:
     - mikedanese
     - puerco
     - saschagrunert
+    - Verolop
     - xmudrii
     privacy: closed
   sig-release:
@@ -236,7 +237,7 @@ teams:
         - saschagrunert # subproject owner / Release Manager
         - sethmccombs # Release Manager Associate
         - thejoycekung # Release Manager Associate
-        - Verolop # Release Manager Associate
+        - Verolop # Release Manager
         - wilsonehusin # Release Manager Associate
         - xmudrii # Release Manager
         privacy: closed
@@ -252,6 +253,7 @@ teams:
             - k8s-release-robot
             - puerco
             - saschagrunert
+            - Verolop
             - xmudrii
             privacy: closed
             previously:
@@ -304,6 +306,7 @@ teams:
         - simrangupta234 # 1.23 CI Signal Shadow
         - supriya-premkumar # 1.23 Enhancements Shadow
         - varshaprasad96 # 1.23 Bug Triage Shadow
+        - Verolop # Release Manager
         - voigt # 1.23 Bug Triage Lead
         - xmudrii # Release Manager
         privacy: closed


### PR DESCRIPTION
- releng(promo-tools): Update maintainer/admin team names - https://github.com/kubernetes-sigs/promo-tools/issues/424
- sig-release: Alpha-sort teams
- sig-release: Add `mdtoc-maintainers` team
- sig-release: Add additional 1.23 Release Team shadows to teams - https://github.com/kubernetes/org/pull/2946/commits/675c62afb847f2ffe3fb83dc76818eed9e1d6303
- sig-release: Promote Verónica López to Release Manager - https://groups.google.com/a/kubernetes.io/g/release-managers/c/zSiEg0dUQRE

/assign @cpanato @puerco @jeremyrickard @Verolop 
cc: @kubernetes/release-engineering 