### PR TITLE
SIG Instrumentation team updates for 2021

### DIFF
--- a/config/kubernetes/sig-instrumentation/teams.yaml
+++ b/config/kubernetes/sig-instrumentation/teams.yaml
@@ -22,6 +22,7 @@ teams:
     description: ""
     members:
     - brancz
+    - CatherineF-dev
     - coffeepac
     - dashpole
     - dgrisonnet
@@ -30,6 +31,7 @@ teams:
     - erain
     - lilic
     - logicalhan
+    - pohly
     - RainbowMango
     - s-urbaniak
     - serathius

--- a/config/kubernetes/sig-instrumentation/teams.yaml
+++ b/config/kubernetes/sig-instrumentation/teams.yaml
@@ -21,14 +21,11 @@ teams:
   sig-instrumentation-members:
     description: ""
     members:
-    - 44past4
-    - andyxning
     - brancz
     - coffeepac
     - dashpole
     - dgrisonnet
     - dims
-    - DirectXMan12
     - ehashman
     - erain
     - lilic


### PR DESCRIPTION
See our 2020 cleanup in https://github.com/kubernetes/org/pull/2497 and https://github.com/kubernetes/org/pull/2541.

The first commit removes inactive contributors. I am defining "inactive" as ([<50 contributions on devstats for the past year](https://k8s.devstats.cncf.io/d/13/developer-activity-counts-by-repository-group?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=All&var-country_name=All) **and** does not attend [regular SIG meetings](https://docs.google.com/document/d/1FE4AQ8B49fYbKhfg4Tx0cui1V0eI4o3PxoqQPUwNEiU/edit#)) **or** requested emeritus status from the project.

The second commit adds two new SIG members, @CatherineF-dev and @pohly. Congratulations and welcome!

/cc @kubernetes/sig-instrumentation-leads 