### PR TITLE
sig-instrumentation: Add mrueg

### DIFF
--- a/config/kubernetes/sig-instrumentation/teams.yaml
+++ b/config/kubernetes/sig-instrumentation/teams.yaml
@@ -31,6 +31,7 @@ teams:
     - erain
     - lilic
     - logicalhan
+    - mrueg
     - olivierlemasle
     - pohly
     - RainbowMango


### PR DESCRIPTION
I'd like to join sig-instrumentation as I'm already maintaining a subproject (kube-state-metrics).

@dgrisonnet 