### PR TITLE
Add davidjumani and rohityadavcloud to kubernetes org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -286,6 +286,7 @@ members:
 - DanyC97
 - dashpole
 - davidewatson
+- davidjumani
 - davidkarlsen
 - davidopp
 - davidz627

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1095,6 +1095,7 @@ members:
 - robinpercy
 - robscott
 - rohitagarwal003
+- rohityadavcloud
 - rojkov
 - RomanBednar
 - rootfs


### PR DESCRIPTION
Adds @davidjumani and @rohityadavcloud as a member of the kubernetes org
- Required for https://github.com/kubernetes/k8s.io/pull/3792#issuecomment-1143127185
- Fixes https://github.com/kubernetes/org/issues/3488