### PR TITLE
Add Fedosin to kubernetes-sigs organization

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -207,6 +207,7 @@ members:
 - Ethyling
 - f0rmiga
 - fabriziopandini
+- Fedosin
 - Fei-Guo
 - feiskyer
 - feloy


### PR DESCRIPTION
I'm already a member of `kubernetes` org: https://github.com/kubernetes/org/blob/main/config/kubernetes/org.yaml#L371