### PR TITLE
Update sig-cli GitHub teams

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1741,8 +1741,7 @@ teams:
     description: Admin access to the kubectl repo
     members:
     - eddiezane
-    - monopole
-    - pwittrock
+    - KnVerey
     - seans3
     - soltysh
     privacy: closed
@@ -1750,8 +1749,7 @@ teams:
     description: Write access to the kubectl repo
     members:
     - eddiezane
-    - monopole
-    - pwittrock
+    - KnVerey
     - seans3
     - soltysh
     privacy: closed

--- a/config/kubernetes/sig-cli/teams.yaml
+++ b/config/kubernetes/sig-cli/teams.yaml
@@ -1,121 +1,18 @@
 teams:
-  sig-cli-api-reviews:
+  sig-cli-leads:
     description: ""
     members:
-    - adohe
-    - janetkuo
+    - eddiezane
     - KnVerey
-    - pwittrock
     - seans3
     - soltysh
     privacy: closed
-  sig-cli-bugs:
+  sig-cli-kubectl-maintainers:
     description: ""
     members:
-    - adohe
-    - dixudx
-    - janetkuo
+    - brianpursley
+    - eddiezane
     - KnVerey
-    - mengqiy
-    - pwittrock
-    - seans3
-    - shiywang
-    - soltysh
-    - wanghaoran1988
-    privacy: closed
-  sig-cli-feature-requests:
-    description: ""
-    members:
-    - adohe
-    - davidopp
-    - janetkuo
-    - KnVerey
-    - mengqiy
-    - pwittrock
-    - seans3
-    - shiywang
-    - smarterclayton
-    - soltysh
-    - wanghaoran1988
-    privacy: closed
-  sig-cli-maintainers:
-    description: ""
-    members:
-    - adohe
-    - janetkuo
-    - KnVerey
-    - liggitt
-    - mengqiy
-    - monopole
-    - pwittrock
-    - seans3
-    - soltysh
-    privacy: closed
-  sig-cli-misc:
-    description: Use only if you can't figure out a better category
-    members:
-    - adohe
-    - brendandburns
-    - deads2k
-    - dims
-    - eparis
-    - janetkuo
-    - KnVerey
-    - mengqiy
-    - pwittrock
-    - seans3
-    - shiywang
-    - smarterclayton
-    - soltysh
-    - sttts
-    - wanghaoran1988
-    privacy: closed
-  sig-cli-pr-reviews:
-    description: ""
-    members:
-    - adohe
-    - deads2k
-    - derekwaynecarr
-    - dims
-    - dixudx
-    - eparis
-    - janetkuo
-    - KnVerey
-    - liggitt
-    - mengqiy
-    - pwittrock
-    - rootfs
-    - seans3
-    - shiywang
-    - smarterclayton
-    - soltysh
-    - sttts
-    - wanghaoran1988
-    - yue9944882
-    privacy: closed
-  sig-cli-proposals:
-    description: ""
-    members:
-    - adohe
-    - brendandburns
-    - davidopp
-    - deads2k
-    - janetkuo
-    - KnVerey
-    - liggitt
-    - mengqiy
-    - pwittrock
-    - seans3
-    - shiywang
-    - smarterclayton
-    - soltysh
-    privacy: closed
-  sig-cli-test-failures:
-    description: ""
-    members:
-    - adohe
-    - KnVerey
-    - pwittrock
     - seans3
     - soltysh
     privacy: closed


### PR DESCRIPTION
This PR replaces unused sig-cli teams with updated and simplified ones.