### PR TITLE
teams: add dougsland to sig-windows-dev-tools admin

### DIFF
--- a/config/kubernetes-sigs/sig-windows/teams.yaml
+++ b/config/kubernetes-sigs/sig-windows/teams.yaml
@@ -39,6 +39,7 @@ teams:
     description: Admin access to sig-windows-dev-tools repo
     members:
     - claudiubelu
+    - dougsland
     - jayunit100
     - jsturtevant
     - marosset
@@ -48,6 +49,7 @@ teams:
     description: Admin access to sig-windows-tools repo
     members:
     - claudiubelu
+    - dougsland
     - jayunit100
     - jsturtevant
     - marosset
@@ -56,6 +58,7 @@ teams:
     description: Write access to sig-windows-tools repo
     members:
     - claudiubelu
+    - dougsland
     - jayunit100
     - jsturtevant
     - marosset


### PR DESCRIPTION
I have been helping and maintaing the project. With admin access I can continue my efforts in the CI/CD for testing different CNIs with sig-windows-dev-tools.

Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>