### PR TITLE
Create team for Bug-Triage

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -325,6 +325,16 @@ teams:
             - mickeyboxell # 1.26 Docs Shadow
             - Rishit-dagli # 1.26 Docs Shadow
             privacy: closed
+          release-team-bug-triage:
+            description: Members of the Bug Triage team for the current release cycle.
+            members:
+              - hosseinsalahi # 1.26 Bug Triage Lead
+              - subhasmitasw # 1.26 Bug Triage Shadow
+              - neoaggelos # 1.26 Bug Triage Shadow
+              - heshamaboelmagd # 1.26 Bug Triage Shadow
+              - cailynse # 1.26 Bug Triage Shadow
+              - salaxander # 1.26 Bug Triage Shadow
+            privacy: closed
           release-team-comms:
             description: Members of the Comms team for the current release cycle.
             members:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -328,12 +328,12 @@ teams:
           release-team-bug-triage:
             description: Members of the Bug Triage team for the current release cycle.
             members:
-              - hosseinsalahi # 1.26 Bug Triage Lead
-              - subhasmitasw # 1.26 Bug Triage Shadow
-              - neoaggelos # 1.26 Bug Triage Shadow
-              - heshamaboelmagd # 1.26 Bug Triage Shadow
-              - cailynse # 1.26 Bug Triage Shadow
-              - salaxander # 1.26 Bug Triage Shadow
+            - hosseinsalahi # 1.26 Bug Triage Lead
+            - subhasmitasw # 1.26 Bug Triage Shadow
+            - neoaggelos # 1.26 Bug Triage Shadow
+            - heshamaboelmagd # 1.26 Bug Triage Shadow
+            - cailynse # 1.26 Bug Triage Shadow
+            - salaxander # 1.26 Bug Triage Shadow
             privacy: closed
           release-team-comms:
             description: Members of the Comms team for the current release cycle.

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -328,12 +328,12 @@ teams:
           release-team-bug-triage:
             description: Members of the Bug Triage team for the current release cycle.
             members:
-            - hosseinsalahi # 1.26 Bug Triage Lead
-            - subhasmitasw # 1.26 Bug Triage Shadow
-            - neoaggelos # 1.26 Bug Triage Shadow
-            - heshamaboelmagd # 1.26 Bug Triage Shadow
             - cailynse # 1.26 Bug Triage Shadow
+            - heshamaboelmagd # 1.26 Bug Triage Shadow
+            - hosseinsalahi # 1.26 Bug Triage Lead
+            - neoaggelos # 1.26 Bug Triage Shadow
             - salaxander # 1.26 Bug Triage Shadow
+            - subhasmitasw # 1.26 Bug Triage Shadow
             privacy: closed
           release-team-comms:
             description: Members of the Comms team for the current release cycle.


### PR DESCRIPTION
For purposes of using the GitHub project board the bug-triage needs to create a GH team for the 1.26 release cycle.
@leonardpahlke @palnabarun 