### PR TITLE
Remove kargakis from kubernetes org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -713,7 +713,6 @@ members:
 - karan
 - karataliu
 - karenhchu
-- kargakis
 - karlkfi
 - Karthik-K-N
 - KashifSaadat
@@ -1980,7 +1979,6 @@ teams:
     - jsafrane
     - justinsb
     - k82cn
-    - kargakis
     - kevin-wangzefeng
     - krousey
     - lavalamp


### PR DESCRIPTION
User no longer exists. This PR fixes peribolos.

Ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-org-peribolos/1591888797027536896

```
 {"component":"unset","file":"/home/prow/go/src/github.com/kubernetes/org/_output/tmp/test-infra/prow/cmd/peribolos/main.go:1289","func":"main.configureTeamMembers.func1","level":"warning","msg":"UpdateTeamMembership(kubernetes-maintainers(kubernetes-maintainers), kargakis, false) failed: status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-membership-for-a-user\"}","severity":"warning","time":"2022-11-13T20:27:44Z"}
{"component":"unset","file":"/home/prow/go/src/github.com/kubernetes/org/_output/tmp/test-infra/prow/cmd/peribolos/main.go:194","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure kubernetes teams: failed to update kubernetes-maintainers members: UpdateTeamMembership(kubernetes-maintainers(kubernetes-maintainers), kargakis, false) failed: status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-membership-for-a-user\"}","severity":"fatal","time":"2022-11-13T20:27:44Z"}
```