### PR TITLE
update github handle fromanirh -> ffromani

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -269,6 +269,7 @@ members:
 - fejta
 - feloy
 - fengshunli
+- ffromani
 - figo
 - FillZpp
 - flaper87
@@ -282,7 +283,6 @@ members:
 - fredkan
 - FriedrichWilken
 - frobware
-- fromanirh
 - fsmunoz
 - furkatgofurov7
 - gab-satchi

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -441,6 +441,7 @@ members:
 - fengshunli
 - FengyunPan2
 - fengzixu
+- ffromani
 - fgimenez
 - figo
 - filbranden
@@ -459,7 +460,6 @@ members:
 - fredkan
 - freehan
 - frobware
-- fromanirh
 - fsmunoz
 - furkatgofurov7
 - G-Harmon


### PR DESCRIPTION
On January 9, 2023 the user "fromanirh" renamed their github handle to "ffromani".

Signed-off-by: Francesco Romani <fromani@redhat.com>