### PR TITLE
releng: update release managers

### DIFF
--- a/config/kubernetes-nightly/sig-release/teams.yaml
+++ b/config/kubernetes-nightly/sig-release/teams.yaml
@@ -25,6 +25,7 @@ teams:
     - saschagrunert
     - sttts
     members:
+    - palnabarun
     - Verolop
     - xmudrii
     privacy: closed

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -90,7 +90,7 @@ teams:
     - justaugustus # subproject owner / Release Manager
     - mkorbi # Release Manager Associate
     - onlydole # Release Manager Associate
-    - palnabarun # Release Manager Associate
+    - palnabarun # Release Manager
     - puerco # subproject owner / Release Manager
     - saschagrunert # subproject owner / Release Manager
     - sethmccombs # Release Manager Associate

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -106,7 +106,7 @@ teams:
     - NilimaC04 # 1.23 Bug Triage Shadow
     - onlydole # Release Manager Associate
     - oxddr # Scalability
-    - palnabarun # Release Manager Associate
+    - palnabarun # Release Manager
     - parispittman # ContribEx
     - phillels # ContribEx
     - pmorie # Multicluster
@@ -172,6 +172,7 @@ teams:
     - dims
     - jeremyrickard
     - justaugustus
+    - palnabarun
     - puerco
     - saschagrunert
     - sttts
@@ -251,7 +252,7 @@ teams:
         - justaugustus # subproject owner / Release Manager
         - mkorbi # Release Manager Associate
         - onlydole # Release Manager Associate
-        - palnabarun # Release Manager Associate
+        - palnabarun # Release Manager
         - puerco # subproject owner / Release Manager
         - saschagrunert # subproject owner / Release Manager
         - sethmccombs # Release Manager Associate
@@ -270,6 +271,7 @@ teams:
             - cpanato
             - justaugustus
             - k8s-release-robot
+            - palnabarun
             - puerco
             - saschagrunert
             - Verolop


### PR DESCRIPTION
Part of https://github.com/kubernetes/sig-release/issues/1789
- kubernetes: add palnabarun to publishing-bot-maintainers and release-managers
- kubernetes-sigs: Promote palnabarun to Release Manager
- kubernetes-nightly: add palnabarun to publishing-bot-maintainers

/kind documentation