### PR TITLE
Remove inactive members

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -274,7 +274,6 @@ members:
 - hannibalhuang
 - hantaowang
 - haosdent
-- haoshuwei
 - hardikdr
 - hasbro17
 - hasheddan

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -432,7 +432,6 @@ members:
 - luxas
 - lzhecheng
 - m00nf1sh
-- m1093782566
 - macaptain
 - maciaszczykm
 - Madhan-SWE

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -279,7 +279,6 @@ members:
 - danielqsj
 - Danil-Grigorev
 - danninov
-- danpopnyc
 - danwinship
 - DanyC97
 - dashpole

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -119,7 +119,6 @@ members:
 - atoato88
 - Atoms
 - AuraSinis
-- Aut0R3V
 - aveshagarwal
 - avidLearnerInProgress
 - AvineshTripathi

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -758,7 +758,6 @@ members:
 - lyzs90
 - lzhecheng
 - m00nf1sh
-- m1093782566
 - m1kola
 - m3ngyang
 - maciaszczykm

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1200,7 +1200,6 @@ members:
 - swamymsft
 - swatisehgal
 - swetharepakula
-- swinslow
 - sxllwx
 - SyamSundarKirubakaran
 - szuecs

--- a/config/kubernetes/sig-network/teams.yaml
+++ b/config/kubernetes/sig-network/teams.yaml
@@ -47,7 +47,6 @@ teams:
     - cmluciano
     - dcbw
     - feiskyer
-    - m1093782566
     - thockin
     privacy: closed
   sig-network-proposals:


### PR DESCRIPTION
All members in this PR have manually left the org, never accepted or turned down the invites. This is causing peribolos to re-invite members and fill up the logs with failed invites.

/hold