### PR TITLE
Refresh of Cluster API Provider vSphere team members

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -259,21 +259,23 @@ teams:
   cluster-api-provider-vsphere-admins:
     description: Admin access to the cluster-api-provider-vsphere repo
     members:
-    - akutz
-    - frapposelli
+    - chrischdi
+    - gab-satchi
+    - killianmuldoon
+    - randomvariable
+    - sbueringer
     - srm09
     - yastij
     privacy: closed
   cluster-api-provider-vsphere-maintainers:
     description: Write access to the cluster-api-provider-vsphere repo
     members:
-    - akutz
-    - figo
-    - frapposelli
+    - chrischdi
+    - gab-satchi
+    - killianmuldoon
     - randomvariable
-    - sidharthsurana
+    - sbueringer
     - srm09
-    - vincepri
     - yastij
     privacy: closed
   cluster-api-release-team:


### PR DESCRIPTION
Update of CAPV team members as was discussed in 2023/06/22 meeting.

Related to https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2082/files