### PR TITLE
Onboard 1.25 RT Leads and CI Signal Lead

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -335,11 +335,7 @@ teams:
             description: Members of the CI Signal team for the current release
               cycle.
             members:
-            - lauralorenz # 1.24 CI Signal Shadow
-            - leonardpahlke # 1.24 CI Signal Lead
-            - Nivedita-coder # 1.24 CI Signal Shadow
-            - shuheiktgw # 1.24 CI Signal Shadow
-            - voigt # 1.24 CI Signal Shadow
+            - RinkiyaKeDad # 1.25 CI Signal Lead
             privacy: closed
           release-team-leads:
             description: Release Team Leads for the current Kubernetes release
@@ -348,12 +344,12 @@ teams:
               as a notification group. Remove org members who are not current
               Release Team Leads.
             members:
-            - cici37 # 1.24 RT Lead Shadow
-            - jameslaverack # 1.24 RT Lead
-            - jlbutler # 1.24 RT Lead Shadow
-            - jrsapi # 1.24 EA
-            - mkorbi # 1.24 RT Lead Shadow
-            - salaxander # 1.24 RT Lead Shadow
+            - cici37 # 1.25 RT Lead
+            - gracenng # 1.25 RT Lead Shadow
+            - jlbutler # 1.25 RT Lead Shadow
+            - leonardpahlke # 1.25 RT Lead Shadow
+            - reylejano # 1.25 EA
+            - salaxander # 1.25 RT Lead Shadow
             privacy: closed
       sig-release-admins:
         description: Admins for SIG Release repositories


### PR DESCRIPTION
This PR is to grand access to CI Signal lead to start working on 1.25 release. I will open a follow up PR to update all 1.25 release team members once they all become Kubernetes org members.

cc @RinkiyaKeDad 