### PR TITLE
Add dgrisonnet to sig-instrumentation leads and approvers

### DIFF
--- a/config/kubernetes/sig-instrumentation/teams.yaml
+++ b/config/kubernetes/sig-instrumentation/teams.yaml
@@ -2,8 +2,8 @@ teams:
   sig-instrumentation-leads:
     description: ""
     members:
-    - brancz
     - dashpole
+    - dgrisonnet
     - ehashman
     - logicalhan
     privacy: closed
@@ -12,6 +12,7 @@ teams:
     members:
     - brancz
     - dashpole
+    - dgrisonnet
     - ehashman
     - logicalhan
     - RainbowMango


### PR DESCRIPTION
Update the sig-instrumentation teams after:
- https://github.com/kubernetes/org/pull/3213
- https://github.com/kubernetes/kubernetes/pull/107793

/cc @logicalhan @ehashman 