### PR TITLE
Add AverageMarcus to image-builder-admins

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -300,6 +300,7 @@ teams:
   image-builder-admins:
     description: admin access to image-builder
     members:
+    - AverageMarcus
     - jsturtevant
     - kkeshavamurthy
     - mboersma
@@ -307,6 +308,7 @@ teams:
   image-builder-maintainers:
     description: write access to image-builder
     members:
+    - AverageMarcus
     - jsturtevant
     - kkeshavamurthy
     - mboersma


### PR DESCRIPTION
Syncs up the GH ownership with image-builder's [`OWNERS_ALIASES`](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES#L18)