### PR TITLE
Add windsonsea to sig-docs-zh-owners

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -261,6 +261,7 @@ teams:
     - Sea-n
     - tanjunchen
     - tengqm
+    - windsonsea
     - xichengliudui
     privacy: closed
   sig-docs-zh-reviews:


### PR DESCRIPTION
Add myself to the `sig-docs-zh-reviews` after [website PR #39964](https://github.com/kubernetes/website/pull/39964), to get the permission, thanks.