### PR TITLE
Add comms team for 1.27

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -349,7 +349,11 @@ teams:
           release-team-comms:
             description: Members of the Comms team for the current release cycle.
             members:
+            - bradmccoydev # 1.27 Comms Shadow 
             - harshitasao # 1.27 Comms Lead
+            - jaehnri # 1.27 Comms Shadow
+            - Nancy-Chauhan # 1.27 Comms Shadow
+            - sfotony # 1.27 Comms Shadow
             privacy: closed
           release-team-enhancements:
             description: Members of the Enhancments team for the current release


### PR DESCRIPTION
Added Comms shadows for 1.27 to the respective team in order to get access to the GitHub project board.

cc @JamesLaverack @salaxander 