### PR TITLE
Remove ihmccreery, username does not exist anymore

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -559,7 +559,6 @@ members:
 - idealhack
 - ihcsim
 - iheanyi1
-- ihmccreery
 - ilya-zuyev
 - imkin
 - immutableT
@@ -1806,7 +1805,6 @@ teams:
     members:
     - cjcullen
     - destijl
-    - ihmccreery
     - jessicaochen
     - zmerlynn
     privacy: closed


### PR DESCRIPTION
Ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-org-peribolos/1582464514404651008

```
 {"component":"unset","file":"/home/prow/go/src/github.com/kubernetes/org/_output/tmp/test-infra/prow/cmd/peribolos/main.go:1280","func":"main.configureTeamMembers.func1","level":"warning","msg":"UpdateTeamMembership(goog-gke(goog-gke), ihmccreery, false) failed: status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-membership-for-a-user\"}","severity":"warning","time":"2022-10-18T20:19:26Z"}
{"component":"unset","file":"/home/prow/go/src/github.com/kubernetes/org/_output/tmp/test-infra/prow/cmd/peribolos/main.go:192","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure kubernetes teams: failed to update goog-gke members: UpdateTeamMembership(goog-gke(goog-gke), ihmccreery, false) failed: status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-membership-for-a-user\"}","severity":"fatal","time":"2022-10-18T20:19:26Z"} 
```


Looks like they moved to `@ikehz` but they haven't been active for a while. This PR removes them from the org, we can re-add later if needed.