### PR TITLE
Add ptux to sig-docs-ja-reviews

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -148,6 +148,7 @@ teams:
     - kakts
     - makocchi-git
     - nasa9084
+    - ptux
     privacy: closed
   sig-docs-ko-owners:
     description: Approvers for Korean content


### PR DESCRIPTION
Add ptux to sig-docs-ja-reviews

related with https://github.com/kubernetes/website/pull/32734