### PR TITLE
revert sig-cluster-lifecycle team changes from commit eda8125

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -315,9 +315,7 @@ teams:
   cluster-api-provider-vsphere-admins:
     description: Admin access to the cluster-api-provider-vsphere repo
     members:
-    - akutz
     - chrischdi
-    - frapposelli
     - gab-satchi
     - killianmuldoon
     - randomvariable
@@ -330,17 +328,12 @@ teams:
   cluster-api-provider-vsphere-maintainers:
     description: Write access to the cluster-api-provider-vsphere repo
     members:
-    - akutz
     - chrischdi
-    - figo
-    - frapposelli
     - gab-satchi
     - killianmuldoon
     - randomvariable
     - sbueringer
-    - sidharthsurana
     - srm09
-    - vincepri
     - yastij
     privacy: closed
     repos:


### PR DESCRIPTION
Reverts `sig-cluster-lifecycle` team changes from the commit - https://github.com/kubernetes/org/commit/eda81258d445e6d8d3968623970a96dcafe52079

Part of https://github.com/kubernetes/org/pull/4363

/sig contributor-experience
/assign @MadhavJivrajani 