### PR TITLE
Fix alias for new member rdpsin

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -603,7 +603,7 @@ members:
 - RaunakShah
 - ravisantoshgudimetla
 - rbitia
-- rdspin
+- rdpsin
 - relyt0925
 - resouer
 - reylejano


### PR DESCRIPTION
Fixes an error where Github alias was wrong. 

Original issue here: https://github.com/kubernetes/org/issues/3372

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>