### PR TITLE
feat: Cluster API Provider AWS Team Changes

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -42,27 +42,17 @@ teams:
   cluster-api-provider-aws-admins:
     description: admin access to cluster-api-provider-aws
     members:
-    - detiber
-    - justinsb
-    - luxas
-    - randomvariable
     - richardcase
     - sedefsavas
-    - timothysc
-    - vincepri
     privacy: closed
   cluster-api-provider-aws-maintainers:
     description: write access to cluster-api-provider-aws
     members:
-    - chuckha
-    - davidewatson
-    - detiber
-    - ingvagabund
-    - randomvariable
+    - Ankitasw
+    - dlipovetsky
     - richardcase
     - sedefsavas
-    - timothysc
-    - vincepri
+    - Skarlso
     privacy: closed
   cluster-api-provider-azure-admins:
     description: ""


### PR DESCRIPTION
Changes to the aliases for the 2 Cluster API provider AWS teams to match the owners_aliases for maintainers/admins as of 2022-10-19.

Until the https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3775 merges on 19th October:

/hold

Fixes: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3621

Signed-off-by: Richard Case <richard.case@outlook.com>