### PR TITLE
1.24 Release Team Onboarding

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -349,12 +349,12 @@ teams:
               as a notification group. Remove org members who are not current
               Release Team Leads.
             members:
-            - jameslaverack # 1.23 RT Lead Shadow
-            - jeremyrickard # 1.23 Emeritus Advisor
-            - jrsapi # 1.23 RT Lead Shadow
-            - mkorbi # 1.23 RT Lead Shadow
-            - monzelmasry # 1.23 RT Lead Shadow
-            - reylejano # 1.23 RT Lead
+            - cici37 # 1.24 RT Lead Shadow
+            - jameslaverack # 1.24 RT Lead
+            - jlbutler # 1.24 RT Lead Shadow
+            - jrsapi # 1.24 EA
+            - mkorbi # 1.24 RT Lead Shadow
+            - salaxander # 1.24 RT Lead Shadow
             privacy: closed
       sig-release-admins:
         description: Admins for SIG Release repositories

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -39,7 +39,7 @@ teams:
     - caseydavenport # Network
     - cheftako # Cloud Provider
     - chrigl # OpenStack
-    - cici37 # 1.23 Release Notes Lead
+    - cici37 # 1.24 Release Lead Shadow
     - claudiubelu # Windows
     - cpanato # Release Manager
     - craiglpeters # Azure
@@ -49,43 +49,46 @@ teams:
     - deads2k # API Machinery / Auth
     - derekwaynecarr # Architecture / Node
     - dims # Architecture / Release
+    - DiptoChakrabarty # 1.24 Bug Triage Shadow
+    - doshyt # 1.24 Bug Triage Shadow
     - eddiezane # CLI
     - ehashman # Instrumentation
-    - encodeflush # 1.23 CI Signal Lead
+    - encodeflush # 1.24 Enhancements Shadow
     - enj # Auth
     - fabriziopandini # Cluster Lifecycle
     - feiskyer # Azure
     - floreks # UI
     - foxish # Big Data
     - frapposelli # VMware
-    - gracenng # 1.23 Enhancements Shadow
+    - gracenng # 1.24 Enhancements Lead
+    - helayoty # 1.24 Bug Triage Shadow
     - hpandeycodeit # Usability
     - Huang-Wei # Scheduling
-    - jameslaverack # 1.23 RT Lead Shadow
+    - jameslaverack # 1.24 RT Lead
     - janetkuo # Apps
     - jayunit100 # Windows
     - jberkus # Release
     - jdumars # Architecture / PM
-    - jeremyrickard # Release / 1.23 Emeritus Adviser
+    - jeremyrickard # Release
     - jhvhs # Service Catalog
+    - jiahuif # 1.24 Enhancements Shadow
     - jimangel # Docs / Release Manager Associate
-    - jlbutler # 1.23 Docs Lead
+    - jlbutler # 1.24 RT Lead Shadow
     - johnbelamaric # Architecture
-    - jrsapi # 1.23 RT Lead Shadow
+    - jrsapi # 1.24 EA
     - jsafrane # Storage
     - jsturtevant # Windows
     - justaugustus # Release
     - justinsb # AWS / Cluster Lifecycle
-    - jyotimahapatra # 1.23 Bug Triage Shadow
+    - jyotimahapatra # 1.24 Bug Triage Lead
     - k8s-release-robot # Release
     - karenhchu # 1.23 Release Comms Lead
-    - kevindelgado # 1.23 Enhancements Shadow
     - khenidak # Azure
     - KnVerey # CLI
     - kow3ns # Apps
-    - lauralorenz # 1.23 Enhancements Shadow
     - lavalamp # API Machinery
     - liggitt # Auth / Release
+    - leonardpahlke # 1.24 CI Signal Lead
     - lingxiankong # OpenStack
     - liyinan926 # Big Data
     - logicalhan # Instrumentation
@@ -94,33 +97,32 @@ teams:
     - marosset # Windows
     - mattfarina # Apps / Architecture
     - mborsz # Scalability
+    - mickeyboxell # 1.24 Comms Lead
     - mikedanese # Auth
-    - mkorbi # Release Manager Associate / 1.23 RT Lead Shadow
+    - mkorbi # Release Manager Associate / 1.24 RT Lead Shadow
     - mm4tt # Scalability
-    - monzelmasry # 1.23 Lead Shadow
     - msau42 # Storage
     - mwielgus # Autoscaling
-    - nannancy # 1.23 Bug Triage Shadow
+    - nate-double-u # 1.24 Docs Lead
     - nckturner # AWS
     - neolit123 # Cluster Lifecycle
-    - NilimaC04 # 1.23 Bug Triage Shadow
     - onlydole # Release Manager Associate
     - oxddr # Scalability
     - palnabarun # Release Manager
     - parispittman # ContribEx
     - phillels # ContribEx
     - pmorie # Multicluster
-    - Priyankasaggu11929 # 1.23 Enhancements Shadow
+    - Priyankasaggu11929 # 1.24 Enhancements Shadow
     - prydonius # Apps
     - puerco # Release Manager
     - pwittrock # CLI
     - quinton-hoole # Multicluster
     - RainbowMango # Instrumentation
     - rajakavitha1 # Usability
-    - reylejano # 1.23 RT Lead
-    - ritpanjw # 1.23 Bug Triage Shadow
+    - rhockenbury # 1.24 Enhancements Shadow
+    - ritpanjw # 1.24 Bug Triage Shadow
     - saad-ali # Storage
-    - salaxander # 1.23 Enhancements Lead
+    - salaxander # 1.24 RT Lead Shadow
     - saschagrunert # Release
     - SataQiu # Cluster Lifecycle
     - seans3 # CLI
@@ -131,16 +133,14 @@ teams:
     - soltysh # CLI
     - spzala # IBM Cloud
     - stevekuznetsov # Testing
-    - supriya-premkumar # 1.23 Enhancements Shadow
     - tallclair # Auth
     - tashimi # Usability
     - thejoycekung # Release Manager Associate
     - thockin # Network
     - timothysc # Cluster Lifecycle / Testing
-    - varshaprasad96 # 1.23 Bug Triage Shadow
     - Verolop # Release Manager
     - vllry # Usability
-    - voigt # 1.23 Bug Triage Lead
+    - voigt # 1.24 CI Signal Shadow
     - wilsonehusin # Release Manager Associate
     - wojtek-t # Scalability
     - xing-yang # Storage

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -49,8 +49,8 @@ teams:
     - deads2k # API Machinery / Auth
     - derekwaynecarr # Architecture / Node
     - dims # Architecture / Release
-    - DiptoChakrabarty # 1.24 Bug Triage Shadow
-    - doshyt # 1.24 Bug Triage Shadow
+    # - DiptoChakrabarty # 1.24 Bug Triage Shadow
+    # - doshyt # 1.24 Bug Triage Shadow
     - eddiezane # CLI
     - ehashman # Instrumentation
     - encodeflush # 1.24 Enhancements Shadow
@@ -119,7 +119,7 @@ teams:
     - quinton-hoole # Multicluster
     - RainbowMango # Instrumentation
     - rajakavitha1 # Usability
-    - rhockenbury # 1.24 Enhancements Shadow
+    # - rhockenbury # 1.24 Enhancements Shadow
     - ritpanjw # 1.24 Bug Triage Shadow
     - saad-ali # Storage
     - salaxander # 1.24 RT Lead Shadow
@@ -287,11 +287,11 @@ teams:
         - chrisnegus # 1.24 Docs Shadow
         - cici37 # 1.24 RT Lead Shadow
         - cpanato # subproject owner / Technical Lead
-        - csantanapr # 1.24 Release Notes Shadow
+        # - csantanapr # 1.24 Release Notes Shadow
         - Debanitrkl # 1.24 Comms Shadow
-        - didicodes # 1.24 Docs Shadow
-        - DiptoChakrabarty # 1.24 Bug Triage Shadow
-        - doshyt # 1.24 Bug Triage Shadow
+        # - didicodes # 1.24 Docs Shadow
+        # - DiptoChakrabarty # 1.24 Bug Triage Shadow
+        # - doshyt # 1.24 Bug Triage Shadow
         - encodeflush # 1.24 Enhancements Shadow
         - gracenng # 1.24 Enhancements Lead
         - helayoty # 1.24 Bug Triage Shadow
@@ -305,12 +305,12 @@ teams:
         - katcosgrove # 1.24 Release Comms Shadow
         - lauralorenz # 1.24 CI Signal Shadow
         - leonardpahlke # 1.24 CI Signal Lead
-        - Lp-Francois # 1.24 Release Notes Shadow
+        # - Lp-Francois # 1.24 Release Notes Shadow
         - mehabhalodiya # 1.24 Docs Shadow
         - mickeyboxell # 1.24 Comms Lead
         - mkorbi # 1.24 RT Lead Shadow
         - nate-double-u # 1.24 Docs Lead
-        - Nivedita-coder # 1.24 CI Signal Shadow
+        # - Nivedita-coder # 1.24 CI Signal Shadow
         - onlydole # subproject owner (1.19 RT Lead)
         - palnabarun # subproject owner (1.21 RT Lead)
         - parul5sahoo # 1.24 Release Notes Shadow
@@ -318,15 +318,15 @@ teams:
         - Priyankasaggu11929 # 1.24 Enhancements Shadow
         - puerco # subproject owner / Technical Lead
         - reylejano # subproject owner (1.23 RT Lead)
-        - rhockenbury # 1.24 Enhancements Shadow
+        # - rhockenbury # 1.24 Enhancements Shadow
         - RinkiyaKeDad # 1.24 Release Notes Shadow
         - ritpanjw # 1.24 Bug Triage Shadow
-        - s04 # 1.24 Comms Shadow
+        # - s04 # 1.24 Comms Shadow
         - salaxander # 1.24 RT Lead Shadow
         - saschagrunert # subproject owner / Chair
         - savitharaghunathan # subproject owner (1.22 RT Lead)
-        - shuheiktgw # 1.24 CI Signal Shadow
-        - valaparthvi # 1.24 Comms Shadow
+        # - shuheiktgw # 1.24 CI Signal Shadow
+        # - valaparthvi # 1.24 Comms Shadow
         - Verolop # Release Manager
         - voigt # 1.24 CI Signal Shadow
         - xmudrii # Release Manager
@@ -338,8 +338,8 @@ teams:
             members:
             - lauralorenz # 1.24 CI Signal Shadow
             - leonardpahlke # 1.24 CI Signal Lead
-            - Nivedita-coder # 1.24 CI Signal Shadow
-            - shuheiktgw # 1.24 CI Signal Shadow
+            # - Nivedita-coder # 1.24 CI Signal Shadow
+            # - shuheiktgw # 1.24 CI Signal Shadow
             - voigt # 1.24 CI Signal Shadow
             privacy: closed
           release-team-leads:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -283,53 +283,52 @@ teams:
       release-team:
         description: Members of the current Release Team and subproject owners.
         members:
-        - AuraSinis # 1.23 Release Notes Shadow
-        - calvh # 1.23 CI Signal Shadow
-        - cccswann # 1.23 Release Comms Shadow
-        - chrisnegus # 1.23 Docs Shadow
-        - cici37 # 1.23 Release Notes Lead
+        - AuraSinis # 1.24 Release Notes Lead
+        - chrisnegus # 1.24 Docs Shadow
+        - cici37 # 1.24 RT Lead Shadow
         - cpanato # subproject owner / Technical Lead
-        - Damans227 # 1.23 Release Notes Shadow
-        - encodeflush # 1.23 CI Signal Lead
-        - gracenng # 1.23 Enhancements Shadow
-        - jameslaverack # 1.23 RT Lead Shadow
+        - csantanapr # 1.24 Release Notes Shadow
+        - encodeflush # 1.24 Enhancements Shadow
+        - Debanitrkl # 1.24 Comms Shadow
+        - didicodes # 1.24 Docs Shadow
+        - DiptoChakrabarty # 1.24 Bug Triage Shadow
+        - doshyt # 1.24 Bug Triage Shadow
+        - gracenng # 1.24 Enhancements Lead
+        - helayoty # 1.24 Bug Triage Shadow
+        - jameslaverack # subproject owner (1.24 RT Lead)
         - jeremyrickard # subproject owner / Technical Lead
-        - jlbutler # 1.23 Docs Lead
-        - jrsapi # 1.23 RT Lead Shadow
+        - jiahuif # 1.24 Enhancements Shadow
+        - jlbutler # 1.24 RT Lead Shadow
+        - jrsapi # 1.24 EA
         - justaugustus # subproject owner / Chair
-        - jyotimahapatra # 1.23 Bug Triage Shadow
-        - karenhchu # 1.23 Release Comms Lead
-        - kaslin # 1.23 Release Comms Shadow 
-        - katcosgrove # 1.23 Release Comms Shadow
-        - kevindelgado # 1.23 Enhancements Shadow
-        - lauralorenz # 1.23 Enhancements Shadow
-        - leonardpahlke # 1.23 CI Signal Shadow
-        - mehabhalodiya # 1.23 Docs Shadow
-        - mickeyboxell # 1.23 Release Comms Shadow
-        - mkorbi # 1.23 RT Lead Shadow
-        - monzelmasry # 1.23 RT Lead Shadow
-        - nannancy # 1.23 Bug Triage Shadow
-        - nate-double-u # 1.23 Docs Shadow
-        - NilimaC04 # 1.23 Bug Triage Shadow
+        - jyotimahapatra # 1.24 Bug Triage Lead
+        - katcosgrove # 1.24 Release Comms Shadow
+        - lauralorenz # 1.24 CI Signal Shadow
+        - leonardpahlke # 1.24 CI Signal Lead
+        - Lp-Francois # 1.24 Release Notes Shadow
+        - mehabhalodiya # 1.24 Docs Shadow
+        - mickeyboxell # 1.24 Comms Lead
+        - mkorbi # 1.24 RT Lead Shadow
+        - nate-double-u # 1.24 Docs Lead
+        - Nivedita-coder # 1.24 CI Signal Shadow
         - onlydole # subproject owner (1.19 RT Lead)
         - palnabarun # subproject owner (1.21 RT Lead)
-        - parul5sahoo # 1.23 Release Notes Shadow
-        - Priyankasaggu11929 # 1.23 Enhancements Shadow
+        - parul5sahoo # 1.24 Release Notes Shadow
+        - pi-victor # 1.24 Docs Shadow
+        - Priyankasaggu11929 # 1.24 Enhancements Shadow
         - puerco # subproject owner / Technical Lead
-        - rajula96reddy # 1.23 CI Signal Shadow
-        - ramrodo # 1.23 Docs Shadow
         - reylejano # subproject owner (1.23 RT Lead)
-        - RinkiyaKeDad # 1.23 CI Signal Shadow
-        - ritpanjw # 1.23 Bug Triage Shadow
-        - salaxander # 1.23 Enhancements Lead
-        - sam-cogan # 1.23 Release Notes Shadow
+        - rhockenbury # 1.24 Enhancements Shadow
+        - RinkiyaKeDad # 1.24 Release Notes Shadow
+        - ritpanjw # 1.24 Bug Triage Shadow
+        - s04 # 1.24 Comms Shadow
+        - salaxander # 1.24 RT Lead Shadow
         - saschagrunert # subproject owner / Chair
         - savitharaghunathan # subproject owner (1.22 RT Lead)
-        - simrangupta234 # 1.23 CI Signal Shadow
-        - supriya-premkumar # 1.23 Enhancements Shadow
-        - varshaprasad96 # 1.23 Bug Triage Shadow
+        - shuheiktgw # 1.24 CI Signal Shadow
+        - valaparthvi # 1.24 Comms Shadow
         - Verolop # Release Manager
-        - voigt # 1.23 Bug Triage Lead
+        - voigt # 1.24 CI Signal Shadow
         - xmudrii # Release Manager
         privacy: closed
         teams:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -87,8 +87,8 @@ teams:
     - KnVerey # CLI
     - kow3ns # Apps
     - lavalamp # API Machinery
-    - liggitt # Auth / Release
     - leonardpahlke # 1.24 CI Signal Lead
+    - liggitt # Auth / Release
     - lingxiankong # OpenStack
     - liyinan926 # Big Data
     - logicalhan # Instrumentation
@@ -288,11 +288,11 @@ teams:
         - cici37 # 1.24 RT Lead Shadow
         - cpanato # subproject owner / Technical Lead
         - csantanapr # 1.24 Release Notes Shadow
-        - encodeflush # 1.24 Enhancements Shadow
         - Debanitrkl # 1.24 Comms Shadow
         - didicodes # 1.24 Docs Shadow
         - DiptoChakrabarty # 1.24 Bug Triage Shadow
         - doshyt # 1.24 Bug Triage Shadow
+        - encodeflush # 1.24 Enhancements Shadow
         - gracenng # 1.24 Enhancements Lead
         - helayoty # 1.24 Bug Triage Shadow
         - jameslaverack # subproject owner (1.24 RT Lead)

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -336,12 +336,11 @@ teams:
             description: Members of the CI Signal team for the current release
               cycle.
             members:
-            - calvh # 1.23 CI Signal Shadow
-            - encodeflush # 1.23 CI Signal Lead
-            - leonardpahlke # 1.23 CI Signal Shadow
-            - rajula96reddy # 1.23 CI Signal Shadow
-            - RinkiyaKeDad # 1.23 CI Signal Shadow
-            - simrangupta234 # 1.23 CI Signal Shadow
+            - lauralorenz # 1.24 CI Signal Shadow
+            - leonardpahlke # 1.24 CI Signal Lead
+            - Nivedita-coder # 1.24 CI Signal Shadow
+            - shuheiktgw # 1.24 CI Signal Shadow
+            - voigt # 1.24 CI Signal Shadow
             privacy: closed
           release-team-leads:
             description: Release Team Leads for the current Kubernetes release

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -222,6 +222,7 @@ teams:
     - cpanato # Technical Lead
     - dims
     - ixdy
+    - JamesLaverack
     - jberkus
     - jdumars
     - jeefy


### PR DESCRIPTION
  - Add RT Lead to sig-release
  - Update sig-release/release-team with RT Lead, EA, RT Lead shadows, Role Leads, Role Shadows and subproject owners
  - Add RT Lead, EA, RT Lead shadows, Role Leads, Enhancements shadows, and Bug Triage shadows to milestone-mantainers
  - Replace current sig-release/release-team/release-team-leads members with RT Lead, EA, RT Lead Shadows
  - Replace sig-release/release-team/ci-signal with CI Signal Lead and CI Signal Shadows

xref https://github.com/kubernetes/sig-release/issues/1791