### PR TITLE
SIG Autoscaling Github Groups Cleanup

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1721,7 +1721,7 @@ teams:
     repos:
       autoscaler: admin
   autoscaler-maintainers:
-    description: ""
+    description: "Maintainers of sub-projects in the autoscaler repo"
     members:
     - bigdarkclown
     - gjtempleton
@@ -1733,7 +1733,7 @@ teams:
     repos:
       autoscaler: write
   autoscaler-reviewers:
-    description: ""
+    description: "Reviewers of PRs in the autoscaler repo"
     members:
     - bigdarkclown
     - feiskyer

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1708,42 +1708,6 @@ teams:
     privacy: closed
     repos:
       api: read
-  autoscaler-admins:
-    description: Admin access to the autoscaler repo
-    members:
-    - bigdarkclown
-    - gjtempleton
-    - MaciekPytel
-    - mwielgus
-    - towca
-    - x13n
-    privacy: closed
-    repos:
-      autoscaler: admin
-  autoscaler-maintainers:
-    description: "Maintainers of sub-projects in the autoscaler repo"
-    members:
-    - bigdarkclown
-    - gjtempleton
-    - MaciekPytel
-    - mwielgus
-    - towca
-    - x13n
-    privacy: closed
-    repos:
-      autoscaler: write
-  autoscaler-reviewers:
-    description: "Reviewers of PRs in the autoscaler repo"
-    members:
-    - bigdarkclown
-    - feiskyer
-    - gjtempleton
-    - MaciekPytel
-    - mwielgus
-    - x13n
-    privacy: closed
-    repos:
-      autoscaler: read
   bash-firefighters:
     description: Folks with expertise in bash reviews
     maintainers:

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1711,6 +1711,7 @@ teams:
   autoscaler-admins:
     description: Admin access to the autoscaler repo
     members:
+    - bigdarkclown
     - gjtempleton
     - MaciekPytel
     - mwielgus
@@ -1721,6 +1722,7 @@ teams:
   autoscaler-maintainers:
     description: ""
     members:
+    - bigdarkclown
     - gjtempleton
     - MaciekPytel
     - mwielgus
@@ -1731,6 +1733,7 @@ teams:
   autoscaler-reviewers:
     description: ""
     members:
+    - bigdarkclown
     - feiskyer
     - gjtempleton
     - MaciekPytel

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1719,26 +1719,17 @@ teams:
   autoscaler-maintainers:
     description: ""
     members:
-    - aleksandra-malinowska
-    - bskiba
-    - DirectXMan12
-    - losipiuk
     - MaciekPytel
     - mwielgus
-    - piosz
     privacy: closed
     repos:
       autoscaler: write
   autoscaler-reviewers:
     description: ""
     members:
-    - aleksandra-malinowska
-    - bskiba
-    - DirectXMan12
     - feiskyer
     - MaciekPytel
     - mwielgus
-    - piosz
     privacy: closed
     repos:
       autoscaler: read

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1716,6 +1716,7 @@ teams:
     - MaciekPytel
     - mwielgus
     - towca
+    - x13n
     privacy: closed
     repos:
       autoscaler: admin
@@ -1727,6 +1728,7 @@ teams:
     - MaciekPytel
     - mwielgus
     - towca
+    - x13n
     privacy: closed
     repos:
       autoscaler: write
@@ -1738,7 +1740,7 @@ teams:
     - gjtempleton
     - MaciekPytel
     - mwielgus
-    - towca
+    - x13n
     privacy: closed
     repos:
       autoscaler: read

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1711,6 +1711,7 @@ teams:
   autoscaler-admins:
     description: Admin access to the autoscaler repo
     members:
+    - gjtempleton
     - MaciekPytel
     - mwielgus
     privacy: closed
@@ -1719,6 +1720,7 @@ teams:
   autoscaler-maintainers:
     description: ""
     members:
+    - gjtempleton
     - MaciekPytel
     - mwielgus
     privacy: closed
@@ -1728,6 +1730,7 @@ teams:
     description: ""
     members:
     - feiskyer
+    - gjtempleton
     - MaciekPytel
     - mwielgus
     privacy: closed

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1714,6 +1714,7 @@ teams:
     - gjtempleton
     - MaciekPytel
     - mwielgus
+    - towca
     privacy: closed
     repos:
       autoscaler: admin
@@ -1723,6 +1724,7 @@ teams:
     - gjtempleton
     - MaciekPytel
     - mwielgus
+    - towca
     privacy: closed
     repos:
       autoscaler: write
@@ -1733,6 +1735,7 @@ teams:
     - gjtempleton
     - MaciekPytel
     - mwielgus
+    - towca
     privacy: closed
     repos:
       autoscaler: read

--- a/config/kubernetes/sig-autoscaling/teams.yaml
+++ b/config/kubernetes/sig-autoscaling/teams.yaml
@@ -26,6 +26,7 @@ teams:
     - gjtempleton
     - MaciekPytel
     - mwielgus
+    - towca
     privacy: closed
   sig-autoscaling-pr-reviews:
     description: ""

--- a/config/kubernetes/sig-autoscaling/teams.yaml
+++ b/config/kubernetes/sig-autoscaling/teams.yaml
@@ -2,70 +2,42 @@ teams:
   sig-autoscaling-api-reviews:
     description: ""
     members:
-    - aleksandra-malinowska
-    - bskiba
-    - davidopp
-    - DirectXMan12
     - MaciekPytel
     - mwielgus
     privacy: closed
   sig-autoscaling-bugs:
     description: ""
     members:
-    - aleksandra-malinowska
-    - bskiba
-    - davidopp
-    - DirectXMan12
     - MaciekPytel
     - mwielgus
     privacy: closed
   sig-autoscaling-feature-requests:
     description: ""
     members:
-    - aleksandra-malinowska
-    - bskiba
-    - davidopp
-    - DirectXMan12
     - MaciekPytel
     - mwielgus
     privacy: closed
   sig-autoscaling-misc:
     description: ""
     members:
-    - aleksandra-malinowska
-    - bskiba
-    - davidopp
-    - DirectXMan12
     - MaciekPytel
     - mwielgus
     privacy: closed
   sig-autoscaling-pr-reviews:
     description: ""
     members:
-    - aleksandra-malinowska
-    - bskiba
-    - davidopp
-    - DirectXMan12
     - MaciekPytel
     - mwielgus
     privacy: closed
   sig-autoscaling-proposals:
     description: ""
     members:
-    - aleksandra-malinowska
-    - bskiba
-    - davidopp
-    - DirectXMan12
     - MaciekPytel
     - mwielgus
     privacy: closed
   sig-autoscaling-test-failures:
     description: ""
     members:
-    - aleksandra-malinowska
-    - bskiba
-    - davidopp
-    - DirectXMan12
     - MaciekPytel
     - mwielgus
     privacy: closed

--- a/config/kubernetes/sig-autoscaling/teams.yaml
+++ b/config/kubernetes/sig-autoscaling/teams.yaml
@@ -23,6 +23,7 @@ teams:
   sig-autoscaling-misc:
     description: ""
     members:
+    - bigdarkclown
     - gjtempleton
     - MaciekPytel
     - mwielgus

--- a/config/kubernetes/sig-autoscaling/teams.yaml
+++ b/config/kubernetes/sig-autoscaling/teams.yaml
@@ -1,4 +1,40 @@
 teams:
+  autoscaler-admins:
+    description: Admin access to the autoscaler repo
+    members:
+    - bigdarkclown
+    - gjtempleton
+    - MaciekPytel
+    - mwielgus
+    - towca
+    - x13n
+    privacy: closed
+    repos:
+      autoscaler: admin
+  autoscaler-maintainers:
+    description: "Maintainers of sub-projects in the autoscaler repo"
+    members:
+    - bigdarkclown
+    - gjtempleton
+    - MaciekPytel
+    - mwielgus
+    - towca
+    - x13n
+    privacy: closed
+    repos:
+      autoscaler: write
+  autoscaler-reviewers:
+    description: "Reviewers of PRs in the autoscaler repo"
+    members:
+    - bigdarkclown
+    - feiskyer
+    - gjtempleton
+    - MaciekPytel
+    - mwielgus
+    - x13n
+    privacy: closed
+    repos:
+      autoscaler: read
   sig-autoscaling-api-reviews:
     description: ""
     members:

--- a/config/kubernetes/sig-autoscaling/teams.yaml
+++ b/config/kubernetes/sig-autoscaling/teams.yaml
@@ -28,6 +28,7 @@ teams:
     - MaciekPytel
     - mwielgus
     - towca
+    - x13n
     privacy: closed
   sig-autoscaling-pr-reviews:
     description: ""

--- a/config/kubernetes/sig-autoscaling/teams.yaml
+++ b/config/kubernetes/sig-autoscaling/teams.yaml
@@ -2,42 +2,49 @@ teams:
   sig-autoscaling-api-reviews:
     description: ""
     members:
+    - gjtempleton
     - MaciekPytel
     - mwielgus
     privacy: closed
   sig-autoscaling-bugs:
     description: ""
     members:
+    - gjtempleton
     - MaciekPytel
     - mwielgus
     privacy: closed
   sig-autoscaling-feature-requests:
     description: ""
     members:
+    - gjtempleton
     - MaciekPytel
     - mwielgus
     privacy: closed
   sig-autoscaling-misc:
     description: ""
     members:
+    - gjtempleton
     - MaciekPytel
     - mwielgus
     privacy: closed
   sig-autoscaling-pr-reviews:
     description: ""
     members:
+    - gjtempleton
     - MaciekPytel
     - mwielgus
     privacy: closed
   sig-autoscaling-proposals:
     description: ""
     members:
+    - gjtempleton
     - MaciekPytel
     - mwielgus
     privacy: closed
   sig-autoscaling-test-failures:
     description: ""
     members:
+    - gjtempleton
     - MaciekPytel
     - mwielgus
     privacy: closed

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -5,7 +5,6 @@ restrictions:
     - "^apiextensions-apiserver"
     - "^apimachinery"
     - "^apiserver"
-    - "^autoscaler"
     - "^cli-runtime"
     - "^client-go"
     - "^cloud-provider"
@@ -60,6 +59,9 @@ restrictions:
   - path: "kubernetes/sig-architecture/teams.yaml"
     allowedRepos:
     - "^enhancements"
+  - path: "kubernetes/sig-autoscaling/teams.yaml"
+    allowedRepos:
+    - "^autoscaler"
   - path: "kubernetes/sig-cli/teams.yaml"
     allowedRepos:
     - "^kubectl"


### PR DESCRIPTION
- Removing a number of inactive members ( @aleksandra-malinowska, @bskiba, @davidopp, @DirectXMan12, @losipiuk, and @piosz) from SIG Autoscaling related GH groups
- Adding in new members - myself to all SIG related groups for now, @towca, @BigDarkClown, and @x13n to SIG Autoscaling sub-project release related groups
- Moved autoscaling-* related groups and restrictions from the root org.yaml into SIG owned org.yaml