### PR TITLE
adding `jrsapi` to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -417,6 +417,7 @@ members:
 - jpeach
 - jpmcb
 - jqmichael
+- jrsapi
 - jsafrane
 - jsturtevant
 - juan-lee


### PR DESCRIPTION
- @jrsapi is already a member of Kubernetes and now, as a release manager associate he needs to be part of the k-sigs as well because we have projects for sig-release there

see https://github.com/kubernetes-sigs/tejolote/pull/23 as reference


