### PR TITLE
Add jihoon-seo to sig-docs-ko-owners

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -149,6 +149,7 @@ teams:
     - claudiajkang
     - gochist
     - ianychoi
+    - jihoon-seo
     - seokho-son
     - ysyukr
     privacy: closed


### PR DESCRIPTION
- Add @jihoon-seo to sig-docs-ko-owners.
- related with kubernetes/website#31206