### PR TITLE
update "$(MERGED_CONFIG)" target to begin with a clean output dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ $(MERGE_CMD):
 	mkdir -p "$(OUTPUT_BIN_DIR)"
 	go build -v -o "$(OUTPUT_BIN_DIR)" ./cmd/merge
 
-$(MERGED_CONFIG): $(MERGE_CMD) $(CONFIG_FILES)
+$(MERGED_CONFIG): clean $(MERGE_CMD) $(CONFIG_FILES)
 	mkdir -p "$(OUTPUT_DIR)"
 	$(MERGE_CMD) \
 		--merge-teams \
@@ -85,6 +85,6 @@ $(TEST_INFRA_PATH):
 	mkdir -p $(TEST_INFRA_PATH)
 	git clone --depth=1 https://github.com/kubernetes/test-infra $(TEST_INFRA_PATH)
 
-$(PERIBOLOS_CMD): clean $(TEST_INFRA_PATH)
+$(PERIBOLOS_CMD): $(TEST_INFRA_PATH)
 	cd $(TEST_INFRA_PATH) && \
 		go build -v -o $(PERIBOLOS_CMD) ./prow/cmd/peribolos


### PR DESCRIPTION
The PR:

- reverts the prior changes from https://github.com/kubernetes/org/pull/4356
-  updates the `$(MERGED_CONFIG)` target in the Makefile to include a `clean` step

This ensures the [post-org-peribolos](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-org-peribolos/1686252591400357888) postsubmit job starts with a fresh output directory, avoiding any stale repo clones (for ex - of `k/test-infra`) with outdated data.