### PR TITLE
Add bridgetkromhout to the kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -98,6 +98,7 @@ members:
 - brahmaroutu
 - brancz
 - brianpursley
+- bridgetkromhout
 - bswartz
 - bzub
 - caesarxuchao


### PR DESCRIPTION
I'm [already a member of the kubernetes org](https://github.com/kubernetes/org/issues/1253) and need to join kubernetes-sigs now. Thanks!

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>