### PR TITLE
Update kube-state-metrics teams

### DIFF
--- a/config/kubernetes/sig-instrumentation/teams.yaml
+++ b/config/kubernetes/sig-instrumentation/teams.yaml
@@ -43,18 +43,14 @@ teams:
   kube-state-metrics-admins:
     description: Admin access to the kube-state-metrics repo
     members:
-    - brancz
-    - lilic
+    - dgrisonnet
+    - fpetkovski
     - mrueg
-    - tariq1890
     privacy: closed
   kube-state-metrics-maintainers:
     description: Write access to the kube-state-metrics repo
     members:
-    - brancz
     - dgrisonnet
     - fpetkovski
-    - lilic
     - mrueg
-    - tariq1890
     privacy: closed


### PR DESCRIPTION
Following up PR to the update of kube-state-metrics OWNERS: https://github.com/kubernetes/kube-state-metrics/pull/1712.

/cc @fpetkovski @mrueg 