### PR TITLE
sig-apps: relocate kompose teams

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1941,28 +1941,6 @@ teams:
     - davidopp
     - kad
     privacy: closed
-  kompose-admins:
-    description: Admin access to the kompose repo
-    members:
-    - AhmedGrati
-    - cdrage
-    - hangyan
-    - janetkuo
-    - kadel
-    - ngtuna
-    - sebgoa
-    privacy: closed
-  kompose-maintainers:
-    description: Write access to the kompose repo
-    members:
-    - AhmedGrati
-    - cdrage
-    - hangyan
-    - janetkuo
-    - kadel
-    - ngtuna
-    - sebgoa
-    privacy: closed
   kube-openapi-admins:
     description: Admin access to the kube-openapi repo
     members:

--- a/config/kubernetes/sig-apps/teams.yaml
+++ b/config/kubernetes/sig-apps/teams.yaml
@@ -1,4 +1,26 @@
 teams:
+  kompose-admins:
+    description: Admin access to the kompose repo
+    members:
+    - AhmedGrati
+    - cdrage
+    - hangyan
+    - janetkuo
+    - kadel
+    - ngtuna
+    - sebgoa
+    privacy: closed
+  kompose-maintainers:
+    description: Write access to the kompose repo
+    members:
+    - AhmedGrati
+    - cdrage
+    - hangyan
+    - janetkuo
+    - kadel
+    - ngtuna
+    - sebgoa
+    privacy: closed
   sig-apps-api-reviews:
     description: ""
     members:


### PR DESCRIPTION
Move declaration of kompose GitHub teams to simplify approval.