### PR TITLE
SIG-CLI: KnVerey to lead, pwittrock to emeritus

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -22,7 +22,7 @@ aliases:
     - mwielgus
   sig-cli-leads:
     - eddiezane
-    - pwittrock
+    - KnVerey
     - seans3
     - soltysh
   sig-cloud-provider-leads:

--- a/config/kubernetes-sigs/sig-cli/teams.yaml
+++ b/config/kubernetes-sigs/sig-cli/teams.yaml
@@ -2,6 +2,7 @@ teams:
   cli-experimental-admins:
     description: admin access to cli-experimental
     members:
+    - KnVerey
     - Liujingfang1
     - pwittrock
     - seans3

--- a/config/kubernetes/sig-cli/teams.yaml
+++ b/config/kubernetes/sig-cli/teams.yaml
@@ -4,6 +4,7 @@ teams:
     members:
     - adohe
     - janetkuo
+    - KnVerey
     - pwittrock
     - seans3
     - soltysh
@@ -14,6 +15,7 @@ teams:
     - adohe
     - dixudx
     - janetkuo
+    - KnVerey
     - mengqiy
     - pwittrock
     - seans3
@@ -27,6 +29,7 @@ teams:
     - adohe
     - davidopp
     - janetkuo
+    - KnVerey
     - mengqiy
     - pwittrock
     - seans3
@@ -40,6 +43,7 @@ teams:
     members:
     - adohe
     - janetkuo
+    - KnVerey
     - liggitt
     - mengqiy
     - monopole
@@ -56,6 +60,7 @@ teams:
     - dims
     - eparis
     - janetkuo
+    - KnVerey
     - mengqiy
     - pwittrock
     - seans3
@@ -75,6 +80,7 @@ teams:
     - dixudx
     - eparis
     - janetkuo
+    - KnVerey
     - liggitt
     - mengqiy
     - pwittrock
@@ -95,6 +101,7 @@ teams:
     - davidopp
     - deads2k
     - janetkuo
+    - KnVerey
     - liggitt
     - mengqiy
     - pwittrock
@@ -107,6 +114,7 @@ teams:
     description: ""
     members:
     - adohe
+    - KnVerey
     - pwittrock
     - seans3
     - soltysh

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -81,7 +81,7 @@ teams:
     - karenhchu # 1.23 Release Comms Lead
     - kevindelgado # 1.23 Enhancements Shadow
     - khenidak # Azure
-    - KnVerey # CLI - Kustomize
+    - KnVerey # CLI
     - kow3ns # Apps
     - lauralorenz # 1.23 Enhancements Shadow
     - lavalamp # API Machinery


### PR DESCRIPTION
Part of kubernetes/community#6102

I'm not sure about some of the changes in this one. I added myself to all the SIG-related Github teams, on the assumption those are for getting pinged on relevant issues. But for subproject teams, I only added myself to cli-experimental admins (because that should probably come with Kustomize admin--our docs are there). Should I be on any other subproject team? @pwittrock do you want to be removed from any of these places?

/cc @eddiezane @pwittrock @soltysh @seans3