### PR TITLE
Add self to aws-fsx-csi-driver maintainers/admins list

### DIFF
--- a/config/kubernetes-sigs/sig-aws/teams.yaml
+++ b/config/kubernetes-sigs/sig-aws/teams.yaml
@@ -38,6 +38,7 @@ teams:
     description: admin access to aws-fsx-csi-driver
     members:
     - justinsb
+    - khoang98
     - leakingtapan
     - wongma7
     privacy: closed
@@ -47,6 +48,7 @@ teams:
     - d-nishi
     - jsafrane
     - justinsb
+    - khoang98
     - leakingtapan
     - wongma7
     privacy: closed


### PR DESCRIPTION
I am a kubernetes-sigs member and an owner for the aws-fsx-csi-driver - I'd like to add myself here as well.

- Sigs member: https://github.com/kubernetes/org/pull/3720
- Owners: https://github.com/kubernetes-sigs/aws-fsx-csi-driver/pull/256