### PR TITLE
Add 1.24 Docs Shadows to GitHub teams

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -350,9 +350,11 @@ teams:
     - bene2k1
     - bradtopol
     - celestehorgan
+    - chrisnegus # 1.24 RT Docs Shadow
     - claudiajkang
     - cstoku
     - dianaabv
+    - didicodes # 1.24 RT Docs Shadow
     - femrtnz
     - girikuncoro
     - gochist
@@ -363,6 +365,7 @@ teams:
     - juandiegopalomino
     - jygastaud
     - lledru
+    - mehabhalodiya # 1.24 RT Docs Shadow
     - msheldyakov
     - nasa9084
     - nate-double-u # 1.24 RT Docs Lead
@@ -370,6 +373,7 @@ teams:
     - onlydole
     - oussemos
     - perriea
+    - pi-victor # 1.24 RT Docs Shadow
     - potapy4
     - raelga
     - Rajakavitha1


### PR DESCRIPTION
Add 1.24 Docs Shadows to `website-milestone-maintainers` in sig-docs/teams.yaml and `release-team` in `sig-release/teams.yaml` GitHub teams

/assign @palnabarun @kikisdeliveryservice @savitharaghunathan @bai
/cc @JamesLaverack 