### PR TITLE
cluster-api: add sbueringer to cluster-api-maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -30,6 +30,7 @@ teams:
     - CecileRobertMichon
     - enxebre
     - fabriziopandini
+    - sbueringer
     - vincepri
     privacy: closed
   cluster-api-operator-admins:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

Follow-up to: https://github.com/kubernetes-sigs/cluster-api/pull/6109

/assign @fabriziopandini 