### PR TITLE
Updated CAPG groups with current maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -128,20 +128,15 @@ teams:
     description: admin access to cluster-api-provider-gcp
     members:
     - cpanato
-    - justinsb
-    - luxas
-    - roberthbailey
-    - timothysc
-    - vincepri
+    - dims
+    - richardcase
     privacy: closed
   cluster-api-provider-gcp-maintainers:
     description: write access to cluster-api-provider-gcp-maintainers
     members:
     - cpanato
-    - detiber
-    - justinsb
-    - krousey
-    - vincepri
+    - dims
+    - richardcase
     privacy: closed
   cluster-api-provider-kubemark-admins:
     description: admin access to cluster-api-provider-kubemark


### PR DESCRIPTION
This change updates the GitHub groups for CAPG with the current maintainers (see [OWNERS](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/main/OWNERS_ALIASES))

Signed-off-by: Richard Case <richard.case@suse.com>

/cc @cpanato @dims 