### PR TITLE
Add David Vossel as cluster-api-provider-kubevirt admin/maintainer

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -170,6 +170,7 @@ teams:
     members:
     - agradouski
     - cchengleo
+    - davidvossel
     - justinsb
     - neolit123
     - timothysc
@@ -180,6 +181,7 @@ teams:
     members:
     - agradouski
     - cchengleo
+    - davidvossel
     privacy: closed
   cluster-api-provider-nested-admins:
     description: admin access to cluster-api-provider-nested


### PR DESCRIPTION
I'm one of the primary contributors to the cluster-api-provider-kubevirt project. We'd like to spread the ownership of the repo out a little bit further and I've volunteered to help there. I'll need the ability to create tags/releases as well as manage secrets for CI.