### PR TITLE
Onboard/Offboard Steering Committee members as per 2023 elections

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -155,11 +155,11 @@ aliases:
     - tabbysable
     - tallclair
   committee-steering:
+    - BenTheElder
     - cblecker
-    - dims
     - justaugustus
-    - liggitt
     - mrbobbytables
+    - palnabarun
     - parispittman
     - tpepper
 ## BEGIN CUSTOM CONTENT

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -2093,10 +2093,10 @@ teams:
     maintainers:
     - cblecker
     - mrbobbytables
+    - palnabarun
     members:
-    - dims
+    - BenTheElder
     - justaugustus
-    - liggitt
     - parispittman
     - tpepper
     privacy: closed


### PR DESCRIPTION
Part of https://github.com/kubernetes/steering/issues/256

Onboard:
- BenTheElder
- palnabarun

Offboard:
- dims
- liggitt

Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>

cc: @kubernetes/steering-committee 
/assign @mrbobbytables @cblecker 