### PR TITLE
Housekeeping SIG Docs OWNERS_Aliases and teams.yaml

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -48,7 +48,6 @@ aliases:
     - palnabarun
   sig-docs-leads:
     - divya-mohan0209
-    - jimangel
     - kbhawkey
     - natalisucks
     - onlydole

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -28,7 +28,6 @@ teams:
     - annajung
     - bradtopol
     - divya-mohan0209
-    - jimangel
     - kbhawkey
     - mickeyboxell
     - natalisucks
@@ -43,7 +42,6 @@ teams:
     members:
     - bradtopol
     - divya-mohan0209
-    - jimangel
     - kbhawkey
     - mehabhalodiya
     - mengjiao-liu
@@ -75,7 +73,6 @@ teams:
     members:
     - awkif
     - feloy
-    - oussemos
     - perriea
     - rekcah78
     - remyleone
@@ -85,7 +82,6 @@ teams:
     members:
     - awkif
     - feloy
-    - oussemos
     - perriea
     - rekcah78
     - remyleone
@@ -103,8 +99,6 @@ teams:
     - Babapool
     - bishal7679
     - divya-mohan0209
-    - Garima-Negi
-    - verma-kunal
     privacy: closed
   sig-docs-id-owners:
     description: Approvers for Indonesian content
@@ -128,7 +122,6 @@ teams:
     - fabriziopandini
     - Fale
     - mattiaperi
-    - micheleberardi
     privacy: closed
   sig-docs-it-reviews:
     description: PR reviews for Italian content
@@ -136,7 +129,6 @@ teams:
     - fabriziopandini
     - Fale
     - mattiaperi
-    - micheleberardi
     privacy: closed
   sig-docs-ja-owners:
     description: Approvers for Japanese content
@@ -180,7 +172,6 @@ teams:
     description: Chairs and tech leads for SIG Docs
     members:
     - divya-mohan0209
-    - jimangel
     - kbhawkey
     - natalisucks
     - onlydole
@@ -217,15 +208,12 @@ teams:
     description: PR reviews for docs-related issues
     members:
     - bradtopol
-    - cody-clark
+    - divya-mohan0209
     - gochist
-    - jimangel
     - kbhawkey
-    - Rajakavitha1
-    - stewart-yu
+    - natalisucks
+    - reylejano
     - tengqm
-    - tfogo
-    - zparnold
     privacy: closed
   sig-docs-pt-owners:
     description: Approvers for Portuguese content
@@ -235,7 +223,6 @@ teams:
     - femrtnz
     - jcjesus
     - jhonmike
-    - rikatz
     - stormqueen1990
     - yagonobre
     privacy: closed
@@ -247,7 +234,6 @@ teams:
     - femrtnz
     - jcjesus
     - jhonmike
-    - rikatz
     - stormqueen1990
     - yagonobre
     privacy: closed
@@ -282,7 +268,6 @@ teams:
     - windsonsea
     - xichengliudui
     - ydFu
-    - Zhuzhenghao
     privacy: closed
   sig-docs-vi-owners:
     description: Admins for Vietnamese content
@@ -317,7 +302,6 @@ teams:
     - kubernetes-website-admins
     members:
     - divya-mohan0209
-    - jimangel
     - natalisucks
     - reylejano
     privacy: closed
@@ -336,10 +320,8 @@ teams:
     - inductor # L10n: Japanese
     - jcjesus # L10n: Portuguese
     - jhonmike # L10n: Portuguese
-    - jimangel # L10n: English
     - mfilocha # L10n: Polish
     - mickeyboxell # 1.27 RT Docs lead
-    - mittalyashu # L10n: Hindi
     - nasa9084 # L10n: Japanese
     - natalisucks # L10n: English
     - nate-double-u # L10n: English
@@ -349,7 +331,6 @@ teams:
     - raelga # L10n: Spanish
     - remyleone # L10n: French
     - reylejano # L10n: English
-    - rikatz # L10n: Portuguese
     - rlenferink # L10n: German
     - SataQiu # L10n: Chinese
     - seokho-son # L10n: Korean
@@ -368,7 +349,6 @@ teams:
     - awkif
     - bene2k1
     - bradtopol
-    - celestehorgan
     - divya-mohan0209
     - femrtnz
     - girikuncoro
@@ -376,27 +356,22 @@ teams:
     - huynguyennovem
     - inductor
     - jcjesus
-    - jimangel
     - katmutua # 1.27 RT Docs Shadow
-    - krol3 
     - LukeMwila # 1.27 RT Docs Shadow
     - mickeyboxell # 1.27 RT Docs lead
     - nasa9084
     - natalisucks
     - nate-double-u
     - onlydole
-    - oussemos
     - perriea
     - potapy4
     - raelga
-    - Rajakavitha1
     - rekcah78
     - remyleone
     - reylejano
     - Rishit-dagli # 1.27 RT Docs Shadow
     - rlenferink
     - SataQiu
-    - savitharaghunathan
     - seokho-son
     - sftim
     - shurup
@@ -407,5 +382,4 @@ teams:
     - truongnh1992
     - xichengliudui
     - ysyukr
-    - zparnold
     privacy: closed


### PR DESCRIPTION
Multiple reviewers & approvers housekept per below PRs/issues:

@jimangel moved to emeritus per [this PR](https://github.com/kubernetes/website/pull/38864). 
=> Removed from OWNERS_Aliases
=> Per confirmation from Jim, we have also untagged him as an approver/reviewer for English content.

@rikatz stepped down from pt-approvers/reviewers per [this PR](https://github.com/kubernetes/website/pull/40814)
=> Removed from sig-docs-pt-owners & sig-docs-pt-reviews

@Garima-Negi & @verma-kunal being housekept from sig-docs-hi-reviews per [this issue](https://github.com/kubernetes/website/issues/41598)

@mittalyashu being housekept from website-maintainers, since he is no longer a Hindi Localization maintainer

@savitharaghunathan being housekept from website-milestone-maintainers since she is no longer an approver/reviewer. 

@celestehorgan has moved to emeritus and hence has been housekept from website-milestone-maintainers.

@oussemos housekept from sig-docs-fr-owners & reviews per [this PR](https://github.com/kubernetes/website/pull/38719).

@micheleberardi, @cody-clark , @Rajakavitha1 , @stewart-yu , @zparnold , @tfogo are no longer active Kubernetes SIG Docs contributors.

If you feel the deletion is an error, please let us know so that we can fix it immediately. These changes have been made comparing the existing set of reviewers & approvers in OWNERS_ALIASES under k/website.