### PR TITLE
Updating Gateway API Admins to match Gateway API Maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -118,7 +118,9 @@ teams:
     description: Admin access to the gateway-api repo
     members:
     - bowei
-    - thockin
+    - robscott
+    - shaneutt
+    - youngnick
     privacy: closed
     previously:
     - service-apis-admins
@@ -126,7 +128,6 @@ teams:
     description: Write access to the gateway-api repo
     members:
     - bowei
-    - hbagdi
     - robscott
     - shaneutt
     - youngnick


### PR DESCRIPTION
This mirrors https://github.com/kubernetes-sigs/gateway-api/pull/1528. I'd assumed it's best to keep the groups separate but equal here to match other config, but let me know if I should just merge this into a single group here as well.