### PR TITLE
config: Init kubernetes-nightly org

### DIFF
--- a/config/kubernetes-nightly/OWNERS
+++ b/config/kubernetes-nightly/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - ameukam
+  - palnabarun
+  - savitharaghunathan
+approvers:
+  - cblecker
+  - fejta
+  - idvoretskyi
+  - mrbobbytables
+  - nikhita
+  - spiffxp
+  - ameukam
+  - palnabarun
+  - savitharaghunathan

--- a/config/kubernetes-nightly/org.yaml
+++ b/config/kubernetes-nightly/org.yaml
@@ -17,8 +17,17 @@ admins:
 - thelinuxfoundation
 members:
 - ameukam
+- cpanato
+- dims
+- jeremyrickard
+- justaugustus
 - palnabarun
+- puerco
+- saschagrunert
 - savitharaghunathan
+- sttts
+- Verolop
+- xmudrii
 teams:
   bots:
     description: Bot service accounts in the kubernetes-nightly org

--- a/config/kubernetes-nightly/org.yaml
+++ b/config/kubernetes-nightly/org.yaml
@@ -1,0 +1,26 @@
+name: Kubernetes Nightly
+description: Org for Kubernetes publishing-bot work
+default_repository_permission: read
+has_organization_projects: true
+has_repository_projects: true
+members_can_create_repositories: false
+billing_email: github@kubernetes.io
+admins:
+- cblecker
+- fejta
+- idvoretskyi
+- k8s-ci-robot
+- k8s-github-robot
+- mrbobbytables
+- nikhita
+- spiffxp
+- thelinuxfoundation
+members:
+teams:
+  bots:
+    description: Bot service accounts in the kubernetes-nightly org
+    maintainers:
+    - k8s-ci-robot
+    - k8s-github-robot
+    - thelinuxfoundation
+    privacy: closed

--- a/config/kubernetes-nightly/org.yaml
+++ b/config/kubernetes-nightly/org.yaml
@@ -16,6 +16,9 @@ admins:
 - spiffxp
 - thelinuxfoundation
 members:
+- ameukam
+- palnabarun
+- savitharaghunathan
 teams:
   bots:
     description: Bot service accounts in the kubernetes-nightly org

--- a/config/kubernetes-nightly/org.yaml
+++ b/config/kubernetes-nightly/org.yaml
@@ -7,25 +7,25 @@ members_can_create_repositories: false
 billing_email: github@kubernetes.io
 admins:
 - cblecker
+- cpanato
+- dims
 - fejta
 - idvoretskyi
+- jeremyrickard
+- justaugustus
 - k8s-ci-robot
 - k8s-github-robot
 - mrbobbytables
 - nikhita
+- puerco
+- saschagrunert
 - spiffxp
+- sttts
 - thelinuxfoundation
 members:
 - ameukam
-- cpanato
-- dims
-- jeremyrickard
-- justaugustus
 - palnabarun
-- puerco
-- saschagrunert
 - savitharaghunathan
-- sttts
 - Verolop
 - xmudrii
 teams:

--- a/config/kubernetes-nightly/org.yaml
+++ b/config/kubernetes-nightly/org.yaml
@@ -24,6 +24,7 @@ admins:
 - thelinuxfoundation
 members:
 - ameukam
+- k8s-publishing-bot
 - palnabarun
 - savitharaghunathan
 - Verolop
@@ -35,4 +36,6 @@ teams:
     - k8s-ci-robot
     - k8s-github-robot
     - thelinuxfoundation
+    members:
+    - k8s-publishing-bot
     privacy: closed

--- a/config/kubernetes-nightly/sig-release/OWNERS
+++ b/config/kubernetes-nightly/sig-release/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-release-leads
+approvers:
+  - sig-release-leads
+labels:
+  - sig/release

--- a/config/kubernetes-nightly/sig-release/teams.yaml
+++ b/config/kubernetes-nightly/sig-release/teams.yaml
@@ -2,12 +2,11 @@ teams:
   publishing-bot-admins:
     description: Admin access to publishing repositories
     maintainers:
-    - nikhita
-    members:
     - cpanato
     - dims
     - jeremyrickard
     - justaugustus
+    - nikhita
     - puerco
     - saschagrunert
     - sttts
@@ -17,15 +16,15 @@ teams:
   publishing-bot-maintainers:
     description: Write access to publishing repositories
     maintainers:
-    - nikhita
-    members:
     - cpanato
     - dims
     - jeremyrickard
     - justaugustus
+    - nikhita
     - puerco
     - saschagrunert
     - sttts
+    members:
     - Verolop
     - xmudrii
     privacy: closed

--- a/config/kubernetes-nightly/sig-release/teams.yaml
+++ b/config/kubernetes-nightly/sig-release/teams.yaml
@@ -1,0 +1,31 @@
+teams:
+  publishing-bot-admins:
+    description: Admin access to publishing repositories
+    maintainers:
+    - nikhita
+    members:
+    - cpanato
+    - dims
+    - jeremyrickard
+    - justaugustus
+    - puerco
+    - saschagrunert
+    - sttts
+    privacy: closed
+    previously:
+    - publishing-bot-reviewers
+  publishing-bot-maintainers:
+    description: Write access to publishing repositories
+    maintainers:
+    - nikhita
+    members:
+    - cpanato
+    - dims
+    - jeremyrickard
+    - justaugustus
+    - puerco
+    - saschagrunert
+    - sttts
+    - Verolop
+    - xmudrii
+    privacy: closed


### PR DESCRIPTION
Part of https://github.com/kubernetes/sig-release/issues/1772.

- config: Init kubernetes-nightly org
- k-nightly: Add NMCs as members
- k-nightly: Add SIG Release teams
- k-nightly: Add Release Engineering as org members
- k-nightly: Promote publishing-bot-admins to org admins
- k-nightly: Update config to reflect existing org membership
  - Add @k8s-publishing-bot (member)

Signed-off-by: Stephen Augustus <foo@auggie.dev>

Slack convo: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1638832884428700