### PR TITLE
Update SIG cluster lifecycle owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -32,7 +32,7 @@ aliases:
     - fabriziopandini
     - justinsb
     - neolit123
-    - timothysc
+    - vincepri
   sig-contributor-experience-leads:
     - alisondy
     - cblecker

--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -21,21 +21,14 @@ teams:
   cluster-api-admins:
     description: ""
     members:
-    - davidewatson
-    - detiber
-    - justinsb
-    - luxas
-    - timothysc
+    - CecileRobertMichon
     - vincepri
     privacy: closed
   cluster-api-maintainers:
     description: ""
     members:
     - CecileRobertMichon
-    - davidewatson
-    - detiber
     - fabriziopandini
-    - timothysc
     - vincepri
     privacy: closed
   cluster-api-provider-aws-admins:


### PR DESCRIPTION
/assign @vincepri @fabriziopandini 

sync CAPI owners with https://github.com/kubernetes-sigs/cluster-api/blob/master/OWNERS_ALIASES