### PR TITLE
add bg-chun to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -106,6 +106,7 @@ members:
 - benmoss
 - BenTheElder
 - bertinatto
+- bg-chun
 - bgrant0607
 - bigkraig
 - binacs


### PR DESCRIPTION
I have a membership for kubernetes org. I contributed to kubelet and scheduler with touching/writing 4 KEPs.
Now I'm going to contribute [kubernetes-sigs/cluster-api](https://github.com/kubernetes-sigs/cluster-api).

[The document](https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#issue-and-pull-request-management) says I'm also eligible for membership of kubernetes-sigs org. 
> If you are a Kubernetes GitHub organization member, you are eligible for membership in the Kubernetes SIGs GitHub organization and can request membership by [opening an issue](https://github.com/kubernetes/org/issues/new?template=membership.md&title=REQUEST%3A%20New%20membership%20for%20%3Cyour-GH-handle%3E) against the kubernetes/org repo.