### PR TITLE
Add chases2 to kubernetes-sigs/org as member

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -116,6 +116,7 @@ members:
 - chaodaiG
 - chaosaffe
 - charleszheng44
+- chases2
 - cheftako
 - chendotjs
 - chethanv28


### PR DESCRIPTION
@chases2  is already a member of kubernetes
Needed to maintain boskos as oncall member

xref to https://github.com/kubernetes/org/pull/3271