### PR TITLE
add aojea to the milestone maintainer group

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -29,6 +29,7 @@ teams:
     - ahg-g # Scheduling
     - alejandrox1 # Testing
     - andrewsykim # Cloud Provider
+    - aojea # Testing / Network
     - Atharva-Shinde # 1.25 Enhancements Shadow
     - BenTheElder # Testing
     - bgrant0607 # Architecture


### PR DESCRIPTION
I'd like to be added to the milestone maintainer group, as a person that is working in EU timezone I think that this will improve the round trip and spread the load

/assign @BenTheElder @thockin 

assign to Tim and Ben as respective Sig network and testing leads

