### PR TITLE
Create team for Communications

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -325,6 +325,14 @@ teams:
             - mickeyboxell # 1.26 Docs Shadow
             - Rishit-dagli # 1.26 Docs Shadow
             privacy: closed
+          release-team-comms:
+            description: Members of the Comms team for the current release cycle.
+            members:
+              - fsmunoz # 1.26 Communications Lead
+              - bradmccoydev # 1.26 Communications Shadow
+              - davidmirror-ops # 1.26 Communications Shadow
+              - harshitasao # 1.26 Communications Shadow
+              - Debanitrkl # 1.26 Communications Shadow
           release-team-enhancements:
             description: Members of the Enhancments team for the current release
               cycle.

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -333,6 +333,7 @@ teams:
               - davidmirror-ops # 1.26 Communications Shadow
               - harshitasao # 1.26 Communications Shadow
               - Debanitrkl # 1.26 Communications Shadow
+              privacy: closed
           release-team-enhancements:
             description: Members of the Enhancments team for the current release
               cycle.

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -328,12 +328,12 @@ teams:
           release-team-comms:
             description: Members of the Comms team for the current release cycle.
             members:
-              - fsmunoz # 1.26 Communications Lead
-              - bradmccoydev # 1.26 Communications Shadow
-              - davidmirror-ops # 1.26 Communications Shadow
-              - harshitasao # 1.26 Communications Shadow
-              - Debanitrkl # 1.26 Communications Shadow
-              privacy: closed
+            - fsmunoz # 1.26 Communications Lead
+            - bradmccoydev # 1.26 Communications Shadow
+            - davidmirror-ops # 1.26 Communications Shadow
+            - harshitasao # 1.26 Communications Shadow
+            - Debanitrkl # 1.26 Communications Shadow
+            privacy: closed
           release-team-enhancements:
             description: Members of the Enhancments team for the current release
               cycle.

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -328,11 +328,11 @@ teams:
           release-team-comms:
             description: Members of the Comms team for the current release cycle.
             members:
-            - fsmunoz # 1.26 Communications Lead
             - bradmccoydev # 1.26 Communications Shadow
             - davidmirror-ops # 1.26 Communications Shadow
-            - harshitasao # 1.26 Communications Shadow
             - Debanitrkl # 1.26 Communications Shadow
+            - fsmunoz # 1.26 Communications Lead
+            - harshitasao # 1.26 Communications Shadow
             privacy: closed
           release-team-enhancements:
             description: Members of the Enhancments team for the current release


### PR DESCRIPTION
For purposes of using the GitHub project board that Enhancements has set up for the current release cycle, and as discussed in in[ #release-comms](https://kubernetes.slack.com/archives/CNT9Y603D/p1663175150499059?thread_ts=1662994419.135199&cid=CNT9Y603D) 