### PR TITLE
Add rohityadavcloud and davidjumani to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -604,6 +604,7 @@ members:
 - roberthbailey
 - robinpercy
 - robscott
+- rohityadavcloud
 - rolfedh
 - roycaihw
 - rrati

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -168,6 +168,7 @@ members:
 - danwinship
 - dashpole
 - davidewatson
+- davidjumani
 - davidopp
 - davidvossel
 - davidz627


### PR DESCRIPTION
Adds @rohityadavcloud and @davidjumani to kubernetes-sig org as members.

This inline with a discussion on https://github.com/kubernetes/org/issues/3279 to have the two become org members to facilitate the migration of cloudstack CAPI provider (https://github.com/aws/cluster-api-provider-cloudstack) repo to k8s-sigs.

Fixes https://github.com/kubernetes/org/issues/3312
Fixes https://github.com/kubernetes/org/issues/3319