### PR TITLE
Add eddycharly to kubernetes-sigs members

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -258,6 +258,7 @@ members:
 - Dyanngg
 - easeway
 - eddiezane
+- eddycharly
 - edreed
 - ehashman
 - EleanorRigby


### PR DESCRIPTION
@eddycharly is already in kubernetes, but not in kubernetes-sigs. Adding his handle here.