### PR TITLE
org repo: Replace lavalamp with jpbetz as TL of sig-apimachinery

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,7 +2,7 @@ aliases:
   sig-api-machinery-leads:
     - deads2k
     - fedebongio
-    - lavalamp
+    - jpbetz
   sig-apps-leads:
     - janetkuo
     - kow3ns


### PR DESCRIPTION
https://github.com/kubernetes/community/issues/7344#issuecomment-1578951806