### PR TITLE
Remove users from configuration to fix peribolos

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -104,7 +104,6 @@ members:
 - bertinatto
 - bgrant0607
 - bigkraig
-- BinacsLee
 - Birdrock
 - bishal7679
 - bmelbourne

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -168,7 +168,6 @@ members:
 - bhumijgupta
 - BigDarkClown
 - bigkraig
-- BinacsLee
 - bishal7679
 - blakebarnett
 - bluebreezecf
@@ -677,7 +676,6 @@ members:
 - jmguzik
 - jmyung
 - joadavis-g
-- joao-luna-98
 - joelanford
 - joelsmith
 - JoelSpeed


### PR DESCRIPTION
- Removing `joao-luna-98` as the user now 404s
- Removing `BinacsLee` as this user has been converted into an organization