### PR TITLE
Revert "Remove qiujian16 from kubernetes-sigs org"

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -697,6 +697,7 @@ members:
 - qabpea
 - qbarrand
 - qinqon
+- qiujian16
 - qiutongs
 - qnetter
 - quinton-hoole


### PR DESCRIPTION
This reverts commit 5a94ef39b7808fe74fd1eb126b7c152f1a657221.

They have rotated all their credentials and can be restored.


fixes: #3890

/area github-membership