### PR TITLE
sig-net: transfer co-chair from dcbw to MikeZappa87

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -60,7 +60,7 @@ aliases:
     - jeremyot
     - pmorie
   sig-network-leads:
-    - dcbw
+    - MikeZappa87
     - shaneutt
     - thockin
   sig-node-leads:

--- a/config/kubernetes/sig-network/teams.yaml
+++ b/config/kubernetes/sig-network/teams.yaml
@@ -77,7 +77,7 @@ teams:
   sig-network-leads:
     description: ""
     members:
-    - dcbw
+    - MikeZappa87
     - shaneutt
     - thockin
     privacy: closed


### PR DESCRIPTION
Per chair transition procedure, there were no objections to Mike being proposed as dcbw's replacement, thus Mike is now a chair.

https://groups.google.com/g/kubernetes-sig-network/c/sZF25bnqZ-8

@MikeZappa87 @thockin @shaneutt 