### PR TITLE
releng: Promote Cici Huang to Release Manager

### DIFF
--- a/config/kubernetes-nightly/sig-release/teams.yaml
+++ b/config/kubernetes-nightly/sig-release/teams.yaml
@@ -26,6 +26,7 @@ teams:
     - saschagrunert
     - sttts
     members:
+    - cici37
     - Verolop
     - xmudrii
     privacy: closed

--- a/config/kubernetes-nightly/sig-release/teams.yaml
+++ b/config/kubernetes-nightly/sig-release/teams.yaml
@@ -26,7 +26,6 @@ teams:
     - saschagrunert
     - sttts
     members:
-    - cici37
     - Verolop
     - xmudrii
     privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -160,7 +160,6 @@ teams:
     - nikhita
     - palnabarun
     members:
-    - cici37
     - cpanato
     - dims
     - jeremyrickard

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -241,7 +241,7 @@ teams:
         - ameukam # Release Manager Associate
         - palnabarun # Release Manager
         members:
-        - cici37 # subproject owner / Release Manager
+        - cici37 # Release Manager
         - cpanato # subproject owner / Release Manager
         - jeremyrickard # subproject owner / Release Manager
         - jimangel # Release Manager Associate
@@ -280,7 +280,7 @@ teams:
         - palnabarun # subproject owner (1.21 RT Lead)
         members:
         - Atharva-Shinde # 1.27 Enhancements Shadow
-        - cici37 # subproject owner / Release Manager
+        - cici37 # Release Manager
         - cpanato # subproject owner / Technical Lead
         - fsmunoz # 1.27 Enhancements Shadow
         - harshanarayana # 1.27 Release Notes Lead

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -38,7 +38,7 @@ teams:
     - caseydavenport # Network
     - cheftako # Cloud Provider
     - chrigl # OpenStack
-    - cici37 # Release Manager Associate
+    - cici37 # Release Manager
     - claudiubelu # Windows
     - cpanato # Release Manager
     - craiglpeters # Azure
@@ -160,6 +160,7 @@ teams:
     - nikhita
     - palnabarun
     members:
+    - cici37
     - cpanato
     - dims
     - jeremyrickard
@@ -241,7 +242,7 @@ teams:
         - ameukam # Release Manager Associate
         - palnabarun # Release Manager
         members:
-        - cici37 # Release Manager Associate
+        - cici37 # subproject owner / Release Manager
         - cpanato # subproject owner / Release Manager
         - jeremyrickard # subproject owner / Release Manager
         - jimangel # Release Manager Associate
@@ -262,6 +263,7 @@ teams:
             maintainers:
             - palnabarun
             members:
+            - cici37
             - cpanato
             - jeremyrickard
             - justaugustus
@@ -279,7 +281,7 @@ teams:
         - palnabarun # subproject owner (1.21 RT Lead)
         members:
         - Atharva-Shinde # 1.27 Enhancements Shadow
-        - cici37 # subproject owner (1.25 RT Lead)
+        - cici37 # subproject owner / Release Manager
         - cpanato # subproject owner / Technical Lead
         - fsmunoz # 1.27 Enhancements Shadow
         - harshanarayana # 1.27 Release Notes Lead


### PR DESCRIPTION
Accompanying GitHub team membership changes to https://github.com/kubernetes/sig-release/issues/2152, https://github.com/kubernetes/sig-release/pull/2156

* Promote cici37 to Branch Manager

/hold until [Branch Managers](https://github.com/kubernetes/sig-release/pull/2156) merges.

/assign @jeremyrickard
/cc https://github.com/orgs/kubernetes/teams/release-managers
/milestone v1.27
/priority important-soon

