### PR TITLE
Sync sig-docs zh team members

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -261,13 +261,14 @@ teams:
   sig-docs-zh-owners:
     description: Approvers for Chinese content
     members:
+    - chenrui333
     - howieyuen
     - mengjiao-liu
     - SataQiu
+    - Sea-n
     - tanjunchen
     - tengqm
     - xichengliudui
-    - zhangxiaoyu-zidif
     privacy: closed
   sig-docs-zh-reviews:
     description: PR reviews for Chinese content
@@ -275,15 +276,14 @@ teams:
     - chenrui333
     - chenxuc
     - howieyuen
-    - idealhack
     - mengjiao-liu
-    - pigletfly
     - SataQiu
+    - Sea-n
     - tanjunchen
     - tengqm
+    - windsonsea
     - xichengliudui
     - ydFu
-    - zhangxiaoyu-zidif
     privacy: closed
   sig-docs-vi-owners:
     description: Admins for Vietnamese content


### PR DESCRIPTION
Sync with [OWNERS_ALIASES](https://github.com/kubernetes/website/blob/main/OWNERS_ALIASES) in k/website.

The modification can be found in this two PR.
- kubernetes/website#35563 
- kubernetes/website#11391

CC zh team lead @tengqm