### PR TITLE
Remove `LappleApple` from SIG Release teams

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -225,7 +225,6 @@ teams:
     - jeefy
     - jeremyrickard # Technical Lead
     - justaugustus # Chair
-    - LappleApple # Program Manager
     - liggitt
     - mariantalla
     - nikopen
@@ -372,7 +371,6 @@ teams:
         - cpanato # Technical Lead
         - jeremyrickard # Technical Lead
         - justaugustus # Chair
-        - LappleApple # Program Manager
         - puerco # Technical Lead
         - saschagrunert # Chair
         privacy: closed
@@ -383,7 +381,6 @@ teams:
         - cpanato # Technical Lead
         - jeremyrickard # Technical Lead
         - justaugustus # Chair
-        - LappleApple # Program Manager
         - puerco # Technical Lead
         - saschagrunert # Chair
         privacy: closed


### PR DESCRIPTION
Lauri has stepped back from SIG Release some time ago. This cleanup should reflect the current state of the SIG. :sob: 

cc @kubernetes/sig-release-leads 

Refers to https://github.com/kubernetes/community/pull/6675