### PR TITLE
Add `jrvaldes` to SIG Node teams

### DIFF
--- a/config/kubernetes/sig-node/teams.yaml
+++ b/config/kubernetes/sig-node/teams.yaml
@@ -19,6 +19,7 @@ teams:
     - dims
     - endocrimes
     - feiskyer
+    - jrvaldes
     - klueska
     - krmayankk
     - matthyx
@@ -42,6 +43,7 @@ teams:
     - dims
     - endocrimes
     - feiskyer
+    - jrvaldes
     - klueska
     - krmayankk
     - matthyx
@@ -65,6 +67,7 @@ teams:
     - dims
     - endocrimes
     - feiskyer
+    - jrvaldes
     - klueska
     - krmayankk
     - matthyx
@@ -88,6 +91,7 @@ teams:
     - dims
     - endocrimes
     - feiskyer
+    - jrvaldes
     - klueska
     - krmayankk
     - matthyx


### PR DESCRIPTION
This changes adds `jrvaldes` to the sig-node teams so that I receive GitHub notifications to support SIG Node with bug triage, features, and PR reviews.

Signed-off-by: Jose Valdes <jvaldes@redhat.com>