### PR TITLE
Add doc-lead-1.26 to website-maintainers

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -351,6 +351,7 @@ teams:
     - jcjesus # L10n: Portuguese
     - jhonmike # L10n: Portuguese
     - jimangel # L10n: English
+    - krol3 # 1.26 RT Docs lead
     - mfilocha # L10n: Polish
     - mittalyashu # L10n: Hindi
     - msheldyakov # L10n: Russian


### PR DESCRIPTION
Temporary adding myself to the website-maintainers team for write access to k/website repo for the release preparation/release day.

/assign @onlydole @reylejano 