### PR TITLE
Revert "update admin/update.sh to include --skip-removals flag"

### DIFF
--- a/admin/update.sh
+++ b/admin/update.sh
@@ -40,7 +40,6 @@ args=(
   --fix-teams
   --fix-team-members
   --fix-team-repos
-  --skip-removals
   "${admins[@]/#/--required-admins=}"
 )
 


### PR DESCRIPTION
Now that peribolos is back on its feet, we don't need the skip-removals flag.

Ref https://github.com/kubernetes/org/issues/4365

/assign @Priyankasaggu11929 
/area github/management
/sig contributor-experience