### PR TITLE
Add new member to kubernetes org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -693,6 +693,7 @@ members:
 - jmhbnz
 - jmyung
 - joadavis-g
+- joekr
 - joelanford
 - joelsmith
 - JoelSpeed


### PR DESCRIPTION
/area github-membership

After speaking with @sbueringer  https://github.com/kubernetes/k8s.io/pull/5077#issuecomment-1502805630 I wanted to add myself to the kubernetes org.

From https://github.com/kubernetes/community/blob/master/community-membership.md#kubernetes-ecosystem
> If you are a member of one of these Orgs, you are implicitly eligible for membership in related orgs, and can request membership when it becomes relevant, by creating a PR directly or [opening an issue](https://github.com/kubernetes/org/issues/new?assignees=&labels=area%2Fgithub-membership&template=membership.yml&title=REQUEST%3A+New+membership+for+%3Cyour-GH-handle%3E) against the kubernetes/org repo, as above.