### PR TITLE
Fix typo, rm krol and add krol3

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -718,7 +718,7 @@ members:
 - kris-nova
 - krishchow
 - krmayankk
-- krol
+- krol3
 - krousey
 - krvaibhaw
 - krzysied


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

A typo made in this [PR](https://github.com/kubernetes/org/issues/3478) added @krol and not @krol3

ref: https://github.com/kubernetes/org/pull/3500

/cc @cici37 @reylejano @kcmartin 