### PR TITLE
Cleanup sig-docs teams

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -142,7 +142,9 @@ teams:
     members:
     - atoato88
     - bells17
+    - inductor
     - kakts
+    - nasa9084
     - ptux
     - t-inu
     privacy: closed

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -28,6 +28,7 @@ teams:
     - annajung
     - bradtopol
     - divya-mohan0209
+    - jimangel
     - kbhawkey
     - krol3
     - natalisucks
@@ -42,6 +43,7 @@ teams:
     members:
     - bradtopol
     - divya-mohan0209
+    - jimangel
     - kbhawkey
     - mehabhalodiya
     - natalisucks
@@ -72,6 +74,7 @@ teams:
     members:
     - awkif
     - feloy
+    - oussemos
     - perriea
     - rekcah78
     - remyleone
@@ -81,6 +84,7 @@ teams:
     members:
     - awkif
     - feloy
+    - oussemos
     - perriea
     - rekcah78
     - remyleone
@@ -123,6 +127,7 @@ teams:
     - fabriziopandini
     - Fale
     - mattiaperi
+    - micheleberardi
     privacy: closed
   sig-docs-it-reviews:
     description: PR reviews for Italian content
@@ -130,6 +135,7 @@ teams:
     - fabriziopandini
     - Fale
     - mattiaperi
+    - micheleberardi
     privacy: closed
   sig-docs-ja-owners:
     description: Approvers for Japanese content
@@ -173,6 +179,7 @@ teams:
     description: Chairs and tech leads for SIG Docs
     members:
     - divya-mohan0209
+    - jimangel
     - kbhawkey
     - natalisucks
     - onlydole
@@ -226,6 +233,7 @@ teams:
     - edsoncelio
     - femrtnz
     - jcjesus
+    - jhonmike
     - rikatz
     - stormqueen1990
     - yagonobre
@@ -237,6 +245,7 @@ teams:
     - edsoncelio
     - femrtnz
     - jcjesus
+    - jhonmike
     - rikatz
     - stormqueen1990
     - yagonobre
@@ -320,9 +329,11 @@ teams:
     - ianychoi # L10n: Korean
     - inductor # L10n: Japanese
     - jcjesus # L10n: Portuguese
+    - jhonmike # L10n: Portuguese
     - jimangel # L10n: English
     - krol3 # 1.26 RT Docs lead
     - mfilocha # L10n: Polish
+    - mittalyashu # L10n: Hindi
     - nasa9084 # L10n: Japanese
     - natalisucks # L10n: English
     - nate-double-u # L10n: English
@@ -365,6 +376,7 @@ teams:
     - natalisucks
     - nate-double-u
     - onlydole
+    - oussemos
     - perriea
     - potapy4
     - raelga

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -4,7 +4,7 @@ teams:
     maintainers:
     - mrbobbytables
     members:
-    - nate-double-u 
+    - nate-double-u
     - onlydole
     - sftim
     privacy: closed
@@ -27,14 +27,13 @@ teams:
     members:
     - annajung
     - bradtopol
-    - celestehorgan
     - divya-mohan0209
-    - jimangel
     - kbhawkey
+    - krol3
     - natalisucks
+    - nate-double-u
     - onlydole
     - reylejano
-    - savitharaghunathan
     - sftim
     - tengqm
     privacy: closed
@@ -42,15 +41,12 @@ teams:
     description: PR reviews for English content
     members:
     - bradtopol
-    - celestehorgan
-    - daminisatya
     - divya-mohan0209
-    - jimangel
     - kbhawkey
     - mehabhalodiya
     - natalisucks
+    - nate-double-u
     - onlydole
-    - rajeshdeshpande02
     - reylejano
     - sftim
     - shannonxtreme
@@ -74,30 +70,20 @@ teams:
   sig-docs-fr-owners:
     description: Approvers for French content
     members:
-    - abuisine
     - awkif
-    - jygastaud
-    - oussemos
+    - feloy
     - perriea
-    - rbenzair
     - rekcah78
     - remyleone
-    - smana
-    - yastij
     privacy: closed
   sig-docs-fr-reviews:
     description: PR reviews for French content
     members:
-    - abuisine
     - awkif
-    - jygastaud
-    - oussemos
+    - feloy
     - perriea
-    - rbenzair
     - rekcah78
     - remyleone
-    - smana
-    - yastij
     privacy: closed
   sig-docs-hi-owners:
     description: Approvers for Hindi content
@@ -107,27 +93,29 @@ teams:
     privacy: closed
   sig-docs-hi-reviews:
     description: PR reviews for Hindi content
-    members: 
+    members:
     - anubha-v-ardhan
     - Babapool
     - bishal7679
     - divya-mohan0209
-    - Garima-Negi 
+    - Garima-Negi
     - verma-kunal
     privacy: closed
   sig-docs-id-owners:
     description: Approvers for Indonesian content
     members:
+    - ariscahyadi
+    - danninov
     - girikuncoro
+    - habibrosyad
     privacy: closed
   sig-docs-id-reviews:
     description: PR reviews for Indonesian content
     members:
+    - ariscahyadi
     - danninov
     - girikuncoro
     - habibrosyad
-    - phanama
-    - wahyuoi
     privacy: closed
   sig-docs-it-owners:
     description: Approvers for Italian content
@@ -135,7 +123,6 @@ teams:
     - fabriziopandini
     - Fale
     - mattiaperi
-    - micheleberardi
     privacy: closed
   sig-docs-it-reviews:
     description: PR reviews for Italian content
@@ -143,7 +130,6 @@ teams:
     - fabriziopandini
     - Fale
     - mattiaperi
-    - micheleberardi
     privacy: closed
   sig-docs-ja-owners:
     description: Approvers for Japanese content
@@ -156,17 +142,13 @@ teams:
     members:
     - atoato88
     - bells17
-    - inductor
     - kakts
-    - makocchi-git
-    - nasa9084
     - ptux
     - t-inu
     privacy: closed
   sig-docs-ko-owners:
     description: Approvers for Korean content
     members:
-    - claudiajkang
     - gochist
     - ianychoi
     - jihoon-seo
@@ -177,12 +159,10 @@ teams:
   sig-docs-ko-reviews:
     description: Reviews for Korean docs PRs
     members:
-    - ClaudiaJKang
     - gochist
     - ianychoi
     - jihoon-seo
     - jmyung
-    - pjhwa
     - seokho-son
     - yoonian
     - ysyukr
@@ -191,7 +171,6 @@ teams:
     description: Chairs and tech leads for SIG Docs
     members:
     - divya-mohan0209
-    - jimangel
     - kbhawkey
     - natalisucks
     - onlydole
@@ -208,25 +187,20 @@ teams:
   sig-docs-pl-reviews:
     description: Reviews for Polish docs PRs
     members:
+    - kpucynski
     - mfilocha
     - nvtkaszpir
     privacy: closed
   sig-docs-ru-owners:
     description: Approvers for Russian content
     members:
-    - aisonaku
-    - dianaabv
-    - msheldyakov
-    - potapy4
+    - Arhell
     - shurup
     privacy: closed
   sig-docs-ru-reviews:
     description: Reviews for Russian docs PRs
     members:
-    - aisonaku
-    - dianaabv
-    - msheldyakov
-    - potapy4
+    - Arhell
     - shurup
     privacy: closed
   sig-docs-pr-reviews:
@@ -247,22 +221,22 @@ teams:
     description: Approvers for Portuguese content
     members:
     - devlware
+    - edsoncelio
     - femrtnz
-    - jailton
     - jcjesus
-    - jhonmike
     - rikatz
+    - stormqueen1990
     - yagonobre
     privacy: closed
   sig-docs-pt-reviews:
     description: PR reviews for Portuguese content
     members:
     - devlware
+    - edsoncelio
     - femrtnz
-    - jailton
     - jcjesus
-    - jhonmike
     - rikatz
+    - stormqueen1990
     - yagonobre
     privacy: closed
   sig-docs-zh-owners:
@@ -297,29 +271,26 @@ teams:
     description: Admins for Vietnamese content
     members:
     - huynguyennovem
-    - ngtuna
     - truongnh1992
     privacy: closed
   sig-docs-vi-reviews:
     description: PR reviews for Vietnamese content
     members:
     - huynguyennovem
-    - ngtuna
     - truongnh1992
     privacy: closed
   sig-docs-uk-owners:
     description: Approvers for Ukrainian content
     members:
-    - anastyakulyk
-    - butuzov
+    - Arhell
     - MaxymVlasov
     privacy: closed
   sig-docs-uk-reviews:
     description: PR reviews for Ukrainian content
+    maintainers:
+    - idvoretskyi
     members:
-    - anastyakulyk
     - Arhell
-    - butuzov
     - MaxymVlasov
     - Potapy4
     privacy: closed
@@ -337,13 +308,8 @@ teams:
     description: Write access to the website repo
     members:
     - a-mccarthy # Localization subproject owner
-    - aisonaku # L10n: Russian
-    - Bradamant3 # L10n: English
     - bradtopol # L10n: English
-    - ClaudiaJKang # L10n: Korean
-    - cstoku # L10n: Japanese
     - devlware # L10: Portuguese
-    - dianaabv # L10n: Russian
     - divya-mohan0209 # L10n: English
     - femrtnz # L10n: Portuguese
     - girikuncoro # L10n: Indonesian
@@ -351,18 +317,13 @@ teams:
     - huynguyennovem # L10n: Vietnamese
     - ianychoi # L10n: Korean
     - inductor # L10n: Japanese
-    - jailton # L10n: Portuguese
     - jcjesus # L10n: Portuguese
-    - jhonmike # L10n: Portuguese
     - jimangel # L10n: English
     - krol3 # 1.26 RT Docs lead
     - mfilocha # L10n: Polish
-    - mittalyashu # L10n: Hindi
-    - msheldyakov # L10n: Russian
     - nasa9084 # L10n: Japanese
     - natalisucks # L10n: English
     - nate-double-u # L10n: English
-    - ngtuna # L10n: Vietnamese
     - nvtkaszpir # L10n: Polish
     - onlydole # L10n: English
     - potapy4 # L10n: Russian
@@ -384,16 +345,11 @@ teams:
     description: Contributors who can use `/milestone` in the website repo
     members:
     - a-mccarthy
-    - abuisine
-    - aisonaku
     - annajung
     - awkif
     - bene2k1
     - bradtopol
     - celestehorgan
-    - claudiajkang
-    - cstoku
-    - dianaabv
     - divya-mohan0209
     - femrtnz
     - girikuncoro
@@ -402,22 +358,15 @@ teams:
     - inductor
     - jcjesus
     - jimangel
-    - juandiegopalomino
-    - jygastaud
     - krol3 # 1.26 RT Docs lead
-    - lledru
-    - msheldyakov
     - nasa9084
     - natalisucks
     - nate-double-u
-    - ngtuna
     - onlydole
-    - oussemos
     - perriea
     - potapy4
     - raelga
     - Rajakavitha1
-    - rbenzair
     - rekcah78
     - remyleone
     - reylejano
@@ -427,15 +376,11 @@ teams:
     - seokho-son
     - sftim
     - shurup
-    - smana
     - tanjunchen
     - tengqm
     - tfogo
     - truongnh1992
-    - vineethreddy02
     - xichengliudui
-    - yastij
     - ysyukr
-    - zhangxiaoyu-zidif
     - zparnold
     privacy: closed


### PR DESCRIPTION
Sync `sig-docs-xx-owners` and `sig-docs-xx-reviews` member with [k/website OWNERS_ALIASES](https://github.com/kubernetes/website/blob/main/OWNERS_ALIASES).

Also cleanup `website-maintainers` and `website-milestone-maintainers`, removed who have no any `owners` or `reviews` role.

Please let me know if any change should be revert.

Hold this PR until 2023-02-05 as it involved 40 contributors.
/hold

/cc @kubernetes/sig-docs-leads

---

Removed A:
- @aisonaku as `ru-owners`, `website-maintainers`, `website-milestone-maintainers`
- @claudiajkang as `ko-owners`, `website-maintainers`, `website-milestone-maintainers`
- @dianaabv as `ru-owners`, `website-maintainers`, `website-milestone-maintainers`
- @msheldyakov as `ru-owners`, `website-maintainers`, `website-milestone-maintainers`
- @ngtuna as `vi-owners`, `website-maintainers`, `website-milestone-maintainers`
- ~~@a-mccarthy as `website-maintainers`, `website-milestone-maintainers`~~
- @cstoku as `website-maintainers`, `website-milestone-maintainers`

Removed B:
- @abuisine as `fr-owners`, `website-milestone-maintainers`
- @jygastaud as `fr-owners`, `website-milestone-maintainers`
- @oussemos as `fr-owners`, `website-milestone-maintainers`
- @rbenzair as `fr-owners`, `website-milestone-maintainers`
- @smana as `fr-owners`, `website-milestone-maintainers`
- @yastij as `fr-owners`, `website-milestone-maintainers`
- @juandiegopalomino as `website-milestone-maintainers`
- @lledru as `website-milestone-maintainers`
- @vineethreddy02 as `website-milestone-maintainers`
- @zhangxiaoyu-zidif as `website-milestone-maintainers`

Removed C:
- @jailton as `pt-owners`, `website-maintainers`
- @jhonmike as `pt-owners`, `website-maintainers`
- @jimangel as `en-owners`, `sig-docs-leads`
- @bradamant3 as `website-maintainers`
- @mittalyashu as `website-maintainers`

Removed D:
- @anastyakulyk as `uk-owners`
- @butuzov as `uk-owners`
- @celestehorgan as `en-owners`
- @makocchi-git as `ja-reviews`
- ~~@nasa9084 as `ja-reviews`~~
- ~~@inductor as `ja-reviews`~~
- @micheleberardi as `it-owners`
- @potapy4 as `ru-owners`
- @savitharaghunathan as `en-owners`

Removed E:
- @daminisatya as `en-reviews`
- ~~@emedina as `es-reviews`~~ (Done by #3963)
- ~~@glo-pena as `es-reviews`~~ (Done by #3963)
- @phanama as `id-reviews`
- @pjhwa as `ko-reviews`
- @rajeshdeshpande02 as `en-reviews`
- @wahyuoi as `id-reviews`

Added:
- @krol3 as `en-owners`
- @arhell as `ru-owners`, `uk-owners`
- @ariscahyadi as `id-owners`
- @danninov as `id-owners`
- @edsoncelio as `pt-owners`
- @feloy as `fr-owners`
- @habibrosyad as `id-owners`
- @stormqueen1990 as `pt-owners`
- @idvoretskyi as `uk-reviews`
- @kpucynski as `pl-reviews`

If you are still interesting in contribute Kubernetes website, please leave a comment within 14 days.