### PR TITLE
k8s-sigs: Add rohityadavcloud and davidjumani as members

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -169,6 +169,7 @@ members:
 - dashpole
 - davidewatson
 - davidopp
+- davidjumani
 - davidvossel
 - davidz627
 - dberkov

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -605,6 +605,7 @@ members:
 - robinpercy
 - robscott
 - rolfedh
+- rohityadavcloud
 - roycaihw
 - rrati
 - rsmitty


### PR DESCRIPTION
Adds @rohityadavcloud and @davidjumani to kubernetes-sig org as members. This inline with a discussion on https://github.com/kubernetes/org/issues/3279 to have the two become org members to facilitate the migration of cloudstack CAPI provider (https://github.com/aws/cluster-api-provider-cloudstack) repo to k8s-sigs.

Fixes #3312
Fixes #3319