### PR TITLE
Add s-kawamura-w664 to the kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -551,6 +551,7 @@ members:
 - rudoi
 - runyontr
 - s-ito-ts
+- s-kawamura-w664
 - s-urbaniak
 - saad-ali
 - sahilvv


### PR DESCRIPTION
I'd like to join the kubernetes-sigs organization to review kubernetes-sigs/contributor-playground for upstream-training in Japan.
I am already a member of the kubernetes org: #2803