### PR TITLE
Add hidekazuna to cluster-api-provider-openstack-maintainers group

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -188,6 +188,7 @@ teams:
     - chaosaffe
     - chrigl
     - dims
+    - hidekazuna
     - jichenjc
     - sbueringer
     privacy: closed


### PR DESCRIPTION
@hidekazuna is already member of maintainer in the CAPO repository: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/master/OWNERS_ALIASES#L24

This PR adds him to cluster-api-provider-openstack-maintainers group.

Fixes #3060 