### PR TITLE
Add campoy and ndipebot to usage-metrics-collector orgs

### DIFF
--- a/config/kubernetes-sigs/sig-instrumentation/teams.yaml
+++ b/config/kubernetes-sigs/sig-instrumentation/teams.yaml
@@ -74,16 +74,20 @@ teams:
   usage-metrics-collector-admins:
     description: Admin access to the usage-metrics-collector repo
     members:
+    - campoy
     - ehashman
     - KnVerey
+    - ndipebot
     - pmorie
     - pwittrock
     privacy: closed
   usage-metrics-collector-maintainers:
     description: Write access to the usage-metrics-collector repo
     members:
+    - campoy
     - ehashman
     - KnVerey
+    - ndipebot
     - pmorie
     - pwittrock
     privacy: closed


### PR DESCRIPTION
Adding @campoy and @ndipebot to usage-metrics-collector-admins and usage-metrics-collector-maintainers.