### PR TITLE
Update Security Profiles Operator owners

### DIFF
--- a/config/kubernetes-sigs/sig-node/teams.yaml
+++ b/config/kubernetes-sigs/sig-node/teams.yaml
@@ -27,6 +27,7 @@ teams:
   security-profiles-operator-admins:
     description: Admin access to security-profiles-operator repo
     members:
+    - ccojocar
     - JAORMX
     - jhrozek
     - pjbgf
@@ -37,6 +38,7 @@ teams:
   security-profiles-operator-maintainers:
     description: Write access to security-profiles-operator repo
     members:
+    - ccojocar
     - JAORMX
     - jhrozek
     - pjbgf


### PR DESCRIPTION
This reflects the desired repo OWNERS state.

PTAL @pjbgf @jhrozek @JAORMX 

cc @ccojocar 

Refers to https://github.com/kubernetes-sigs/security-profiles-operator/pull/1524, https://github.com/kubernetes/test-infra/pull/28912, https://github.com/kubernetes/k8s.io/pull/4866