### PR TITLE
Update CoCC GitHub team to represent current membership

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1454,11 +1454,11 @@ teams:
   code-of-conduct-committee:
     description: Kubernetes Code of Conduct Committee
     members:
-    - aevaonline
     - celestehorgan
     - karenhchu
-    - tashimi
+    - palnabarun
     - tpepper
+    - vllry
     privacy: closed
   csi-api-admins:
     description: Admin access to csi-api repo


### PR DESCRIPTION
Emeritus:
- @AevaOnline 
- @tashimi 

New:
- @palnabarun 
- @vllry 

Signed-off-by: Stephen Augustus <foo@auggie.dev>
cc: @kubernetes/code-of-conduct-committee 
ref: https://groups.google.com/g/kubernetes-dev/c/psxNavBV4i0, https://github.com/kubernetes/community/pull/5967

/assign @mrbobbytables @cblecker 