### PR TITLE
sync CAPZ maintainer team members with OWNERS

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -104,24 +104,22 @@ teams:
   cluster-api-provider-azure-admins:
     description: ""
     members:
-    - alexeldeib
     - CecileRobertMichon
-    - devigned
     - jackfrancis
     - mboersma
-    - shysank
+    - nojnhuh
+    - sonasingh46
     privacy: closed
     repos:
       cluster-api-provider-azure: admin
   cluster-api-provider-azure-maintainers:
     description: ""
     members:
-    - alexeldeib
     - CecileRobertMichon
-    - devigned
     - jackfrancis
     - mboersma
-    - shysank
+    - nojnhuh
+    - sonasingh46
     privacy: closed
     repos:
       cluster-api-provider-azure: write


### PR DESCRIPTION
Syncing with recent changes made to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

cc: @sonasingh46 