### PR TITLE
Update Kustomize teams

### DIFF
--- a/config/kubernetes-sigs/sig-cli/teams.yaml
+++ b/config/kubernetes-sigs/sig-cli/teams.yaml
@@ -106,15 +106,9 @@ teams:
     description: ""
     members:
     - knverey
-    - monopole
-    - pwittrock
+    - natasha41575
     privacy: closed
   kustomize-maintainers:
     description: ""
-    members:
-    - justinsb
-    - mortent
-    - natasha41575
-    - phanimarupaka
-    - Shell32-Natsu
+    members: [] # there are currently no maintainers besides the owners
     privacy: closed


### PR DESCRIPTION
Second part of updates/cleanup in https://github.com/kubernetes-sigs/kustomize/pull/4426. Per [Kustomize's contributor ladder](https://github.com/kubernetes-sigs/kustomize/blob/master/CONTRIBUTING.md#contributor-ladder), owners should be on the "admins" list here and approvers should be on "maintainers". Since the former has more permissions than the latter, it is not necessary to add owners to both. The (unfortunate) reality is that we don't have any approvers besides our owners at this point, hence the second list now being empty. Emeritus status is reflected in Kustomize's internal owners file rather than being duplicated here.

/cc @natasha41575 