### PR TITLE
Add oomichi/cristicalin to kubespray-maintainers team

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -279,12 +279,10 @@ teams:
     description: Write access to the kubespray repo
     members:
     - ant31
-    - Atoms
     - chadswen
+    - cristicalin
     - floryut
     - mattymo
     - miouge1
-    - mirwan
-    - riverzhang
-    - woopstar
+    - oomichi
     privacy: closed


### PR DESCRIPTION
@oomichi and @cristicalin are both valuable members, who are now full time approvers/maintainers of kubespray.

Hats down for you guys.