### PR TITLE
Fix anyulled member to the right org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -55,7 +55,6 @@ members:
 - animeshsingh
 - Ankitasw
 - ant31
-- anyulled
 - aojea
 - apelisse
 - arahamad

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -82,6 +82,7 @@ members:
 - anthonyrtong
 - antoineco
 - anubha-v-ardhan
+- anyulled
 - aojea
 - aoxn
 - apelisse


### PR DESCRIPTION
The [approval](https://github.com/kubernetes/org/issues/3116) for this member was granted given his contributions to the website translation which means @kubernetes org. This change fixes the permissions to the user.