### PR TITLE
Add self to kubernetes-csi org

### DIFF
--- a/config/kubernetes-csi/org.yaml
+++ b/config/kubernetes-csi/org.yaml
@@ -32,6 +32,7 @@ members:
 - chrishenzie
 - codenrhoden
 - cofyc
+- ConnorJC3
 - coulof
 - cwdsuzhou
 - davidz627


### PR DESCRIPTION
Adds myself to the kubernetes-csi org, as there is a project being used for SIG Storage work that is restricted to org members.

I am already a member of the kubernetes and kubernetes-sigs GitHub orgs.