### PR TITLE
admin: tell peribolos to reconcile team repo permissions

### DIFF
--- a/admin/update.sh
+++ b/admin/update.sh
@@ -39,6 +39,7 @@ args=(
   --fix-org-members
   --fix-teams
   --fix-team-members
+  --fix-team-repos
   "${admins[@]/#/--required-admins=}"
 )
 


### PR DESCRIPTION
We now have the ability to manage team repo permissions with a restrictions model using peribolos as part of https://github.com/kubernetes/org/pull/2614

But from the logs of the latest peribolos run:
```
{"component":"unset","file":"/home/prow/go/src/github.com/kubernetes/org/_output/tmp/test-infra/prow/cmd/peribolos/main.go:850","func":"main.configureOrg","level":"info","msg":"Skipping team repo permissions configuration","severity":"info","time":"2023-08-01T09:44:21Z"}
```

This is because the flag that actually tells peribolos to reconcile team repo permissions ([`--fix-team-repos`](https://github.com/kubernetes/test-infra/blob/955da602bebe2ee209e80e9d38b2fb89192a42c0/prow/cmd/peribolos/main.go#L93)) was not set.

This commit rectifies that.

/assign @nikhita @Priyankasaggu11929 
/hold
/sig contributor-experience