### PR TITLE
Add dims to test-infra-admins + test-infra-maintainers

### DIFF
--- a/config/kubernetes/sig-testing/teams.yaml
+++ b/config/kubernetes/sig-testing/teams.yaml
@@ -66,6 +66,7 @@ teams:
     - chaodaiG
     - chases2
     - cjwagner
+    - dims
     - fejta
     - k8s-infra-ci-robot
     - listx
@@ -83,6 +84,7 @@ teams:
     - amwat
     - BenTheElder
     - cjwagner
+    - dims
     - fejta
     - ixdy
     - krzyzacy


### PR DESCRIPTION
Most of the folks on these 2 teams are no longer active. Putting my hands up to help with the repo. (Triggered right now by the need for adding `/lgtm`'s to some PRs that hit a github webhook hiccup!)