### PR TITLE
Add Vitthal Sai Kaul and Bishal Das as SIG-Docs Hindi l10n Reviewers

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -109,6 +109,7 @@ teams:
     members: 
     - anubha-v-ardhan
     - Babapool
+    - bishal7679
     - divya-mohan0209
     - Garima-Negi 
     - verma-kunal

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -108,6 +108,7 @@ teams:
     description: PR reviews for Hindi content
     members: 
     - anubha-v-ardhan
+    - Babapool
     - divya-mohan0209
     - Garima-Negi 
     - verma-kunal


### PR DESCRIPTION
We at SIG-Docs Hindi localization would like to add @Babapool and @bishal7679 as an official reviewer for Hindi as discussed [here](https://kubernetes.slack.com/archives/CJ14B9BDJ/p1670247355517609) and [here](https://kubernetes.slack.com/archives/CJ14B9BDJ/p1670313142357499) on Slack.
Vitthal has been contributing to Hindi l10n for some time now and helped us localizing more docs and review PRs.

see https://github.com/kubernetes/website/pull/38479
see https://github.com/kubernetes/website/pull/38598
cc @Babapool @bishal7679 @divya-mohan0209 