### PR TITLE
Add myself to kubernetes (already in kubernetes-sigs)

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -803,6 +803,7 @@ members:
 - leakingtapan
 - leilajal
 - leiyiz
+- lentzi90
 - leonardpahlke
 - lex111
 - lianghao208


### PR DESCRIPTION
As per the [community membership doc](https://github.com/kubernetes/community/blob/master/community-membership.md#kubernetes-ecosystem) I can simply open a PR to add myself to kubernetes when I'm already in kubernetes-sigs. I'm contributing to CAPO under kubernetes-sigs, and as part of that I have also needed to work with test-infra, which is why I want this.