### PR TITLE
Add Prajyot-Parab to kubernetes

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1021,6 +1021,7 @@ members:
 - Potapy4
 - Pothulapati
 - prachirp
+- Prajyot-Parab
 - prameshj
 - prankul88
 - prasadkatti


### PR DESCRIPTION
Hi, I'm a member of the [kubernetes-sigs org](https://github.com/kubernetes/org/blob/2d1ce973592fe7d5bbb51275bc48bd92ea7781b5/config/kubernetes-sigs/org.yaml#L605) and would like to get added to the kubernetes. I referred [membership](https://github.com/kubernetes/community/blob/master/community-membership.md#kubernetes-ecosystem) guide, which says:

> "If you are a member of one of these Orgs, you are implicitly eligible for membership in related orgs, and can request membership when it becomes relevant, by creating a PR directly"

Fixes: #3544  
