### PR TITLE
CAPI: Update list with v1.6 CAPI Release Team Members GitHub handles

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -341,20 +341,23 @@ teams:
   cluster-api-release-team:
     description: Release team of Cluster API
     members:
-    - aniruddha2000
-    - CecileRobertMichon
+    # members added in commented lines have a pending membership
+    # and will be added back once it is acquired.
+    # - adilGhaffarDev
+    - cahillsf
     - chiukapoor
-    - chrischdi
     - furkatgofurov7
     - g-gaston
     - hackeramitkumar
-    - joekr
-    - johannesfrey
-    - killianmuldoon
+    # - kranurag7
+    # - mjlshen
     - nawazkh
+    - nprokopic
     - Prajyot-Parab
-    - sbueringer
-    - tobiasgiese
+    # - razashahid107
+    # - Sunnatillo
+    - vincepri
+    - willie-yao
     privacy: closed
   etcdadm-admins:
     description: Admin access to the etcdadm repo


### PR DESCRIPTION
New CAPI v1.6 RT members announced here: https://kubernetes.slack.com/archives/C8TSNPY4T/p1690324526230509

This PR:
- removes old and adds new v1.6 RT members from/to the list in alphabetical order