### PR TITLE
drop palnabarun from code-of-conduct-committee team

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1677,8 +1677,6 @@ teams:
     privacy: closed
   code-of-conduct-committee:
     description: Kubernetes Code of Conduct Committee
-    maintainers:
-    - palnabarun
     members:
     - detiber
     - endocrimes


### PR DESCRIPTION
Part of https://github.com/kubernetes/community/issues/6916

Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>
