### PR TITLE
Add qbarrand as KMM admin

### DIFF
--- a/config/kubernetes-sigs/sig-node/teams.yaml
+++ b/config/kubernetes-sigs/sig-node/teams.yaml
@@ -1,4 +1,14 @@
 teams:
+  kernel-module-management-admins:
+    description: Admin access to kernel-module-management repo
+    members:
+    - qbarrand
+    privacy: closed
+  kernel-module-management-maintainers:
+    description: Write access to kernel-module-management repo
+    members:
+    - qbarrand
+    privacy: closed
   node-feature-discovery-operator-admins:
     description: Admin access to node-feature-discovery-operator repo
     members:


### PR DESCRIPTION
Add @qbarrand as a maintainer for [Kernel Module Management](https://github.com/kubernetes-sigs/kernel-module-management) that we are transitioning from https://github.com/qbarrand/oot-operator.