### PR TITLE
kubernetes/sig-cluster-lifecycle: update kubeadm teams

### DIFF
--- a/config/kubernetes/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes/sig-cluster-lifecycle/teams.yaml
@@ -24,19 +24,16 @@ teams:
   kubeadm-admins:
     description: Admin access to the kubeadm repo
     members:
-    - luxas
-    - timothysc
+    - fabriziopandini
+    - neolit123
+    - SataQiu
     privacy: closed
   kubeadm-maintainers:
     description: Write access to the kubeadm repo
     members:
-    - detiber
     - fabriziopandini
-    - luxas
     - neolit123
-    - rosti
     - SataQiu
-    - timothysc
     privacy: closed
   minikube-admins:
     description: Admin access to the minikube repo


### PR DESCRIPTION
Include only the current active approver roster in
maintainers:
https://github.com/kubernetes/kubeadm/blob/cb2f0aef8f780525d0364590fc9a19a04576edea/OWNERS#L4-L6

Include only myself as admin. Admin access is currently
only required for the master->main default branch rename
which is planned for 1.23. Admin access is not required for anything
else and maintainers have sufficient control.

https://github.com/kubernetes/kubeadm/issues/2589