### PR TITLE
add schrej to kubernetes org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1338,6 +1338,7 @@ members:
 - sbezverk
 - sbs2001
 - sbueringer
+- schrej
 - ScorpioCPH
 - scottrigby
 - ScrapCodes


### PR DESCRIPTION
Adds myself to the kubernetes org so I can have ownership in k/k8s.io (https://github.com/kubernetes/k8s.io/pull/5477).

Direct PR since I'm already a member of kubernetes-sigs (#3160).