### PR TITLE
Update external-dns admins and maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -46,21 +46,21 @@ teams:
   external-dns-admins:
     description: Admin access to the external-dns repo
     members:
-    - hjacobs
     - linki
     - njuettner
     - Raffo
+    - szuecs
     privacy: closed
     previously:
     - admins-external-dns
   external-dns-maintainers:
     description: Write access to the external-dns repo
     members:
-    - hjacobs
     - linki
     - njuettner
     - Raffo
     - seanmalloy
+    - szuecs
     privacy: closed
     previously:
     - maintainers-external-dns


### PR DESCRIPTION
This PR updates `config/kubernetes-sigs/sig-network/teams.yaml` to add a new admin and maintainer and remove an inactive one. 

/cc @szuecs 