### PR TITLE
remove adtac and add sanposhiho to the simulator admin

### DIFF
--- a/config/kubernetes-sigs/sig-scheduling/teams.yaml
+++ b/config/kubernetes-sigs/sig-scheduling/teams.yaml
@@ -42,14 +42,8 @@ teams:
   kube-scheduler-simulator-admins:
     description: Admin access to the kube-scheduler-simulator
     members:
-    - adtac
     - alculquicondor
     - Huang-Wei
-    privacy: closed
-  kube-scheduler-simulator-maintainers:
-    description: Write access to the kube-scheduler-simulator
-    members:
-    - adtac
     - sanposhiho
     privacy: closed
   kueue-admins:


### PR DESCRIPTION
- remove @adtac 
- move @sanposhiho to the admin
- no one in maintainers then, so remove it.

ref: https://github.com/kubernetes-sigs/kube-scheduler-simulator/pull/297