### PR TITLE
Sync CAPZ owners with Azure provider project

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -70,6 +70,7 @@ teams:
     - alexeldeib
     - CecileRobertMichon
     - devigned
+    - mboersma
     - shysank
     privacy: closed
   cluster-api-provider-azure-maintainers:
@@ -78,6 +79,7 @@ teams:
     - alexeldeib
     - CecileRobertMichon
     - devigned
+    - mboersma
     - shysank
     privacy: closed
   cluster-api-provider-azure-pms:
@@ -85,9 +87,9 @@ teams:
     members:
     - alexeldeib
     - CecileRobertMichon
-    - cpanato
     - devigned
     - jackfrancis
+    - Jont828
     - jsturtevant
     - mboersma
     - shysank


### PR DESCRIPTION
Syncs up with recent changes to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

cc: @cpanato @Jont828