### PR TITLE
Adds srm09 to capv admins and maintainers list

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -208,20 +208,19 @@ teams:
     description: Admin access to the cluster-api-provider-vsphere repo
     members:
     - akutz
-    - andrewsykim
     - frapposelli
+    - srm09
     - yastij
     privacy: closed
   cluster-api-provider-vsphere-maintainers:
     description: Write access to the cluster-api-provider-vsphere repo
     members:
     - akutz
-    - andrewsykim
-    - detiber
     - figo
     - frapposelli
     - randomvariable
     - sidharthsurana
+    - srm09
     - vincepri
     - yastij
     privacy: closed


### PR DESCRIPTION
This patch adds `srm09` to the CAPV admins and maintainers list. Also, removing community members who are not involved with this project directly anymore.