### PR TITLE
removed spiffxp and added xmcqueen per nomination sig-testing chair

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -99,8 +99,8 @@ aliases:
     - cjwagner
     - michelle192837
     - pohly
-    - spiffxp
     - stevekuznetsov
+    - xmcqueen
   sig-ui-leads:
     - floreks
     - maciaszczykm

--- a/config/kubernetes-sigs/sig-testing/teams.yaml
+++ b/config/kubernetes-sigs/sig-testing/teams.yaml
@@ -31,7 +31,7 @@ teams:
     - alejandrox1
     - andrewsykim
     - BenTheElder
-    - spiffxp
+    - xmcqueen
     - vladimirvivien
     privacy: closed
   e2e-framework-maintainers:
@@ -40,7 +40,7 @@ teams:
     - alejandrox1
     - andrewsykim
     - BenTheElder
-    - spiffxp
+    - xmcqueen
     privacy: closed
   kind-admins:
     description: Admin access to the kind repo
@@ -62,13 +62,13 @@ teams:
     description: Admin access to kubetest2
     members:
     - MushuEE
-    - spiffxp
+    - xmcqueen
     privacy: closed
   kubetest2-maintainers:
     description: Write access to kubetest2
     members:
     - MushuEE
-    - spiffxp
+    - xmcqueen
     privacy: closed
   prow-admins:
     description: Admin access to prow

--- a/config/kubernetes-sigs/sig-testing/teams.yaml
+++ b/config/kubernetes-sigs/sig-testing/teams.yaml
@@ -68,7 +68,7 @@ teams:
     description: Write access to kubetest2
     members:
     - MushuEE
-    - xmcqueen
+    - spiffxp
     privacy: closed
   prow-admins:
     description: Admin access to prow

--- a/config/kubernetes-sigs/sig-testing/teams.yaml
+++ b/config/kubernetes-sigs/sig-testing/teams.yaml
@@ -31,8 +31,8 @@ teams:
     - alejandrox1
     - andrewsykim
     - BenTheElder
+    - spiffxp
     - vladimirvivien
-    - xmcqueen
     privacy: closed
   e2e-framework-maintainers:
     description: write access to e2e-framework
@@ -40,7 +40,7 @@ teams:
     - alejandrox1
     - andrewsykim
     - BenTheElder
-    - xmcqueen
+    - spiffxp
     privacy: closed
   kind-admins:
     description: Admin access to the kind repo
@@ -62,7 +62,7 @@ teams:
     description: Admin access to kubetest2
     members:
     - MushuEE
-    - xmcqueen
+    - spiffxp
     privacy: closed
   kubetest2-maintainers:
     description: Write access to kubetest2

--- a/config/kubernetes-sigs/sig-testing/teams.yaml
+++ b/config/kubernetes-sigs/sig-testing/teams.yaml
@@ -31,8 +31,8 @@ teams:
     - alejandrox1
     - andrewsykim
     - BenTheElder
-    - xmcqueen
     - vladimirvivien
+    - xmcqueen
     privacy: closed
   e2e-framework-maintainers:
     description: write access to e2e-framework

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -133,7 +133,6 @@ teams:
     - shyamjvs # Scalability
     - soltysh # CLI
     - sowmyav27 # 1.27 Bug Triage Shadow
-    - xmcqueen # Testing
     - spzala # IBM Cloud
     - stevekuznetsov # Testing
     - tallclair # Auth
@@ -145,6 +144,7 @@ teams:
     - vllry # Usability
     - wojtek-t # Scalability
     - xing-yang # Storage
+    - xmcqueen # Testing
     - xmudrii # Release Manager
     privacy: closed
     previously:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -133,7 +133,7 @@ teams:
     - shyamjvs # Scalability
     - soltysh # CLI
     - sowmyav27 # 1.27 Bug Triage Shadow
-    - spiffxp # Testing
+    - xmcqueen # Testing
     - spzala # IBM Cloud
     - stevekuznetsov # Testing
     - tallclair # Auth

--- a/config/kubernetes/sig-testing/teams.yaml
+++ b/config/kubernetes/sig-testing/teams.yaml
@@ -21,10 +21,10 @@ teams:
     - michelle192837
     - mkumatag
     - pigmej
-    - xmcqueen
     - stevekuznetsov
     - timothysc
     - xiangpengzhao
+    - xmcqueen
     privacy: closed
     teams:
       sig-testing-leads:
@@ -34,8 +34,8 @@ teams:
         - BenTheElder
         - michelle192837
         - pohly
-        - xmcqueen
         - stevekuznetsov
+        - xmcqueen
         privacy: closed
       sig-testing-pr-reviews:
         description: sig-testing PR reviews
@@ -52,8 +52,8 @@ teams:
         - krzyzacy
         - michelle192837
         - mkumatag
-        - xmcqueen
         - stevekuznetsov
+        - xmcqueen
         privacy: closed
   test-infra-admins:
     description: admin access to test-infra
@@ -67,8 +67,8 @@ teams:
     - listx
     - michelle192837
     - mpherman2
-    - xmcqueen
     - stevekuznetsov
+    - xmcqueen
     privacy: closed
   test-infra-maintainers:
     description: write access to test-infra
@@ -80,8 +80,8 @@ teams:
     - ixdy
     - krzyzacy
     - michelle192837
-    - xmcqueen
     - stevekuznetsov
+    - xmcqueen
     privacy: closed
   sig-testing-dummy-project-team:
     description: dummy team to test prow project plugin; no acl

--- a/config/kubernetes/sig-testing/teams.yaml
+++ b/config/kubernetes/sig-testing/teams.yaml
@@ -21,7 +21,7 @@ teams:
     - michelle192837
     - mkumatag
     - pigmej
-    - spiffxp
+    - xmcqueen
     - stevekuznetsov
     - timothysc
     - xiangpengzhao
@@ -34,7 +34,7 @@ teams:
         - BenTheElder
         - michelle192837
         - pohly
-        - spiffxp
+        - xmcqueen
         - stevekuznetsov
         privacy: closed
       sig-testing-pr-reviews:
@@ -52,7 +52,7 @@ teams:
         - krzyzacy
         - michelle192837
         - mkumatag
-        - spiffxp
+        - xmcqueen
         - stevekuznetsov
         privacy: closed
   test-infra-admins:
@@ -67,7 +67,7 @@ teams:
     - listx
     - michelle192837
     - mpherman2
-    - spiffxp
+    - xmcqueen
     - stevekuznetsov
     privacy: closed
   test-infra-maintainers:
@@ -80,7 +80,7 @@ teams:
     - ixdy
     - krzyzacy
     - michelle192837
-    - spiffxp
+    - xmcqueen
     - stevekuznetsov
     privacy: closed
   sig-testing-dummy-project-team:

--- a/config/kubernetes/sig-testing/teams.yaml
+++ b/config/kubernetes/sig-testing/teams.yaml
@@ -67,8 +67,8 @@ teams:
     - listx
     - michelle192837
     - mpherman2
+    - spiffxp
     - stevekuznetsov
-    - xmcqueen
     privacy: closed
   test-infra-maintainers:
     description: write access to test-infra
@@ -80,8 +80,8 @@ teams:
     - ixdy
     - krzyzacy
     - michelle192837
+    - spiffxp
     - stevekuznetsov
-    - xmcqueen
     privacy: closed
   sig-testing-dummy-project-team:
     description: dummy team to test prow project plugin; no acl


### PR DESCRIPTION
getting the sig lists up-to-date with chair rotation per kubernetes/community#7239