### PR TITLE
Re-add Jim Angel for SIG Docs

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -176,6 +176,7 @@ teams:
     description: Chairs and tech leads for SIG Docs
     members:
     - divya-mohan0209
+    - jimangel
     - kbhawkey
     - natalisucks
     - onlydole
@@ -306,6 +307,7 @@ teams:
     - kubernetes-website-admins
     members:
     - divya-mohan0209
+    - jimangel
     - natalisucks
     - reylejano
     privacy: closed


### PR DESCRIPTION
Jim Angel is a SIG Docs co-chair until the end of the first quarter, March 31, 2022 per [email to dev@](https://groups.google.com/a/kubernetes.io/g/dev/c/SP6weMvx3wg/m/l8LAL-OFCQAJ)


/cc @jimangel