### PR TITLE
grant write access for k/structured-merge-diff to jiahuif

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -301,6 +301,7 @@ members:
 - jeremyrickard
 - jhrozek
 - jhvhs
+- jiahuif
 - JiaoDean
 - jiatongw
 - Jiawei0227

--- a/config/kubernetes-sigs/sig-api-machinery/teams.yaml
+++ b/config/kubernetes-sigs/sig-api-machinery/teams.yaml
@@ -209,6 +209,7 @@ teams:
     description: write access to structured-merge-diff
     members:
     - apelisse
+    - jiahuif
     - jpbetz
     - lavalamp
     # emeritus


### PR DESCRIPTION
- membership of kubernetes-sigs, implicitly granted due to existing membership of kubernetes 
- grant write access for k/structured-merge-diff to jiahuif, endorsed by @apelisse 