### PR TITLE
Add sanposhiho to kube-scheduler-simulator admin

### DIFF
--- a/config/kubernetes-sigs/sig-scheduling/teams.yaml
+++ b/config/kubernetes-sigs/sig-scheduling/teams.yaml
@@ -43,12 +43,12 @@ teams:
     - adtac
     - alculquicondor
     - Huang-Wei
+    - sanposhiho
     privacy: closed
   kube-scheduler-simulator-maintainers:
     description: Write access to the kube-scheduler-simulator
     members:
     - adtac
-    - sanposhiho
     privacy: closed
   poseidon-admins:
     description: Admin access to the poseidon repo


### PR DESCRIPTION
Hello team. hope you have a nice week ahead :)

/cc @alculquicondor 
/cc @Huang-Wei 
/cc @adtac 

add @sanposhiho to kube-scheduler-simulator-admins.

Summary : [kube-scheduler-simulator](https://github.com/kubernetes-sigs/kube-scheduler-simulator) doesn't have reviewers for implementation changes and **I'd like to merge my PRs without reviewing**.

I want to have a discussion for it. 

---

[kube-scheduler-simulator](https://github.com/kubernetes-sigs/kube-scheduler-simulator) now doesn’t have enough reviewers. It’s because it was created by myself on GSoC and very few people (or no people) know the internal implementation details. I can review PRs created by others, but (at least for now) I am the main developer and there is no one who can review my PRs.
As a result, development has been halted since August, when the repo was created. ([ref](https://github.com/kubernetes-sigs/kube-scheduler-simulator/pulls))

So, I propose to add me to admin team and merge my PRs without reviews. (Except, of course, for PRs need discussion or approval.) 

### Why

- **it’s better than stopping development here**
- It is still in the early stages of development.
  - so it doesn't help that there are so few contributers.
  - if the number of contributors increases in the future, we can switch to the normal review process.
- it is not our main project.
  - It's only a side project, so the priority is much lower than main k/k and [scheduler-plugins](https://github.com/kubernetes-sigs/scheduler-plugins). 
- there is some repo that main developer merges his/her PRs without reviews.
  - for example: [golang/mock](https://github.com/golang/mock)
  - but I'm not sure if there are repo like that on kubernetes, kubernetes-sigs org

### alternative way

include something like video or photo in the PR to make it clear that the problem has been solved or a new feature has been added with the PR. And reviewers will approve it if they think it looks good with the video/photo.
This means that the reviewer does not have to do a detailed code review. 