### PR TITLE
org: Add dougsland to kubernetes sig org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -185,6 +185,7 @@ members:
 - dobsonj
 - dongsupark
 - dougm
+- dougsland
 - draveness
 - droot
 - dstrebel


### PR DESCRIPTION
GitHub-Issue: https://github.com/kubernetes/org/issues/3171
Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>