### PR TITLE
add shaneutt to kubernetes org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1184,6 +1184,7 @@ members:
 - sftim
 - Sh4d1
 - shaileshsharan98
+- shaneutt
 - shannonxtreme
 - sharifelgamal
 - shashidharatd


### PR DESCRIPTION
Signed-off-by: Shane Utt <shaneutt@linux.com>

Note: I am already a member of kubernetes-sigs, and a maintainer of Gateway API.