### PR TITLE
Update OWNERS_ALIASES for CoCC to reflect 2023 election

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -153,7 +153,7 @@ aliases:
     - mylesagray
     - phenixblue
   committee-code-of-conduct:
-    - detiber
+    - AnaMMedina21
     - endocrimes
     - hlipsig
     - jeremyrickard


### PR DESCRIPTION
This PR updates the `OWNERS_ALIASES` file to reflect the 2023 CoCC Election Results

- [x] Off board @detiber 
- [x]  Onboard @AnaMMedina21 

/committee code-of-conduct
/committee steering

Part of https://github.com/kubernetes/community/issues/7482