### PR TITLE
Providing jyotimahapatra write access on aws-iam-authenticator

### DIFF
--- a/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
+++ b/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
@@ -44,6 +44,7 @@ teams:
    - micahhausler
    - nckturner
    - wongma7
+   - jyotimahapatra
    privacy: closed
   blobfuse-csi-driver-admins:
    description: Admin access to the blobfuse-csi-driver repo

--- a/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
+++ b/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
@@ -40,11 +40,11 @@ teams:
   aws-iam-authenticator-maintainers:
    description: Write access to the aws-iam-authenticator repo
    members:
+   - jyotimahapatra
    - m00nf1sh
    - micahhausler
    - nckturner
    - wongma7
-   - jyotimahapatra
    privacy: closed
   blobfuse-csi-driver-admins:
    description: Admin access to the blobfuse-csi-driver repo


### PR DESCRIPTION
I'm spending more time in https://github.com/kubernetes-sigs/aws-iam-authenticator and I'm already in [OWNERS](https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/master/OWNERS#L14) file. 
I'd like to create tags and releases for aws-iam-authenticator and based on https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization looks like i need to have write permission to be able to create tags and releases. 