### PR TITLE
Rename kris-nova to krisnova

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -441,8 +441,8 @@ members:
 - KnVerey
 - koba1t
 - kow3ns
-- kris-nova
 - krishchow
+- krisnova
 - krmayankk
 - krol3
 - krousey

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -752,8 +752,8 @@ members:
 - kpucynski
 - kragniz
 - krancour
-- kris-nova
 - krishchow
+- krisnova
 - krmayankk
 - krol3
 - krousey


### PR DESCRIPTION
Renaming @kris-nova to @krisnova.

fixes following error:
```
{"component":"unset","error":"status code 422 not one of [200], body: {\"message\":\"Members must be users, not organizations.\",\"documentation_url\":\"https://docs.github.com/rest/reference/orgs#set-organization-membership-for-a-user\"}","file":"/home/prow/go/src/github.com/kubernetes/org/_output/tmp/test-infra/prow/cmd/peribolos/main.go:476","func":"main.configureOrgMembers.func1","level":"warning","msg":"UpdateOrgMembership(kubernetes-sigs, kris-nova, false) failed","severity":"warning","time":"2022-10-02T20:08:24Z"}
```