### PR TITLE
Correcting case for GitHub usernames

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -418,7 +418,7 @@ members:
 - jbpratt
 - jdumars
 - jeefy
-- jefftree
+- Jefftree
 - jeffvance
 - jeffwan
 - jennybuckley
@@ -626,7 +626,7 @@ members:
 - mikeshng
 - mimowo
 - minbaev
-- miouge1
+- Miouge1
 - mirwan
 - misterikkit
 - mjlshen
@@ -801,7 +801,7 @@ members:
 - reylejano
 - rficcaglia
 - rhatdan
-- riaankl
+- Riaankl
 - Richabanker
 - richackard
 - richardcase

--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -413,7 +413,7 @@ teams:
     - cristicalin
     - floryut
     - mattymo
-    - miouge1
+    - Miouge1
     - oomichi
     - yankay
     privacy: closed

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -2060,7 +2060,7 @@ teams:
     description: Write access to the kube-openapi repo
     members:
     - apelisse
-    - jefftree
+    - Jefftree
     - lavalamp
     - roycaihw
     privacy: closed

--- a/config/kubernetes/sig-api-machinery/teams.yaml
+++ b/config/kubernetes/sig-api-machinery/teams.yaml
@@ -49,7 +49,7 @@ teams:
     - deads2k
     - enj
     - fedebongio
-    - jefftree
+    - Jefftree
     - jiahuif
     - jpbetz
     - kwiesmueller


### PR DESCRIPTION
Summary:
While GitHub is not case-sensitive, the [Elekto tool used for CNCF elections currently does need username case to match GitHub-official reality](https://github.com/kubernetes/community/blame/master/elections/steering/documentation/README.md#L226). This means that we should be consistent in how we store GitHub usernames, matching the official capitalization, so as to be able to correctly generate voter lists from devstats data.


What is currently wrong:
In the course of preparing for this year's steering election, I learned from the esteemed @mrbobbytables and subsequently [documented that election eligibility pulls from several files](https://github.com/kubernetes/community/pull/7443/files). When generating the eligible voters list using those files as input, I noticed that my sample data had a discrepancy with the example output @mrbobbytables was showing, because his method was lowercasing all usernames. Presumably, for other uses of those files it's fine for GitHub handles to be all-lowercase. However, this leads to incorrect data for the purposes of Elekto, because a voter won't be listed as being eligible if their devstats data doesn't match a username in these files storing their participation status.

Scope of data fix:
These are the GitHub usernames that turned up as a discrepancy if case is ignored between devstats data and these files, scoped specifically to eligible voters for the 2023 steering elections. I am not attempting a comprehensive fix of all data or data generation (as I do think adding usernames to these files is manual), but I do want to make sure we can prevent "why can't I vote?!" for these specific people we can see will be affected if they try to vote in this or any future election that uses eligibility data generated from these files.