### PR TITLE
Add t-inu to sig-docs-ja-reviews

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -157,6 +157,7 @@ teams:
     - makocchi-git
     - nasa9084
     - ptux
+    - t-inu
     privacy: closed
   sig-docs-ko-owners:
     description: Approvers for Korean content


### PR DESCRIPTION
Add t-inu to sig-docs-ja-reviews.
ref: https://github.com/kubernetes/website/pull/35970