### PR TITLE
Sync CAPZ owners with Azure provider project

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -70,6 +70,7 @@ teams:
     - alexeldeib
     - CecileRobertMichon
     - devigned
+    - jackfrancis
     - mboersma
     - shysank
     privacy: closed
@@ -79,6 +80,7 @@ teams:
     - alexeldeib
     - CecileRobertMichon
     - devigned
+    - jackfrancis
     - mboersma
     - shysank
     privacy: closed


### PR DESCRIPTION
Syncs up with recent changes to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

cc: @jackfrancis 