### PR TITLE
Add mboersma to image-builder-admins

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -301,25 +301,16 @@ teams:
   image-builder-admins:
     description: admin access to image-builder
     members:
-    - CecileRobertMichon
-    - codenrhoden
     - jsturtevant
-    - justinsb
     - kkeshavamurthy
-    - luxas
-    - timothysc
+    - mboersma
     privacy: closed
   image-builder-maintainers:
     description: write access to image-builder
     members:
-    - CecileRobertMichon
-    - codenrhoden
     - jsturtevant
-    - justinsb
     - kkeshavamurthy
-    - luxas
-    - moshloop
-    - timothysc
+    - mboersma
     privacy: closed
   kubespray-admins:
     description: Admin access to the kubespray repo


### PR DESCRIPTION
Syncs up the GH ownership with image-builder's [`OWNERS_ALIASES`](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES#L18)