### PR TITLE
Add Garima Negi as reviewer for Hindi l10n

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -94,14 +94,13 @@ teams:
     members:
     - anubha-v-ardhan
     - divya-mohan0209
-    - mittalyashu
     privacy: closed
   sig-docs-hi-reviews:
     description: PR reviews for Hindi content
     members: 
     - anubha-v-ardhan
     - divya-mohan0209
-    - mittalyashu
+    - Garima-Negi 
     - verma-kunal
     privacy: closed
   sig-docs-id-owners:


### PR DESCRIPTION
Adds [Garima Negi](https://github.com/Garima-Negi) as a reviewer for Hindi l10n as discussed on [Slack](https://kubernetes.slack.com/archives/CJ14B9BDJ/p1655230491320389)

ref: https://github.com/kubernetes/website/pull/35052