### PR TITLE
Remove Josh since his departure from the maintaining org

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -110,7 +110,6 @@ teams:
     - davidjumani
     - jweite-amazon
     - maxdrib
-    - rejoshed
     - rohityadavcloud
     privacy: closed
     previously:


### PR DESCRIPTION
Josh has left the organization and is no longer working on or maintaining the CAPC repo. https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/pull/184/files