### PR TITLE
Updating SIG Cloud Provider leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,7 +27,9 @@ aliases:
     - soltysh
   sig-cloud-provider-leads:
     - andrewsykim
+    - bridgetkromhout
     - cheftako
+    - elmiko
     - nckturner
   sig-cluster-lifecycle-leads:
     - CecileRobertMichon


### PR DESCRIPTION
This PR updates this owners file to match https://github.com/kubernetes/community/blob/master/sig-cloud-provider/README.md#leadership (which was updated in April in https://github.com/kubernetes/community/pull/7251).

 /assign @mrbobbytables