### PR TITLE
added sig-node-leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -66,6 +66,8 @@ aliases:
   sig-node-leads:
     - dchen1107
     - derekwaynecarr
+    - mrunalp
+    - SergeyKanzhelev
   sig-release-leads:
     - cpanato
     - jeremyrickard

--- a/config/kubernetes/sig-node/teams.yaml
+++ b/config/kubernetes/sig-node/teams.yaml
@@ -9,6 +9,14 @@ teams:
     - thockin
     - yujuhong
     privacy: closed
+  sig-node-leads:
+    description: Chairs and Technical Leads for SIG Node
+    members:
+    - dchen1107
+    - derekwaynecarr
+    - mrunalp
+    - SergeyKanzhelev
+    privacy: closed
   sig-node-bugs:
     description: Bugs for Kubernetes Node Special-Interest-Group
     members:


### PR DESCRIPTION
In response to https://github.com/kubernetes/enhancements/issues/24#issuecomment-1410951614

It looks like the team is missing.