### PR TITLE
Add `haircommander` to `cri-tools-maintainers`

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -1002,6 +1002,7 @@ teams:
     description: Write access to the cri-tools repo
     members:
     - feiskyer
+    - haircommander
     - mrunalp
     - Random-Liu
     - saschagrunert


### PR DESCRIPTION
We should add Peter to the `cri-tools-maintainers` handle after the merge of: https://github.com/kubernetes-sigs/cri-tools/pull/1044

cc @feiskyer @haircommander @mrunalp @Random-Liu @yujuhong 