### PR TITLE
Update teams.yaml

### DIFF
--- a/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
@@ -6,7 +6,8 @@ teams:
     - mrbobbytables
     - nikhita
     members:
-    - castrojo
+    - chris-short
+    - kaslin
     privacy: closed
   contributor-tweets-maintainers:
     description: write access to contributor-tweets


### PR DESCRIPTION
Adding Chris Short and Kaslin Fields as admins on the contributor-tweets repo.

Removing Jorge at Bob's request.