### PR TITLE
Updates SIG CLI cli-utils repository admins and maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-cli/teams.yaml
+++ b/config/kubernetes-sigs/sig-cli/teams.yaml
@@ -18,19 +18,18 @@ teams:
   cli-utils-admins:
     description: admin access to cli-utils
     members:
-    - Liujingfang1
-    - mortent
-    - phanimarupaka
-    - pwittrock
+    - eddiezane
+    - knverey
     - seans3
     - soltysh
     privacy: closed
   cli-utils-maintainers:
     description: write access to cli-utils
     members:
+    - karlkfi
     - liggitt
     - Liujingfang1
-    - monopole
+    - mortent
     privacy: closed
   krew-admins:
     description: admin access to krew


### PR DESCRIPTION
* Updates the `cli-utils-admins` to include the full set of new SIG CLI leadership
* Updates the `cli-utils-maintainers` to include active members `karlkfi` and `mortent`, while removing legacy maintainers.