### PR TITLE
Use new dev email in membership request

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.yml
+++ b/.github/ISSUE_TEMPLATE/membership.yml
@@ -31,7 +31,7 @@ body:
       required: true
     - label: I have [enabled 2FA on my GitHub account](https://github.com/settings/security)
       required: true
-    - label: I have subscribed to the [kubernetes-dev e-mail list](https://groups.google.com/forum/#!forum/kubernetes-dev)
+    - label: I have subscribed to the [kubernetes dev e-mail list](https://groups.google.com/a/kubernetes.io/group/dev)
       required: true
     - label: I am actively contributing to 1 or more Kubernetes subprojects
       required: true


### PR DESCRIPTION
The current group is being sunset in favor of the new group. This changes the link to point directly to it.