### PR TITLE
kubernetes-sigs: add ArangoGutierrez as nfd admin and maintainer

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -1148,11 +1148,13 @@ teams:
   node-feature-discovery-admins:
     description: Admin access to the node-feature-discovery repo
     members:
+    - ArangoGutierrez
     - marquiz
     privacy: closed
   node-feature-discovery-maintainers:
     description: Write access to the node-feature-discovery repo
     members:
+    - ArangoGutierrez
     - marquiz
     privacy: closed
   sig-storage-lib-external-provisioner-admins:


### PR DESCRIPTION
Add ArangoGutierrez into the admin and maintainers group of the kubernetes-sigs node-feature-discovery project. He was recently added as a project approver in kubernetes-sigs/node-feature-discovery#1180.