### PR TITLE
Cleanup aws-ebs-csi-driver maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-aws/teams.yaml
+++ b/config/kubernetes-sigs/sig-aws/teams.yaml
@@ -17,7 +17,6 @@ teams:
     - nirmalaagash
     - rdpsin
     - torredil
-    - vdhanan
     - wongma7
     privacy: closed
   aws-encryption-provider-admins:


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

Remove users who are no longer active contributors to `aws-ebs-csi-driver`.