### PR TITLE
Fix bad previous name in kmm teams

### DIFF
--- a/config/kubernetes-sigs/sig-node/teams.yaml
+++ b/config/kubernetes-sigs/sig-node/teams.yaml
@@ -49,4 +49,4 @@ teams:
     - zvonkok
     privacy: closed
     previously:
-    - kernel-module-management-maintainers
+    - special-resource-operator-maintainers


### PR DESCRIPTION
Follow up on mistake I made in #3650

Caught by CI: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-org-peribolos/1565015810299138048