### PR TITLE
sync NPAPI owners to org team members

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -151,7 +151,6 @@ teams:
   network-policy-api-admins:
     description: Admin access to the network-policy-api repo
     members:
-    - abhiraut
     - astoycos
-    - rikatz
+    - Dyanngg
     privacy: closed


### PR DESCRIPTION
Make sure the k8s org team members for the network-policy-api admins are up to date with the [repo's owners file](https://github.com/kubernetes-sigs/network-policy-api/blob/master/OWNERS).

Follow up to https://github.com/kubernetes-sigs/network-policy-api/pull/97