### PR TITLE
Update teams.yaml

### DIFF
--- a/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
@@ -5,8 +5,8 @@ teams:
     - cblecker
     - mrbobbytables
     - nikhita
-    members:
-    - castrojo
+    - chris-short
+    - kaslin
     privacy: closed
   contributor-tweets-maintainers:
     description: write access to contributor-tweets

--- a/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
@@ -5,6 +5,7 @@ teams:
     - cblecker
     - mrbobbytables
     - nikhita
+    members:
     - chris-short
     - kaslin
     privacy: closed


### PR DESCRIPTION
Adding chris-short and kaslin as admins on the contributor-tweets repo. Removing castrojo at @mrbobbytables request.

Access is needed to help manage the github action and rename master -> main