### PR TITLE
Cleanup cluster-api-provider-openstack groups, promote jichenjc to admin

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -175,19 +175,12 @@ teams:
   cluster-api-provider-openstack-admins:
     description: admin access to cluster-api-provider-openstack
     members:
-    - chaosaffe
-    - dims
-    - luxas
-    - roberthbailey
+    - jichenjc
     - sbueringer
-    - timothysc
     privacy: closed
   cluster-api-provider-openstack-maintainers:
     description: write access to cluster-api-provider-openstack
     members:
-    - chaosaffe
-    - chrigl
-    - dims
     - hidekazuna
     - jichenjc
     - sbueringer


### PR DESCRIPTION
Hey folks,

goal of this PR is to cleanup the CAPO admin and maintainer groups. 

According to a short Slack discussion (https://kubernetes.slack.com/archives/C8TSNPY4T/p1635322637149000) it should be fine to only include folks who are currently active maintainers of CAPO.

@chaosaffe @dims @luxas @roberthbailey @timothysc @chrigl Please let me know, in case it's not okay to remove you from those groups.