### PR TITLE
Adding new SIG Cloud Provider leads

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -37,6 +37,7 @@ teams:
     - bradamant3 # Docs
     - bradmccoydev # 1.28 Comms Lead
     - brancz # Instrumentation
+    - bridgetkromhout # Cloud Provider
     - cantbewong # VMware
     - caseydavenport # Network
     - cheftako # Cloud Provider
@@ -54,6 +55,7 @@ teams:
     - dims # Architecture / Release
     - eddiezane # CLI
     - ehashman # Instrumentation
+    - elmiko # Cloud Provider
     - enj # Auth
     - fabriziopandini # Cluster Lifecycle
     - feiskyer # Azure


### PR DESCRIPTION
This PR updates this sig-release team file to match https://github.com/kubernetes/community/blob/master/sig-cloud-provider/README.md#leadership (which was updated in April in https://github.com/kubernetes/community/pull/7251).

 /assign @mrbobbytables