### PR TITLE
Offboard Luke Hinds from SRC

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -165,7 +165,6 @@ aliases:
     - cji
     - enj
     - joelsmith
-    - lukehinds
     - micahhausler
     - ritazh
     - tabbysable

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -2151,7 +2151,6 @@ teams:
     - cji
     - enj
     - joelsmith
-    - lukehinds
     - micahhausler
     - ritazh
     - SaranBalaji90


### PR DESCRIPTION
Luke has stepped down from the SRC (https://github.com/kubernetes/committee-security-response/issues/182) and this PR is part of our offboarding process. 