### PR TITLE
Add sbueringer & fabriziopandini to cluster-api-admins

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -22,6 +22,8 @@ teams:
     description: ""
     members:
     - CecileRobertMichon
+    - fabriziopandini
+    - sbueringer
     - vincepri
     privacy: closed
   cluster-api-maintainers:


### PR DESCRIPTION
Adding myself and Fabrizio to Cluster API admins.

The idea is that through the admin access to the repo we will also get access to Netlify.

Adding Fabrizio as well so he can also help out with Netlify duties.

xref: https://kubernetes.slack.com/archives/C1TU9EB9S/p1669656532332839?thread_ts=1669638214.266839&cid=C1TU9EB9S