### PR TITLE
Add note to membership issue template; no need to request membership if you are already part of a K8s org 

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.yml
+++ b/.github/ISSUE_TEMPLATE/membership.yml
@@ -6,7 +6,7 @@ body:
 - type: markdown
   attributes:
     value: |
-      Thank you for filling out this membership request! Please note, if you are already part of a GitHub Kubernetes organization like kubernetes-sigs, you do not need to open this request and can add yourself directly!
+      Thank you for filling out this membership request! Please note, if you are already part of any Kubernetes GitHub organization like kubernetes-sigs and you are filing this request to be added to kubernetes, you do not need to open this request and can add yourself directly! The org memberships are now equivalent and sponsorship is not needed to join additional Kubernetes GitHub orgs.
 - id: github
   type: input
   attributes:

--- a/.github/ISSUE_TEMPLATE/membership.yml
+++ b/.github/ISSUE_TEMPLATE/membership.yml
@@ -3,6 +3,10 @@ description: Request membership in a Kubernetes Org
 labels: [ "area/github-membership" ]
 title: "REQUEST: New membership for <your-GH-handle>"
 body:
+- type: markdown
+  attributes:
+    value: |
+      Thank you for filling out this membership request! Please note, if you are already part of a GitHub Kubernetes organization like kubernetes-sigs, you do not need to open this request and can add yourself directly!
 - id: github
   type: input
   attributes:


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

Creating a membership request is sometimes done by members who are already part of the Kubernetes community. The note added to the issue template should prevent this, as it is not necessary to ask for sponsorship if you are already part of one of the K8 organizations.

/cc @palnabarun @mrbobbytables 