### PR TITLE
Add astoycos to NPAPI admins

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -135,5 +135,6 @@ teams:
     description: Admin access to the network-policy-api repo
     members:
     - abhiraut
+    - astoycos
     - rikatz
     privacy: closed


### PR DESCRIPTION
astoycos is an owner in the
adminNetworkPolicy API repo
and should be added here as
well.

Related to https://github.com/kubernetes/org/issues/3643