### PR TITLE
update kubebuilder admins as defined in the project owners

### DIFF
--- a/config/kubernetes-sigs/sig-api-machinery/teams.yaml
+++ b/config/kubernetes-sigs/sig-api-machinery/teams.yaml
@@ -104,14 +104,6 @@ teams:
     description: admin access to kubebuilder
     members:
     - camilamacedo86
-    - DirectXMan12
-    - droot
-    - estroz
-    - grodrigues3
-    - Liujingfang1
-    - mengqiy
-    - monopole
-    - pmorie
     - pwittrock
     privacy: closed
   kubebuilder-contributors:


### PR DESCRIPTION
**Description** 
Updating permissions to have the same what is defined in the https://github.com/kubernetes-sigs/kubebuilder/blob/master/OWNERS_ALIASES

