### PR TITLE
Add chengxiangdong and niuzhenguo as cloud-provider-huaweicloud admin/maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
+++ b/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
@@ -80,13 +80,17 @@ teams:
   cloud-provider-huaweicloud-admins:
    description: Admin access to the cloud-provider-huaweicloud repo
    members:
+   - chengxiangdong
    - kevin-wangzefeng
+   - niuzhenguo
    - RainbowMango
    privacy: closed
   cloud-provider-huaweicloud-maintainers:
    description: Write access to the cloud-provider-huaweicloud repo
    members:
+   - chengxiangdong
    - kevin-wangzefeng
+   - niuzhenguo
    - RainbowMango
    privacy: closed
   ibm-powervs-block-csi-driver-admins:


### PR DESCRIPTION
In order to help unlock the development and release versions of `cloud-provider-huaweicloud`.
I want to add myself and @niuzhenguo to the maintainers of `cloud-provider-huaweicloud` to have the ablility to create branches and tags.

Myself and @niuzhenguo are already listed in the OWNERS files in `cloud-provider-huaweicloud`: https://github.com/kubernetes-sigs/cloud-provider-huaweicloud/blob/master/OWNERS

/cc @kevin-wangzefeng @RainbowMango