### PR TITLE
Remove nzoueidi

### DIFF
--- a/config/kubernetes-client/org.yaml
+++ b/config/kubernetes-client/org.yaml
@@ -42,7 +42,6 @@ members:
 - micw523
 - moshevayner
 - nnmin-aws
-- nzoueidi
 - oz123
 - rlenferink
 - roycaihw

--- a/config/kubernetes-csi/org.yaml
+++ b/config/kubernetes-csi/org.yaml
@@ -75,7 +75,6 @@ members:
 - nearora-msft
 - NickrenREN
 - nnmin-aws
-- nzoueidi
 - oprinmarius
 - PatrickLang
 - pohly

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -658,7 +658,6 @@ members:
 - npolshakova
 - nprokopic
 - nunnatsa
-- nzoueidi
 - odinuge
 - olemarkus
 - olivercodes

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1058,7 +1058,6 @@ members:
 - nunnatsa
 - nvtkaszpir
 - nwoods3
-- nzoueidi
 - obitech
 - Octopusjust
 - OddBloke

--- a/config/kubernetes/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes/sig-contributor-experience/teams.yaml
@@ -88,7 +88,6 @@ teams:
     members:
     - idealhack
     - justaugustus
-    - nzoueidi
     privacy: closed
   project-board-maintainers:
     description: Contributors with access to groom issues on org-level project boards.
@@ -177,7 +176,6 @@ teams:
     - jdumars
     - jeefy
     - markyjackson-taulia
-    - nzoueidi
     - onlydole
     - parispittman
     - sarahnovotny


### PR DESCRIPTION
Don't know if they've renamed or just removed their account, but https://github.com/nzoueidi is 404'ing.