### PR TITLE
Rename cluster-api-cloudstack -> cluster-api-provider-cloudstack teams

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -33,18 +33,6 @@ teams:
     - sbueringer
     - vincepri
     privacy: closed
-  cluster-api-cloudstack-admins:
-    description: ""
-    members:
-    - davidjumani
-    - rohityadavcloud
-    privacy: closed
-  cluster-api-cloudstack-maintainers:
-    description: ""
-    members:
-    - davidjumani
-    - rohityadavcloud
-    privacy: closed
   cluster-api-operator-admins:
     description: "admin access to cluster-api-operator"
     members:
@@ -106,6 +94,22 @@ teams:
     - mboersma
     - shysank
     privacy: closed
+  cluster-api-provider-cloudstack-admins:
+    description: ""
+    members:
+    - davidjumani
+    - rohityadavcloud
+    privacy: closed
+    previously:
+    - cluster-api-cloudstack-admins
+  cluster-api-provider-cloudstack-maintainers:
+    description: ""
+    members:
+    - davidjumani
+    - rohityadavcloud
+    privacy: closed
+    previously:
+    - cluster-api-cloudstack-maintainers
   cluster-api-provider-digitalocean-admins:
     description: Admin access to the cluster-api-provider-digitalocean repo
     members:


### PR DESCRIPTION
I missed the `provider` part of the team names when I created #3454 , updating to match standard convention.

ref: #3279
ref: #3454 