### PR TITLE
Adding Shane Utt as Gateway API Maintainer

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -111,9 +111,8 @@ teams:
     members:
     - bowei
     - hbagdi
-    - jpeach
     - robscott
-    - thockin
+    - shaneutt
     - youngnick
     privacy: closed
     previously:


### PR DESCRIPTION
This mirrors https://github.com/kubernetes-sigs/gateway-api/pull/1231 and adds @shaneutt as a Gateway API maintainer.