### PR TITLE
Add chaodaiG as k8s-sig member

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -113,6 +113,7 @@ members:
 - celestehorgan
 - chadswen
 - champtar
+- chaodaiG
 - chaosaffe
 - charleszheng44
 - cheftako


### PR DESCRIPTION
fixes: https://github.com/kubernetes/org/issues/3270

chaodaiG is already a member of kubernetes