### PR TITLE
add szuecs to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -752,6 +752,7 @@ members:
 - sunpa93
 - swatisehgal
 - SyamSundarKirubakaran
+- szuecs
 - t-inu
 - tabbysable
 - tahsinrahman


### PR DESCRIPTION
fixes: #3442

I had marked this as fixed in #3456 but missed adding @szuecs membership. -_- woops.

/area github-membership