### PR TITLE
Add jaypipes to the kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -275,6 +275,7 @@ members:
 - JAORMX
 - javier-b-perez
 - jayonlau
+- jaypipes
 - jayunit100
 - jbeda
 - jberkhahn


### PR DESCRIPTION
I'm reviewing PRs in the kubernetes-sigs/aws-iam-authenticator project.

I am already a member of the kubernetes org: #1172

/area github-membership

Signed-off-by: Jay Pipes <jaypipes@gmail.com>