### PR TITLE
drop googlers that no longer have deb/rpm access from build-admins

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -6,9 +6,7 @@ teams:
       Release Chairs/TLs for continuity.
     members:
     - BenjaminKazemi
-    - BenTheElder
     - cpanato
-    - juanfescobar
     - justaugustus
     - MushuEE
     - puerco


### PR DESCRIPTION
xref: https://github.com/kubernetes/website/pull/37169, https://github.com/kubernetes/release/pull/2697