### PR TITLE
kubernetes-sigs: add endocrimes as member

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -206,6 +206,7 @@ members:
 - EleanorRigby
 - electrocucaracha
 - elmiko
+- endocrimes
 - entro-pi
 - enxebre
 - EppO


### PR DESCRIPTION
Adding myself as a member to kubernetes-sigs to simplify contributions to image-builder and other projects (as per https://github.com/kubernetes/community/blob/master/community-membership.md#kubernetes-ecosystem for existing k8s org members)