### PR TITLE
Add killianmuldoon as CAPI maintainer

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -48,6 +48,7 @@ teams:
     - CecileRobertMichon
     - enxebre
     - fabriziopandini
+    - killianmuldoon
     - sbueringer
     - vincepri
     privacy: closed


### PR DESCRIPTION
Add killianmuldoon to the CAPI maintainer team.

PR making changes on the CAPI OWNER_ALIASES is at https://github.com/kubernetes-sigs/cluster-api/pull/7996