### PR TITLE
Adding contributor-tweets repo admins

### DIFF
--- a/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
@@ -6,7 +6,8 @@ teams:
     - mrbobbytables
     - nikhita
     members:
-    - castrojo
+    - chris-short
+    - kaslin
     privacy: closed
   contributor-tweets-maintainers:
     description: write access to contributor-tweets


### PR DESCRIPTION
Adding chris-short and kaslin as admins on the contributor-tweets repo. Removing castrojo at @mrbobbytables request.

Access is needed to help manage the github action and rename master -> main