### PR TITLE
Update CAPO maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -284,8 +284,8 @@ teams:
   cluster-api-provider-openstack-maintainers:
     description: write access to cluster-api-provider-openstack
     members:
-    - hidekazuna
     - jichenjc
+    - lentzi90
     - mdbooth
     - seanschneeweiss
     - tobiasgiese


### PR DESCRIPTION
We don't differentiate between maintainers admins and maintainers, so these lists are intended to be identical.