### PR TITLE
Add seanmalloy and ingvagabund to descheduler repo with write access

### DIFF
--- a/config/kubernetes-sigs/sig-scheduling/teams.yaml
+++ b/config/kubernetes-sigs/sig-scheduling/teams.yaml
@@ -24,6 +24,7 @@ teams:
     - damemi
     - k82cn
     - ravisantoshgudimetla
+    - seanmalloy
     privacy: closed
     previously:
     - descehduler-maintainers

--- a/config/kubernetes-sigs/sig-scheduling/teams.yaml
+++ b/config/kubernetes-sigs/sig-scheduling/teams.yaml
@@ -22,6 +22,7 @@ teams:
     members:
     - aveshagarwal
     - damemi
+    - ingvagabund
     - k82cn
     - ravisantoshgudimetla
     - seanmalloy


### PR DESCRIPTION
There is currently only one active maintainer with write access to the
descheduler repo. Adding a second maintainer with write access allows
multiple people to help with create git tags and branches for releases.