### PR TITLE
Adding new maintainers to CAPC repo

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -108,10 +108,10 @@ teams:
     description: ""
     members:
     - davidjumani
-    - rohityadavcloud
+    - jweite-amazon
     - maxdrib
     - rejoshed
-    - jweite-amazon
+    - rohityadavcloud
     privacy: closed
     previously:
     - cluster-api-cloudstack-maintainers

--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -109,6 +109,8 @@ teams:
     members:
     - davidjumani
     - rohityadavcloud
+    - maxdrib
+    - rejoshed
     privacy: closed
     previously:
     - cluster-api-cloudstack-maintainers

--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -111,6 +111,7 @@ teams:
     - rohityadavcloud
     - maxdrib
     - rejoshed
+    - jweite-amazon
     privacy: closed
     previously:
     - cluster-api-cloudstack-maintainers


### PR DESCRIPTION
In order to help unblock development and release of the CAPC repository, we would like to add a few more maintainers to the CAPC repo to have the ability to create branches and tags. These individuals are already listed in the OWNERS file in CAPC: https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/blob/main/OWNERS