### PR TITLE
peribolos: fix typo s/repo/repos/g in csi-proxy-maintainers/admins team

### DIFF
--- a/config/kubernetes-csi/org.yaml
+++ b/config/kubernetes-csi/org.yaml
@@ -334,7 +334,7 @@ teams:
     - saad-ali
     - xing-yang
     privacy: closed
-    repo:
+    repos:
       csi-proxy: admin
   csi-proxy-maintainers:
     description: Write access to csi-proxy repo
@@ -349,7 +349,7 @@ teams:
     - sunnylovestiramisu
     - xing-yang
     privacy: closed
-    repo:
+    repos:
       csi-proxy: write
   csi-release-tools-admins:
     description: Admin access to csi-release-tools repo


### PR DESCRIPTION
Fixes the typo `s/repo/repos/g` in csi-proxy-maintainers and csi-proxy-admins github team configs.

ref:  https://kubernetes.slack.com/archives/C01672LSZL0/p1692808314288179

/assign @MadhavJivrajani 