### PR TITLE
Add `rexagod` to sig-instrumentation

### DIFF
--- a/config/kubernetes/sig-instrumentation/teams.yaml
+++ b/config/kubernetes/sig-instrumentation/teams.yaml
@@ -35,6 +35,7 @@ teams:
     - olivierlemasle
     - pohly
     - RainbowMango
+    - rexagod
     - RichaBanker
     - s-urbaniak
     - serathius


### PR DESCRIPTION
Hello, I'd like to be added to the aforementioned SIG as I'm already a reviewer in [k/KSM](https://github.com/kubernetes/kube-state-metrics).

Thanks.