### PR TITLE
add nawazkh to kubernetes org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1000,6 +1000,7 @@ members:
 - natasha41575
 - nate-double-u
 - navidshaikh
+- nawazkh
 - NayeonKeum
 - ncdc
 - nckturner


### PR DESCRIPTION
Following the below directive mentioned while adding myself to the kubernetes org via git issue;
> if you are already part of any Kubernetes GitHub organization like kubernetes-sigs and you are filing this request to be added to kubernetes, you do not need to open this request and can add yourself directly! The org memberships are now equivalent and sponsorship is not needed to join additional Kubernetes GitHub orgs.

raising this PR to add myself to the kubernetes org.

Groups I am part of
- Kubernetes-sigs
- Cluster-api-release-team