### PR TITLE
Add my-git9 to sig-docs-zh-reviews

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -281,6 +281,7 @@ teams:
     - chenxuc
     - howieyuen
     - mengjiao-liu
+    - my-git9
     - SataQiu
     - Sea-n
     - tanjunchen


### PR DESCRIPTION
I want to join the sig-docs-zh-reviews team.

I have met the [requirements for reviewer](https://github.com/kubernetes/community/blob/master/community-membership.md#reviewer):
- Member of Kubernetes for 3+ months
- 280+ PRs merged: https://github.com/kubernetes/website/pulls?q=is%3Apr+is%3Amerged+author%3Amy-git9
- 30+ PRs reviewed:https://github.com/kubernetes/website/pulls?q=is%3Apr+reviewed-by%3Amy-git9

Thanks