### PR TITLE
fix repo name - s/lkwd/lwkd/g

### DIFF
--- a/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
@@ -47,7 +47,7 @@ teams:
     - jberkus
     privacy: closed
     repos:
-      lkwd: admin
+      lwkd: admin
   lwkd-maintainers:
     description: write access to the lwkd repo
     members:
@@ -55,7 +55,7 @@ teams:
     - jberkus
     privacy: closed
     repos:
-      lkwd: write
+      lwkd: write
   maintainers-admins:
     description: admin access to the maintainers repo
     maintainers:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -201,7 +201,7 @@ restrictions:
     allowedRepos:
     - "^contributor-tweets"
     - "^discuss-theme"
-    - "^lkwd"
+    - "^lwkd"
     - "^maintainers"
     - "^slack-infra"
   - path: "kubernetes-sigs/sig-docs/teams.yaml"


### PR DESCRIPTION
The PR fixes the typo in the repo name (`lkwd` -> `lwkd`).

Also a fix for the following error in the failing `post-org-peribolos` job: 
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-org-peribolos/1686345196503044096 

```
{"component":"unset","file":"/home/prow/go/src/github.com/kubernetes/org/_output/tmp/test-infra/prow/cmd/peribolos/main.go:194","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure kubernetes-sigs team lwkd-admins repos: failed to update team 4981835(lwkd-admins) permissions on repo lkwd to admin: status code 404 not one of [204], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/teams/teams#add-or-update-team-repository-permissions\"}","severity":"fatal","time":"2023-08-01T12:19:04Z"}
```

