### PR TITLE
Add everpeace to kubernetes-sigs organization

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -230,6 +230,7 @@ members:
 - erikgb
 - estroz
 - Ethyling
+- everpeace
 - f0rmiga
 - fabriziopandini
 - Fedosin


### PR DESCRIPTION
According to the community documentation, a member in a Kubernetes related Github organizations are implicitly eligible for membership in related organizations. See: https://github.com/kubernetes/community/blob/master/community-membership.md#kubernetes-ecosystem

everpeace is eligible to be a member of kubernetes-sigs organization because he is a member of kubernetes organization (https://github.com/kubernetes/org/issues/1173).