### PR TITLE
Update James Strong's k-sigs membership

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -758,6 +758,7 @@ members:
 - stevekuznetsov
 - steveperry-53
 - stmcginnis
+- strongjz
 - sttts
 - sunpa93
 - swatisehgal


### PR DESCRIPTION
James Strong is a member of the kubernetes org:

https://github.com/kubernetes/org/blob/93aa088144549e3d8a434cecc5d3b7459ef783f6/config/kubernetes/org.yaml#L1268

This should grant him access to k-sigs too. This PR adds him to the `kubernetes-sigs` org to enable him to lgtm on reviews on our projects there.

/assign @palnabarun 
/cc @strongjz 

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>