### PR TITLE
Add chendave to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -154,6 +154,7 @@ members:
 - charleszheng44
 - chases2
 - cheftako
+- chendave
 - chendotjs
 - chengxiangdong
 - chetak123


### PR DESCRIPTION
chendave is already a member of kubernetes org, and is a reviewer of kubadm and scheduler.

Need to kubernetes-sig member to work with other sig projects (kubetest2, test-infra etc.)

