### PR TITLE
make: fix make deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 # available for override
 GITHUB_TOKEN_PATH ?=
@@ -67,7 +67,7 @@ deploy: config test peribolos
 		--fix-team-members \
 		$(shell [ -n "${GITHUB_TOKEN_PATH}" ] && echo "--github-token-path=${GITHUB_TOKEN_PATH}") \
 		$(patsubst %, --required-admins=%, $(ADMINS)) \
-		$@
+		$(-*-command-variables-*-) $(filter-out $@,$(MAKECMDGOALS))
 
 # actual targets that only get built if they don't already exist
 $(MERGE_CMD):


### PR DESCRIPTION
Trying to avoid changing the job config args, which are passed in as `--foo=bar`. This doesn't work with the approach taken in kubernetes/k8s.io to pass flags through to a make target.  So use a different approach.