### PR TITLE
releng: Update publishing-bot teams to include Release Managers

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -153,7 +153,12 @@ teams:
     maintainers:
     - nikhita
     members:
+    - cpanato
     - dims
+    - jeremyrickard
+    - justaugustus
+    - puerco
+    - saschagrunert
     - sttts
     privacy: closed
     previously:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -153,9 +153,7 @@ teams:
     maintainers:
     - nikhita
     members:
-    - caesarxuchao
     - dims
-    - mfojtik
     - sttts
     privacy: closed
     previously:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -148,8 +148,8 @@ teams:
     privacy: closed
     previously:
     - kubernetes-milestone-maintainers
-  publishing-bot-reviewers:
-    description: Reviews for publishing-bot
+  publishing-bot-admins:
+    description: Admin access to the publishing-bot repo
     maintainers:
     - nikhita
     members:
@@ -158,6 +158,8 @@ teams:
     - mfojtik
     - sttts
     privacy: closed
+    previously:
+    - publishing-bot-reviewers
   repo-infra-admins:
     description: Admin access to the repo-infra repo
     maintainers:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -163,6 +163,21 @@ teams:
     privacy: closed
     previously:
     - publishing-bot-reviewers
+  publishing-bot-maintainers:
+    description: Write access to the publishing-bot repo
+    maintainers:
+    - nikhita
+    members:
+    - cpanato
+    - dims
+    - jeremyrickard
+    - justaugustus
+    - puerco
+    - saschagrunert
+    - sttts
+    - Verolop
+    - xmudrii
+    privacy: closed
   repo-infra-admins:
     description: Admin access to the repo-infra repo
     maintainers:


### PR DESCRIPTION
Part of https://github.com/kubernetes/sig-release/issues/1772.

- sig-release: Rename pub-bot team to publishing-bot-admins
- publishing-bot-admins: Prune inactive members
- publishing-bot-admins: Add sig-release-admins
- publishing-bot-maintainers: Create team 

/assign @puerco @cpanato @nikhita @dims 
/cc @kubernetes/publishing-bot-reviewers 
cc: @kubernetes/release-engineering 
/hold for reviews from pub-bot maintainers