### PR TITLE
Peribolos: update repo permissions for GH teams

### DIFF
--- a/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
@@ -75,6 +75,8 @@ teams:
     members:
     - dims
     privacy: closed
+    repos:
+      maintainers: write
   sigs-github-actions-admins:
     description: admin access to the sigs-github-actions repo
     maintainers:
@@ -85,6 +87,8 @@ teams:
     - nikhita
     - palnabarun
     privacy: closed
+    repos:
+      sigs-github-actions: admin
   sigs-github-actions-maintainers:
     description: write access to the sigs-github-actions repo
     maintainers:
@@ -95,7 +99,7 @@ teams:
     - Priyankasaggu11929
     privacy: closed
     repos:
-      maintainers: write
+      sigs-github-actions: write
   slack-infra-admins:
     description: admin access to slack-infra
     members:

--- a/config/kubernetes-sigs/sig-scheduling/teams.yaml
+++ b/config/kubernetes-sigs/sig-scheduling/teams.yaml
@@ -57,6 +57,8 @@ teams:
     - kerthcet
     - sanposhiho
     privacy: closed
+    repos:
+      kube-scheduler-wasm-extension: admin
   kueue-admins:
     description: Admin access to the kueue repo
     members:

--- a/config/kubernetes-sigs/sig-windows/teams.yaml
+++ b/config/kubernetes-sigs/sig-windows/teams.yaml
@@ -46,6 +46,7 @@ teams:
   sig-windows-dev-tools-admins:
     description: Admin access to sig-windows-dev-tools repo
     members:
+    - aroradaman
     - claudiubelu
     - dougsland
     - jayunit100

--- a/config/kubernetes-sigs/sig-windows/teams.yaml
+++ b/config/kubernetes-sigs/sig-windows/teams.yaml
@@ -55,6 +55,7 @@ teams:
     privacy: closed
     repos:
       sig-windows-dev-tools: admin
+      windows-service-proxy: admin
   sig-windows-tools-admins:
     description: Admin access to sig-windows-tools repo
     members:

--- a/config/kubernetes/sig-api-machinery/teams.yaml
+++ b/config/kubernetes/sig-api-machinery/teams.yaml
@@ -5,12 +5,16 @@ teams:
     - cici37
     - jpbetz
     privacy: closed
+    repos:
+      cel-admission-webhook: admin
   cel-admission-webhook-maintainers:
     description: write access to cel-admission-webhook
     members:
     - cici37
     - jpbetz
     privacy: closed
+    repos:
+      cel-admission-webhook: write
   sig-api-machinery-api-reviews:
     description: ""
     members:

--- a/config/kubernetes/sig-architecture/teams.yaml
+++ b/config/kubernetes/sig-architecture/teams.yaml
@@ -17,6 +17,8 @@ teams:
         - dims
         - johnbelamaric
         privacy: closed
+        repos:
+          design-proposals-archive: admin
       sig-architecture-pr-reviews:
         description: SIG Architecture PR review notifications
         members:

--- a/config/kubernetes/sig-k8s-infra/teams.yaml
+++ b/config/kubernetes/sig-k8s-infra/teams.yaml
@@ -93,6 +93,8 @@ teams:
         - spiffxp
         - thockin
         privacy: closed
+        repos:
+          registry.k8s.io: admin
       registry.k8s.io-maintainers:
         description: Write access to kubernetes/registry.k8s.io
         members:
@@ -102,3 +104,5 @@ teams:
         - spiffxp
         - thockin
         privacy: closed
+        repos:
+          registry.k8s.io: write

--- a/config/kubernetes/sig-security/teams.yaml
+++ b/config/kubernetes/sig-security/teams.yaml
@@ -24,9 +24,13 @@ teams:
     - IanColdwater
     - tabbysable
     privacy: closed
+    repos:
+      sig-security: admin
   sig-security-maintainers:
     description: Write access to sig-security repo
     members:
     - IanColdwater
     - tabbysable
     privacy: closed
+    repos:
+      sig-security: write

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -94,13 +94,16 @@ restrictions:
     - "^kube-state-metrics"
     - "^klog"
     - "^metrics"
+  - path: "kubernetes/sig-k8s-infra/teams.yaml"
+    allowedRepos:
+    - "^k8s.io"
+  - path: "kubernetes/sig-security/teams.yaml"
+    allowedRepos:
+    - "^sig-security"
   - path: "kubernetes/sig-testing/teams.yaml"
     allowedRepos:
     - "^test-infra"
     - "^publishing-bot"
-  - path: "kubernetes/sig-k8s-infra/teams.yaml"
-    allowedRepos:
-    - "^k8s.io"
   - path: "kubernetes-sigs/org.yaml"
     allowedRepos:
     - "^application"

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -272,6 +272,7 @@ restrictions:
     - "^descheduler"
     - "^kube-batch"
     - "^kube-scheduler-simulator"
+    - "^kube-scheduler-wasm-extension"
     - "^kueue"
     - "^kwok"
     - "^scheduler-plugins"

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -59,6 +59,9 @@ restrictions:
   - path: "kubernetes/sig-apps/teams.yaml"
     allowedRepos:
     - "^kompose"
+  - path: "kubernetes/sig-api-machinery/teams.yaml"
+    allowedRepos:
+    - "^cel-admission-webhook"
   - path: "kubernetes/sig-architecture/teams.yaml"
     allowedRepos:
     - "^enhancements"

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -64,6 +64,7 @@ restrictions:
     - "^cel-admission-webhook"
   - path: "kubernetes/sig-architecture/teams.yaml"
     allowedRepos:
+    - "^design-proposals-archive"
     - "^enhancements"
   - path: "kubernetes/sig-autoscaling/teams.yaml"
     allowedRepos:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -98,6 +98,7 @@ restrictions:
   - path: "kubernetes/sig-k8s-infra/teams.yaml"
     allowedRepos:
     - "^k8s.io"
+    - "^registry.k8s.io"
   - path: "kubernetes/sig-security/teams.yaml"
     allowedRepos:
     - "^sig-security"

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -212,6 +212,7 @@ restrictions:
     - "^discuss-theme"
     - "^lwkd"
     - "^maintainers"
+    - "^sigs-github-actions"
     - "^slack-infra"
   - path: "kubernetes-sigs/sig-docs/teams.yaml"
     allowedRepos:


### PR DESCRIPTION
The PR: 

- update `repos:` permissions for the following GitHub teams under kubernetes and kubernetes-sigs orgs:
    - `cel-admission-webhook-admins`
    - `cel-admission-webhook-maintainers`
    - ` maintainers-maintainers`ask
    - `sigs-github-actions-admins`
    - `sigs-github-actions-maintainers`
    - `kube-scheduler-wasm-extension-admins`
    - `cel-admission-webhook-admins`
    - `cel-admission-webhook-maintainers`
    - `sig-security-admins`
    - `sig-security-maintainers`
    
- update `restrictions.yaml` to whitelist new repo permissions added as part of ^

- add `aroradaman` to `sig-windows-dev-tools-admins` GH team
   (as per the ask in [4370#issuecomment-1671371021](https://github.com/kubernetes/org/pull/4370#issuecomment-1671371021))

/area github-repo
/assign @MadhavJivrajani 