### PR TITLE
Update cluster-api-operator-admins

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -62,6 +62,8 @@ teams:
     description: "admin access to cluster-api-operator"
     members:
     - alexander-demicev
+    - damdo
+    - Fedosin
     - JoelSpeed
     privacy: closed
   cluster-api-provider-aws-admins:


### PR DESCRIPTION
Current list of cluster-api-operator admins is outdated. This PR syncs it with what we have in the repository itself:
https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/OWNERS_ALIASES#L17-L20

Fixes #4277