### PR TITLE
Add priyankasaggu11929 as GitHub Admin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GITHUB_TOKEN_PATH ?=
 TEST_INFRA_PATH ?= $(OUTPUT_DIR)/tmp/test-infra
 
 # intentionally hardcoded list to ensure it's high friction to remove someone
-ADMINS = cblecker idvoretskyi MadhavJivrajani mrbobbytables nikhita palnabarun
+ADMINS = cblecker MadhavJivrajani mrbobbytables nikhita palnabarun Priyankasaggu11931
 ORGS = $(shell find ./config -type d -mindepth 1 -maxdepth 1 | cut -d/ -f3)
 
 # use absolute path to ./_output, which is .gitignored

--- a/OWNERS
+++ b/OWNERS
@@ -2,22 +2,23 @@
 
 reviewers:
   - cblecker
-  - idvoretskyi
   - MadhavJivrajani
   - mrbobbytables
   - nikhita
   - palnabarun
+  - Priyankasaggu11929
 approvers:
   - cblecker
-  - idvoretskyi
   - MadhavJivrajani
   - mrbobbytables
   - nikhita
   - palnabarun
+  - Priyankasaggu11929
 emeritus_approvers:
   - ameukam
   - calebamiles
   - fejta
+  - idvoretskyi
   - spiffxp
 
 labels:

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -11,8 +11,8 @@
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
 cblecker
-idvoretskyi
 MadhavJivrajani
 mrbobbytables
 nikhita
 palnabarun
+Priyankasaggu11929

--- a/admin/update.sh
+++ b/admin/update.sh
@@ -23,11 +23,11 @@ readonly REPO_ROOT
 
 readonly admins=(
   cblecker
-  idvoretskyi
   MadhavJivrajani
   mrbobbytables
   nikhita
   palnabarun
+  Priyankasaggu11929
 )
 
 cd "${REPO_ROOT}"

--- a/config/kubernetes-client/OWNERS
+++ b/config/kubernetes-client/OWNERS
@@ -3,17 +3,19 @@
 reviewers:
   - MadhavJivrajani
   - palnabarun
+  - Priyankasaggu11929
   - savitharaghunathan
 approvers:
   - cblecker
-  - idvoretskyi
   - MadhavJivrajani
   - mrbobbytables
   - nikhita
   - palnabarun
+  - Priyankasaggu11929
   - savitharaghunathan
 emeritus_approvers:
   - ameukam
   - calebamiles
   - fejta
+  - idvoretskyi
   - spiffxp

--- a/config/kubernetes-client/org.yaml
+++ b/config/kubernetes-client/org.yaml
@@ -1,12 +1,12 @@
 admins:
 - cblecker
-- idvoretskyi
 - k8s-ci-robot
 - k8s-github-robot
 - MadhavJivrajani
 - mrbobbytables
 - nikhita
 - palnabarun
+- Priyankasaggu11929
 - thelinuxfoundation
 billing_email: github@kubernetes.io
 default_repository_permission: read
@@ -31,6 +31,7 @@ members:
 - grodrigues3
 - iamneha
 - idealhack
+- idvoretskyi
 - irvifa
 - ityuhui
 - jlsong01

--- a/config/kubernetes-csi/OWNERS
+++ b/config/kubernetes-csi/OWNERS
@@ -3,17 +3,19 @@
 reviewers:
   - MadhavJivrajani
   - palnabarun
+  - Priyankasaggu11929
   - savitharaghunathan
 approvers:
   - cblecker
-  - idvoretskyi
   - MadhavJivrajani
   - mrbobbytables
   - nikhita
   - palnabarun
+  - Priyankasaggu11929
   - savitharaghunathan
 emeritus_approvers:
   - ameukam
   - calebamiles
   - fejta
+  - idvoretskyi
   - spiffxp

--- a/config/kubernetes-csi/org.yaml
+++ b/config/kubernetes-csi/org.yaml
@@ -1,12 +1,12 @@
 admins:
 - cblecker
-- idvoretskyi
 - k8s-ci-robot
 - k8s-github-robot
 - MadhavJivrajani
 - mrbobbytables
 - nikhita
 - palnabarun
+- Priyankasaggu11929
 - thelinuxfoundation
 billing_email: github@kubernetes.io
 default_repository_permission: read
@@ -51,6 +51,7 @@ members:
 - huffmanca
 - humblec
 - idealhack
+- idvoretskyi
 - ihcsim
 - irvifa
 - j-griffith
@@ -87,7 +88,6 @@ members:
 - pohly
 - Pradumnasaraf
 - prateekpandey14
-- Priyankasaggu11929
 - pwschuurman
 - RaunakShah
 - rlenferink

--- a/config/kubernetes-incubator/OWNERS
+++ b/config/kubernetes-incubator/OWNERS
@@ -2,13 +2,14 @@
 
 approvers:
   - cblecker
-  - idvoretskyi
   - MadhavJivrajani
   - mrbobbytables
   - nikhita
   - palnabarun
+  - Priyankasaggu11929
 emeritus_approvers:
   - ameukam
   - calebamiles
   - fejta
+  - idvoretskyi
   - spiffxp

--- a/config/kubernetes-incubator/org.yaml
+++ b/config/kubernetes-incubator/org.yaml
@@ -7,11 +7,11 @@ members_can_create_repositories: false
 billing_email: github@kubernetes.io
 admins:
 - cblecker
-- idvoretskyi
 - k8s-ci-robot
 - k8s-github-robot
 - MadhavJivrajani
 - mrbobbytables
 - nikhita
 - palnabarun
+- Priyankasaggu11929
 - thelinuxfoundation

--- a/config/kubernetes-nightly/OWNERS
+++ b/config/kubernetes-nightly/OWNERS
@@ -3,12 +3,13 @@
 reviewers:
   - MadhavJivrajani
   - palnabarun
+  - Priyankasaggu11929
   - savitharaghunathan
 approvers:
   - cblecker
-  - idvoretskyi
   - MadhavJivrajani
   - mrbobbytables
   - nikhita
   - palnabarun
+  - Priyankasaggu11929
   - savitharaghunathan

--- a/config/kubernetes-nightly/org.yaml
+++ b/config/kubernetes-nightly/org.yaml
@@ -9,7 +9,6 @@ admins:
 - cblecker
 - cpanato
 - dims
-- idvoretskyi
 - jeremyrickard
 - justaugustus
 - k8s-ci-robot
@@ -18,12 +17,14 @@ admins:
 - mrbobbytables
 - nikhita
 - palnabarun
+- Priyankasaggu11929
 - puerco
 - saschagrunert
 - sttts
 - thelinuxfoundation
 members:
 - ameukam
+- idvoretskyi
 - k8s-publishing-bot
 - savitharaghunathan
 - Verolop

--- a/config/kubernetes-retired/OWNERS
+++ b/config/kubernetes-retired/OWNERS
@@ -2,13 +2,14 @@
 
 approvers:
   - cblecker
-  - idvoretskyi
   - MadhavJivrajani
   - mrbobbytables
   - nikhita
   - palnabarun
+  - Priyankasaggu11929
 emeritus_approvers:
   - ameukam
   - calebamiles
   - fejta
+  - idvoretskyi
   - spiffxp

--- a/config/kubernetes-retired/org.yaml
+++ b/config/kubernetes-retired/org.yaml
@@ -7,11 +7,11 @@ members_can_create_repositories: false
 billing_email: github@kubernetes.io
 admins:
 - cblecker
-- idvoretskyi
 - k8s-ci-robot
 - k8s-github-robot
 - MadhavJivrajani
 - mrbobbytables
 - nikhita
 - palnabarun
+- Priyankasaggu11929
 - thelinuxfoundation

--- a/config/kubernetes-sigs/OWNERS
+++ b/config/kubernetes-sigs/OWNERS
@@ -3,17 +3,19 @@
 reviewers:
   - MadhavJivrajani
   - palnabarun
+  - Priyankasaggu11929
   - savitharaghunathan
 approvers:
   - cblecker
-  - idvoretskyi
   - MadhavJivrajani
   - mrbobbytables
   - nikhita
   - palnabarun
+  - Priyankasaggu11929
   - savitharaghunathan
 emeritus_approvers:
   - ameukam
   - calebamiles
   - fejta
+  - idvoretskyi
   - spiffxp

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -1,12 +1,12 @@
 admins:
 - cblecker
-- idvoretskyi
 - k8s-ci-robot
 - k8s-github-robot
 - MadhavJivrajani
 - mrbobbytables
 - nikhita
 - palnabarun
+- Priyankasaggu11929
 - thelinuxfoundation
 billing_email: github@kubernetes.io
 default_repository_permission: read
@@ -386,6 +386,7 @@ members:
 - ibabou
 - ibzib
 - idealhack
+- idvoretskyi
 - imnmo
 - ingvagabund
 - inteon
@@ -755,7 +756,6 @@ members:
 - prankul88
 - prankulmahajan
 - pravarag
-- Priyankasaggu11929
 - prksu
 - Promaethius
 - prydonius

--- a/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
@@ -81,11 +81,11 @@ teams:
     description: admin access to the sigs-github-actions repo
     maintainers:
     - cblecker
-    - idvoretskyi
     - MadhavJivrajani
     - mrbobbytables
     - nikhita
     - palnabarun
+    - Priyankasaggu11929
     privacy: closed
     repos:
       sigs-github-actions: admin
@@ -95,7 +95,6 @@ teams:
     - cblecker
     - MadhavJivrajani
     - nikhita
-    members:
     - Priyankasaggu11929
     privacy: closed
     repos:

--- a/config/kubernetes/OWNERS
+++ b/config/kubernetes/OWNERS
@@ -3,17 +3,19 @@
 reviewers:
   - MadhavJivrajani
   - palnabarun
+  - Priyankasaggu11929
   - savitharaghunathan
 approvers:
   - cblecker
-  - idvoretskyi
   - MadhavJivrajani
   - mrbobbytables
   - nikhita
   - palnabarun
+  - Priyankasaggu11929
   - savitharaghunathan
 emeritus_approvers:
   - ameukam
   - calebamiles
   - fejta
+  - idvoretskyi
   - spiffxp

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1908,13 +1908,12 @@ teams:
       dns: write
   examples:
     description: Creation and curation of example applications that run on Kubernetes
-    maintainers:
-    - idvoretskyi
     members:
     - ahmetb
     - chrislovecnm
     - erictune
     - foxish
+    - idvoretskyi
     - janetkuo
     - jaredbhatti
     - jayunit100
@@ -1924,8 +1923,8 @@ teams:
   examples-admins:
     description: Admin access to the examples repo
     maintainers:
-    - idvoretskyi
     members:
+    - idvoretskyi
     - sebgoa
     privacy: closed
     repos:
@@ -1933,9 +1932,9 @@ teams:
   examples-maintainers:
     description: Write access to the examples repo
     maintainers:
-    - idvoretskyi
     members:
     - ahmetb
+    - idvoretskyi
     - sebgoa
     privacy: closed
     repos:
@@ -2177,11 +2176,11 @@ teams:
     description: Kubernetes GitHub Owners
     maintainers:
     - cblecker
-    - idvoretskyi
     - MadhavJivrajani
     - mrbobbytables
     - nikhita
     - palnabarun
+    - Priyankasaggu11929
     privacy: closed
     repos:
       org: admin

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1,12 +1,12 @@
 admins:
 - cblecker
-- idvoretskyi
 - k8s-ci-robot
 - k8s-github-robot
 - MadhavJivrajani
 - mrbobbytables
 - nikhita
 - palnabarun
+- Priyankasaggu11929
 - thelinuxfoundation
 billing_email: github@kubernetes.io
 default_repository_permission: read
@@ -613,6 +613,7 @@ members:
 - ibzib
 - Iceber
 - idealhack
+- idvoretskyi
 - ihcsim
 - iheanyi1
 - iholder101
@@ -1196,7 +1197,6 @@ members:
 - presztak
 - prezha
 - PriyankaH21
-- Priyankasaggu11929
 - PriyanshuAhlawat
 - priyawadhwa
 - prksu

--- a/config/kubernetes/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes/sig-contributor-experience/teams.yaml
@@ -3,14 +3,13 @@ teams:
     description: ""
     maintainers:
     - cblecker
-    - idvoretskyi
     - MadhavJivrajani
     - mrbobbytables
     - nikhita
     - palnabarun
+    - Priyankasaggu11929
     members:
     - kaslin
-    - Priyankasaggu11929
     privacy: closed
     repos:
       community: admin
@@ -21,9 +20,9 @@ teams:
     - MadhavJivrajani
     - mrbobbytables
     - nikhita
+    - Priyankasaggu11929
     members:
     - kaslin
-    - Priyankasaggu11929
     privacy: closed
     repos:
       community: write
@@ -31,17 +30,18 @@ teams:
     description: Contributors who can use `/milestone` in the community repo. Defined by an entry in an OWNERS file for a contribex subproject.
     maintainers:
     - cblecker
-    - idvoretskyi
     - MadhavJivrajani
     - mrbobbytables
     - nikhita
     - palnabarun
+    - Priyankasaggu11929
     members:
     - castrojo
     - dims
     - fejta
     - grodrigues3
     - guineveresaenger
+    - idvoretskyi
     - jberkus
     - jdumars
     - jeefy
@@ -50,7 +50,6 @@ teams:
     - lukaszgryglicki
     - parispittman
     - Phillels
-    - Priyankasaggu11929
     - spiffxp
     - tpepper
     privacy: closed
@@ -90,11 +89,11 @@ teams:
       Subproject Board
     maintainers:
     - cblecker
-    - idvoretskyi
     - MadhavJivrajani
     - mrbobbytables
     - nikhita
     - palnabarun
+    - Priyankasaggu11929
     members:
     - ezzoueidi
     - idealhack
@@ -104,9 +103,8 @@ teams:
     description: Contributors with access to groom issues on org-level project boards.
       Groups can opt-in to assistance with grooming by adding this team to their project
       board with admin permissions.
-    maintainers:
-    - idvoretskyi
     members:
+    - idvoretskyi
     - jdumars
     - justaugustus
     - lachie83
@@ -117,11 +115,11 @@ teams:
     description: Improve contributor productivity
     maintainers:
     - cblecker
-    - idvoretskyi
     - MadhavJivrajani
     - mrbobbytables
     - nikhita
     - palnabarun
+    - Priyankasaggu11929
     members:
     - alisondy
     - castrojo
@@ -131,6 +129,7 @@ teams:
     - grodrigues3
     - hongchaodeng
     - idealhack
+    - idvoretskyi
     - jessfraz
     - kaslin
     - lavalamp
@@ -139,7 +138,6 @@ teams:
     - philips
     - Phillels
     - pigmej
-    - Priyankasaggu11929
     - pwittrock
     - thockin
     - xiang90
@@ -167,35 +165,34 @@ teams:
         - mrbobbytables
         - nikhita
         - palnabarun
+        - Priyankasaggu11929
         members:
         - jberkus
         - kaslin
-        - Priyankasaggu11929
         privacy: closed
       sig-contributor-experience-pr-reviews:
         description: PR reviews for contributor-experience infrastructure, such as the
           PR bot, etc.
         maintainers:
         - cblecker
-        - idvoretskyi
         - MadhavJivrajani
         - nikhita
         - palnabarun
+        - Priyankasaggu11929
         members:
         - idealhack
         - kaslin
-        - Priyankasaggu11929
         privacy: closed
   youtube-admins:
     description: Members who have admin access to the Kubernetes Community
       YouTube channel.
     maintainers:
-    - idvoretskyi
     - mrbobbytables
     members:
     - alejandrox1
     - castrojo
     - ezzoueidi
+    - idvoretskyi
     - jbeda
     - jdumars
     - jeefy

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -291,10 +291,9 @@ teams:
     privacy: closed
   sig-docs-uk-reviews:
     description: PR reviews for Ukrainian content
-    maintainers:
-    - idvoretskyi
     members:
     - Arhell
+    - idvoretskyi
     - MaxymVlasov
     - Potapy4
     privacy: closed

--- a/config/kubernetes/sig-k8s-infra/teams.yaml
+++ b/config/kubernetes/sig-k8s-infra/teams.yaml
@@ -14,7 +14,6 @@ teams:
     description: sig-k8s-infra members
     maintainers:
     - cblecker
-    - idvoretskyi
     - nikhita
     members:
     - ameukam
@@ -25,6 +24,7 @@ teams:
     - cpanato
     - dims
     - hh
+    - idvoretskyi
     - ixdy
     - justinsb
     - listx
@@ -46,9 +46,8 @@ teams:
         privacy: closed
       k8s-infra-aws-admins:
         description: granted access to the k8s-infra AWS account
-        maintainers:
-        - idvoretskyi
         members:
+        - idvoretskyi
         - justinsb
         - thockin
         privacy: closed
@@ -56,10 +55,10 @@ teams:
         description: granted read-only access to the k8s-infra GCP org (excluding secrets)
         maintainers:
         - cblecker
-        - idvoretskyi
         members:
         - BobyMCbobs
         - hh
+        - idvoretskyi
         - justinsb
         - puerco
         - Riaankl

--- a/config/kubernetes/wg-structured-logging/teams.yaml
+++ b/config/kubernetes/wg-structured-logging/teams.yaml
@@ -11,7 +11,6 @@ teams:
       - mengjiao-liu
       - navidshaikh
       - pohly
-      - Priyankasaggu11929
       - serathius
       - shivanshu1333
       - yangjunmyfm192085


### PR DESCRIPTION
Ref https://github.com/kubernetes/community/pull/7464

**Commit 1**

`.*: add Priyankasaggu11929 and rotate out idvoretskyi as admin`

Change root OWNERS and ADMIN variables in scripts.

**Commit 2**

`remove Priyankasaggu11929 from wg-structured-logging teams.yaml`

**Commit 3**

`config: GH admin rotation - update team configs`

Move idvoretskyi to members wherever applicable.
Add Priyankasaggu11929 as maintainer anew or move from member to maintainer wherever necessary.

**Commit 4**

`config: GH Admin rotation - upgrade org OWNERS and configs`
    
Add Priyankasaggu11929 as admin in all orgs and move idvoretskyi to member wherever applicable.
Add Priyankasaggu11929 as reviewer and approver in OWNERS of all orgs and move idvoretskyi to emiratus.


/cc https://github.com/orgs/kubernetes/teams/owners
/assign @nikhita