### PR TITLE
Remove Kashomon from github orgs

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -651,7 +651,6 @@ members:
 - karlkfi
 - Karthik-K-N
 - KashifSaadat
-- Kashomon
 - kaslin
 - kasramp
 - katcosgrove
@@ -1821,7 +1820,6 @@ teams:
     - justinsb
     - k82cn
     - kargakis
-    - Kashomon
     - kevin-wangzefeng
     - krousey
     - lavalamp

--- a/config/kubernetes/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes/sig-contributor-experience/teams.yaml
@@ -107,7 +107,6 @@ teams:
     - hongchaodeng
     - idealhack
     - jessfraz
-    - Kashomon
     - lavalamp
     - monopole
     - parispittman


### PR DESCRIPTION
The username does not exist anymore and peribolos is [failing](https://testgrid.k8s.io/sig-contribex-org#ci-peribolos):
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-org-peribolos/1516492932016771072

```
 {"component":"unset","file":"/home/prow/go/src/github.com/kubernetes/org/_output/tmp/test-infra/prow/cmd/peribolos/main.go:1293","func":"main.configureTeamMembers.func1","level":"warning","msg":"UpdateTeamMembership(kubernetes-maintainers(kubernetes-maintainers), kashomon, false) failed: status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-membership-for-a-user\"}","severity":"warning","time":"2022-04-19T19:11:09Z"}
{"component":"unset","file":"/home/prow/go/src/github.com/kubernetes/org/_output/tmp/test-infra/prow/cmd/peribolos/main.go:209","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure kubernetes teams: failed to update kubernetes-maintainers members: UpdateTeamMembership(kubernetes-maintainers(kubernetes-maintainers), kashomon, false) failed: status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-membership-for-a-user\"}","severity":"fatal","time":"2022-04-19T19:11:09Z"} 
```

It looks like the account moved to https://github.com/artemispax but
they are no longer active in Kubernetes.

If they need access back again, they can simply create a PR to add
themselves in.