### PR TITLE
writers should be maintainers (community-images and porche)

### DIFF
--- a/config/kubernetes-sigs/sig-k8s-infra/teams.yaml
+++ b/config/kubernetes-sigs/sig-k8s-infra/teams.yaml
@@ -11,6 +11,15 @@ teams:
   community-images-writers:
     description: write access to community-images
     maintainers:
+      - ameukam
+    members:
+      - dims
+      - spiffxp
+      - thockin
+    privacy: closed
+  community-images-maintainers:
+    description: write access to community-images
+    maintainers:
     - ameukam
     members:
     - dims
@@ -29,6 +38,17 @@ teams:
     - thockin
     privacy: closed
   porche-writers:
+    description: write access to porche
+    maintainers:
+      - ameukam
+    members:
+      - bentheelder
+      - dims
+      - justinsb
+      - spiffxp
+      - thockin
+    privacy: closed
+  porche-maintainers:
     description: write access to porche
     maintainers:
     - ameukam


### PR DESCRIPTION
We've been using `-maintainers` NOT `-writers`:
https://cs.k8s.io/?q=-maintainers%3A&i=nope&files=&excludeFiles=&repos=kubernetes/org

EDIT: Adding a new group `-maintainers` in addition to `-writers` per guidance from @mrbobbytables 