### PR TITLE
Rotate ameukam and add MadhavJivrajani as GitHub Admin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GITHUB_TOKEN_PATH ?=
 TEST_INFRA_PATH ?= $(OUTPUT_DIR)/tmp/test-infra
 
 # intentionally hardcoded list to ensure it's high friction to remove someone
-ADMINS = ameukam cblecker idvoretskyi mrbobbytables nikhita palnabarun
+ADMINS = cblecker idvoretskyi MadhavJivrajani mrbobbytables nikhita palnabarun
 ORGS = $(shell find ./config -type d -mindepth 1 -maxdepth 1 | cut -d/ -f3)
 
 # use absolute path to ./_output, which is .gitignored

--- a/OWNERS
+++ b/OWNERS
@@ -1,20 +1,21 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - ameukam
   - cblecker
   - idvoretskyi
+  - MadhavJivrajani
   - mrbobbytables
   - nikhita
   - palnabarun
 approvers:
-  - ameukam
   - cblecker
   - idvoretskyi
+  - MadhavJivrajani
   - mrbobbytables
   - nikhita
   - palnabarun
 emeritus_approvers:
+  - ameukam
   - calebamiles
   - fejta
   - spiffxp

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -10,9 +10,9 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-ameukam
 cblecker
 idvoretskyi
+MadhavJivrajani
 mrbobbytables
 nikhita
 palnabarun

--- a/admin/update.sh
+++ b/admin/update.sh
@@ -22,9 +22,9 @@ REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
 readonly REPO_ROOT
 
 readonly admins=(
-  ameukam
   cblecker
   idvoretskyi
+  MadhavJivrajani
   mrbobbytables
   nikhita
   palnabarun

--- a/config/kubernetes-client/OWNERS
+++ b/config/kubernetes-client/OWNERS
@@ -1,18 +1,19 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - ameukam
+  - MadhavJivrajani
   - palnabarun
   - savitharaghunathan
 approvers:
   - cblecker
   - idvoretskyi
+  - MadhavJivrajani
   - mrbobbytables
   - nikhita
-  - ameukam
   - palnabarun
   - savitharaghunathan
 emeritus_approvers:
+  - ameukam
   - calebamiles
   - fejta
   - spiffxp

--- a/config/kubernetes-client/org.yaml
+++ b/config/kubernetes-client/org.yaml
@@ -1,9 +1,9 @@
 admins:
-- ameukam
 - cblecker
 - idvoretskyi
 - k8s-ci-robot
 - k8s-github-robot
+- MadhavJivrajani
 - mrbobbytables
 - nikhita
 - palnabarun
@@ -16,6 +16,7 @@ has_repository_projects: true
 members:
 - akshaymankar
 - ambiknai
+- ameukam
 - arahamad
 - bgrant0607
 - brendandburns

--- a/config/kubernetes-csi/OWNERS
+++ b/config/kubernetes-csi/OWNERS
@@ -1,18 +1,19 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - ameukam
+  - MadhavJivrajani
   - palnabarun
   - savitharaghunathan
 approvers:
   - cblecker
   - idvoretskyi
+  - MadhavJivrajani
   - mrbobbytables
   - nikhita
-  - ameukam
   - palnabarun
   - savitharaghunathan
 emeritus_approvers:
+  - ameukam
   - calebamiles
   - fejta
   - spiffxp

--- a/config/kubernetes-csi/org.yaml
+++ b/config/kubernetes-csi/org.yaml
@@ -1,9 +1,9 @@
 admins:
-- ameukam
 - cblecker
 - idvoretskyi
 - k8s-ci-robot
 - k8s-github-robot
+- MadhavJivrajani
 - mrbobbytables
 - nikhita
 - palnabarun
@@ -16,6 +16,7 @@ has_repository_projects: true
 members:
 - 27149chen
 - alexander-ding
+- ameukam
 - amolmote
 - andrewsykim
 - andyzhangx

--- a/config/kubernetes-incubator/OWNERS
+++ b/config/kubernetes-incubator/OWNERS
@@ -3,11 +3,12 @@
 approvers:
   - cblecker
   - idvoretskyi
+  - MadhavJivrajani
   - mrbobbytables
   - nikhita
-  - ameukam
   - palnabarun
 emeritus_approvers:
+  - ameukam
   - calebamiles
   - fejta
   - spiffxp

--- a/config/kubernetes-incubator/org.yaml
+++ b/config/kubernetes-incubator/org.yaml
@@ -6,11 +6,11 @@ has_repository_projects: true
 members_can_create_repositories: false
 billing_email: github@kubernetes.io
 admins:
-- ameukam
 - cblecker
 - idvoretskyi
 - k8s-ci-robot
 - k8s-github-robot
+- MadhavJivrajani
 - mrbobbytables
 - nikhita
 - palnabarun

--- a/config/kubernetes-nightly/OWNERS
+++ b/config/kubernetes-nightly/OWNERS
@@ -1,14 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - ameukam
+  - MadhavJivrajani
   - palnabarun
   - savitharaghunathan
 approvers:
   - cblecker
   - idvoretskyi
+  - MadhavJivrajani
   - mrbobbytables
   - nikhita
-  - ameukam
   - palnabarun
   - savitharaghunathan

--- a/config/kubernetes-nightly/org.yaml
+++ b/config/kubernetes-nightly/org.yaml
@@ -6,7 +6,6 @@ has_repository_projects: true
 members_can_create_repositories: false
 billing_email: github@kubernetes.io
 admins:
-- ameukam
 - cblecker
 - cpanato
 - dims
@@ -15,6 +14,7 @@ admins:
 - justaugustus
 - k8s-ci-robot
 - k8s-github-robot
+- MadhavJivrajani
 - mrbobbytables
 - nikhita
 - palnabarun
@@ -23,6 +23,7 @@ admins:
 - sttts
 - thelinuxfoundation
 members:
+- ameukam
 - k8s-publishing-bot
 - savitharaghunathan
 - Verolop

--- a/config/kubernetes-retired/OWNERS
+++ b/config/kubernetes-retired/OWNERS
@@ -3,11 +3,12 @@
 approvers:
   - cblecker
   - idvoretskyi
+  - MadhavJivrajani
   - mrbobbytables
   - nikhita
-  - ameukam
   - palnabarun
 emeritus_approvers:
+  - ameukam
   - calebamiles
   - fejta
   - spiffxp

--- a/config/kubernetes-retired/org.yaml
+++ b/config/kubernetes-retired/org.yaml
@@ -6,11 +6,11 @@ has_repository_projects: true
 members_can_create_repositories: false
 billing_email: github@kubernetes.io
 admins:
-- ameukam
 - cblecker
 - idvoretskyi
 - k8s-ci-robot
 - k8s-github-robot
+- MadhavJivrajani
 - mrbobbytables
 - nikhita
 - palnabarun

--- a/config/kubernetes-sigs/OWNERS
+++ b/config/kubernetes-sigs/OWNERS
@@ -1,18 +1,19 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - ameukam
+  - MadhavJivrajani
   - palnabarun
   - savitharaghunathan
 approvers:
   - cblecker
   - idvoretskyi
+  - MadhavJivrajani
   - mrbobbytables
   - nikhita
-  - ameukam
   - palnabarun
   - savitharaghunathan
 emeritus_approvers:
+  - ameukam
   - calebamiles
   - fejta
   - spiffxp

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -1,9 +1,9 @@
 admins:
-- ameukam
 - cblecker
 - idvoretskyi
 - k8s-ci-robot
 - k8s-github-robot
+- MadhavJivrajani
 - mrbobbytables
 - nikhita
 - palnabarun
@@ -55,6 +55,7 @@ members:
 - alvaroaleman
 - amacaskill
 - ambiknai
+- ameukam
 - amolmote
 - Amulyam24
 - amwat
@@ -562,7 +563,6 @@ members:
 - macaptain
 - maciaszczykm
 - Madhan-SWE
-- MadhavJivrajani
 - Madhur97
 - maelvls
 - makkes

--- a/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
@@ -54,12 +54,12 @@ teams:
   maintainers-maintainers:
     description: write access to the maintainers repo
     maintainers:
+    - MadhavJivrajani
     - mrbobbytables
     - nikhita
     - palnabarun
     members:
     - dims
-    - MadhavJivrajani
     privacy: closed
   slack-infra-admins:
     description: admin access to slack-infra

--- a/config/kubernetes-sigs/sig-k8s-infra/teams.yaml
+++ b/config/kubernetes-sigs/sig-k8s-infra/teams.yaml
@@ -1,36 +1,32 @@
 teams:
   community-images-admins:
     description: admins access to community-images
-    maintainers:
-    - ameukam
     members:
+    - ameukam
     - dims
     - spiffxp
     - thockin
     privacy: closed
   community-images-writers:
     description: write access to community-images
-    maintainers:
-      - ameukam
     members:
+      - ameukam
       - dims
       - spiffxp
       - thockin
     privacy: closed
   community-images-maintainers:
     description: write access to community-images
-    maintainers:
-    - ameukam
     members:
+    - ameukam
     - dims
     - spiffxp
     - thockin
     privacy: closed
   porche-admins:
     description: admins access to porche
-    maintainers:
-    - ameukam
     members:
+    - ameukam
     - bentheelder
     - dims
     - justinsb
@@ -39,9 +35,8 @@ teams:
     privacy: closed
   porche-writers:
     description: write access to porche
-    maintainers:
-      - ameukam
     members:
+      - ameukam
       - bentheelder
       - dims
       - justinsb
@@ -50,9 +45,8 @@ teams:
     privacy: closed
   porche-maintainers:
     description: write access to porche
-    maintainers:
-    - ameukam
     members:
+    - ameukam
     - bentheelder
     - dims
     - justinsb

--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -88,9 +88,9 @@ teams:
     description: Members of the Release Engineering subproject, including
       Release Managers and Release Manager Associates.
     maintainers:
-    - ameukam # Release Manager Associate
     - palnabarun # Release Manager
     members:
+    - ameukam # Release Manager Associate
     - cpanato # subproject owner / Release Manager
     - jeremyrickard # subproject owner
     - jimangel # Release Manager Associate

--- a/config/kubernetes/OWNERS
+++ b/config/kubernetes/OWNERS
@@ -1,18 +1,19 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - ameukam
+  - MadhavJivrajani
   - palnabarun
   - savitharaghunathan
 approvers:
   - cblecker
   - idvoretskyi
+  - MadhavJivrajani
   - mrbobbytables
   - nikhita
-  - ameukam
   - palnabarun
   - savitharaghunathan
 emeritus_approvers:
+  - ameukam
   - calebamiles
   - fejta
   - spiffxp

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1,9 +1,9 @@
 admins:
-- ameukam
 - cblecker
 - idvoretskyi
 - k8s-ci-robot
 - k8s-github-robot
+- MadhavJivrajani
 - mrbobbytables
 - nikhita
 - palnabarun
@@ -77,6 +77,7 @@ members:
 - alvaroaleman
 - amacaskill
 - ambiknai
+- ameukam
 - amolmote
 - Amotul-raheem
 - ams0
@@ -902,7 +903,6 @@ members:
 - MaciekPytel
 - Madhan-SWE
 - madhanrm
-- MadhavJivrajani
 - makocchi-git
 - MAKOSCAFEE
 - mansikulkarni96

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -2107,9 +2107,9 @@ teams:
   owners:
     description: Kubernetes GitHub Owners
     maintainers:
-    - ameukam
     - cblecker
     - idvoretskyi
+    - MadhavJivrajani
     - mrbobbytables
     - nikhita
     - palnabarun

--- a/config/kubernetes/sig-api-machinery/teams.yaml
+++ b/config/kubernetes/sig-api-machinery/teams.yaml
@@ -36,6 +36,8 @@ teams:
     privacy: closed
   sig-api-machinery-members:
     description: Members of sig-api-machinery
+    maintainers:
+    - MadhavJivrajani
     members:
     - alexzielenski
     - andrewsykim
@@ -54,7 +56,6 @@ teams:
     - lavalamp
     - liggitt
     - logicalhan
-    - MadhavJivrajani
     - munnerz
     - seans3
     - smarterclayton
@@ -84,12 +85,13 @@ teams:
     privacy: closed
   sig-api-machinery-pr-reviews:
     description: ""
+    maintainers:
+    - MadhavJivrajani
     members:
     - deads2k
     - lavalamp
     - liggitt
     - logicalhan
-    - MadhavJivrajani
     - smarterclayton
     - sttts
     privacy: closed

--- a/config/kubernetes/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes/sig-contributor-experience/teams.yaml
@@ -4,23 +4,23 @@ teams:
     maintainers:
     - cblecker
     - idvoretskyi
+    - MadhavJivrajani
     - mrbobbytables
     - nikhita
     - palnabarun
     members:
     - kaslin
-    - MadhavJivrajani
     - Priyankasaggu11929
     privacy: closed
   community-maintainers:
     description: ""
     maintainers:
     - cblecker
+    - MadhavJivrajani
     - mrbobbytables
     - nikhita
     members:
     - kaslin
-    - MadhavJivrajani
     - Priyankasaggu11929
     privacy: closed
   community-milestone-maintainers:
@@ -28,6 +28,7 @@ teams:
     maintainers:
     - cblecker
     - idvoretskyi
+    - MadhavJivrajani
     - mrbobbytables
     - nikhita
     - palnabarun
@@ -43,7 +44,6 @@ teams:
     - justaugustus
     - kaslin
     - lukaszgryglicki
-    - MadhavJivrajani
     - parispittman
     - Phillels
     - Priyankasaggu11929
@@ -81,9 +81,9 @@ teams:
     description: Members who have access to edit the GitHub Administration
       Subproject Board
     maintainers:
-    - ameukam
     - cblecker
     - idvoretskyi
+    - MadhavJivrajani
     - mrbobbytables
     - nikhita
     - palnabarun
@@ -110,6 +110,7 @@ teams:
     maintainers:
     - cblecker
     - idvoretskyi
+    - MadhavJivrajani
     - mrbobbytables
     - nikhita
     - palnabarun
@@ -125,7 +126,6 @@ teams:
     - jessfraz
     - kaslin
     - lavalamp
-    - MadhavJivrajani
     - monopole
     - parispittman
     - philips
@@ -155,13 +155,13 @@ teams:
         description: Chairs and Technical Leads for SIG Contributor Experience
         maintainers:
         - cblecker
+        - MadhavJivrajani
         - mrbobbytables
         - nikhita
         - palnabarun
         members:
         - jberkus
         - kaslin
-        - MadhavJivrajani
         - Priyankasaggu11929
         privacy: closed
       sig-contributor-experience-pr-reviews:
@@ -170,12 +170,12 @@ teams:
         maintainers:
         - cblecker
         - idvoretskyi
+        - MadhavJivrajani
         - nikhita
         - palnabarun
         members:
         - idealhack
         - kaslin
-        - MadhavJivrajani
         - Priyankasaggu11929
         privacy: closed
   youtube-admins:

--- a/config/kubernetes/sig-k8s-infra/teams.yaml
+++ b/config/kubernetes/sig-k8s-infra/teams.yaml
@@ -1,9 +1,8 @@
 teams:
   k8s.io-admins:
     description: Admin access to kubernetes/k8s.io
-    maintainers:
-    - ameukam
     members:
+    - ameukam
     - dims
     - k8s-infra-ci-robot
     - spiffxp
@@ -12,11 +11,11 @@ teams:
   sig-k8s-infra:
     description: sig-k8s-infra members
     maintainers:
-    - ameukam
     - cblecker
     - idvoretskyi
     - nikhita
     members:
+    - ameukam
     - BenTheElder
     - BobyMCbobs
     - chewong
@@ -37,9 +36,8 @@ teams:
     teams:
       sig-k8s-infra-leads:
         description: sig-k8s-infra chairs and technical leads
-        maintainers:
-        - ameukam
         members:
+        - ameukam
         - dims
         - spiffxp
         - thockin
@@ -68,9 +66,8 @@ teams:
         privacy: closed
       k8s-infra-gcp-org-admins:
         description: granted owner access to the k8s-infra GCP org
-        maintainers:
-        - ameukam
         members:
+        - ameukam
         - dims
         - spiffxp
         - thockin
@@ -86,9 +83,8 @@ teams:
         privacy: closed
       registry.k8s.io-admins:
         description: Admin access to kubernetes/registry.k8s.io
-        maintainers:
-        - ameukam
         members:
+        - ameukam
         - bentheelder
         - dims
         - spiffxp
@@ -96,9 +92,8 @@ teams:
         privacy: closed
       registry.k8s.io-maintainers:
         description: Write access to kubernetes/registry.k8s.io
-        maintainers:
-        - ameukam
         members:
+        - ameukam
         - bentheelder
         - dims
         - spiffxp

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -17,7 +17,6 @@ teams:
     description: Contributors who can use `/milestone` or `/status` commands on
       issues/PRs and have triage access to the kubernetes/enhancements repo
     maintainers:
-    - ameukam # Release Manager Associate
     - cblecker # ContribEx
     - mrbobbytables # ContribEx
     - nikhita # ContribEx
@@ -27,6 +26,7 @@ teams:
     - adisky # OpenStack
     - ahg-g # Scheduling
     - alejandrox1 # Testing
+    - ameukam # Release Manager Associate
     - andrewsykim # Cloud Provider
     - aojea # Testing / Network
     - aramase # 1.28 Enhancements Shadow
@@ -250,9 +250,9 @@ teams:
         description: Members of the Release Engineering subproject, including
           Release Managers, Release Manager Associates, and Build Admins.
         maintainers:
-        - ameukam # Release Manager Associate
         - palnabarun # Release Manager
         members:
+        - ameukam # Release Manager Associate
         - cici37 # Release Manager
         - cpanato # subproject owner / Release Manager
         - gracenng # Release Manager Associate

--- a/config/kubernetes/wg-structured-logging/teams.yaml
+++ b/config/kubernetes/wg-structured-logging/teams.yaml
@@ -8,7 +8,6 @@ teams:
   wg-structured-logging-members:
     description: ""
     members:
-      - MadhavJivrajani
       - mengjiao-liu
       - navidshaikh
       - pohly


### PR DESCRIPTION
Ref https://github.com/kubernetes/community/pull/7327

#### Commit 1

Change root OWNERS and ADMIN variables in scripts

#### Commit 2

Remove self from wg-structured-logging-members, no longer active, didn't want to elevate to `maintainer` role in the teams here.

#### Commit 3

config: GH admin rotation - update team configs

Move ameukam to members wherever applicable.

Add MadhavJivrajani as maintainer anew or move
from member to maintainer wherever necessary.

#### Commit 4

config: GH Admin rotation - update org OWNERS and configs

Add MadhavJivrajani as admin in all orgs and move ameukam
to member wherever applicable.

Add MadhavJivrajani as reviewer and approver in OWNERS of
all orgs and move ameukam to emeritus.

/cc @kubernetes/owners 
/assign @nikhita 