### PR TITLE
Add dims as admin for provider-aws-test-infra repo

### DIFF
--- a/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
+++ b/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
@@ -134,6 +134,7 @@ teams:
   provider-aws-test-infra-admins:
    description: Admin access to the provider-aws-test-infra repo
    members:
+   - dims
    - nckturner
    - wongma7
    privacy: closed


### PR DESCRIPTION
related - https://github.com/kubernetes-sigs/provider-aws-test-infra/pull/1

Also see this repo where we have a test-e2e-node that works with AWS
- https://github.com/dims/remote-aws-runner 

and possibly some stuff from:
- https://github.com/aws/aws-k8s-tester