### PR TITLE
Add stmcginnis as kubernetes org member

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1340,6 +1340,7 @@ members:
 - stevesloka
 - stewart-yu
 - stlaz
+- stmcginnis
 - stormqueen1990
 - stp-ip
 - strongjz


### PR DESCRIPTION
Added to kubernetes-sigs with https://github.com/kubernetes/org/pull/2734/

This also adds to kubernetes itself since contributions are not limited to only SIG work.

Some recent work:

### kubernetes/contributor-site

[PRs](https://github.com/kubernetes/contributor-site/pulls?q=is%3Apr+author%3Astmcginnis+)

### kubernetes/community

[PRs](https://github.com/kubernetes/community/pulls?q=is%3Apr+author%3Astmcginnis+)
[Issues](https://github.com/kubernetes/community/issues?q=is%3Aissue+author%3Astmcginnis)