### PR TITLE
Add spzala to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -587,6 +587,7 @@ members:
 - soniasingla
 - sophieliu15
 - spurin
+- spzala
 - srampal
 - srm09
 - starpit


### PR DESCRIPTION
I am an org member for Kubernetes, subproject owner for
the provider-ibmcloud, and reviewer for the
kubernetes-sigs/cluster-api-provider-ibmcloud.