### PR TITLE
Add bugoverdose to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -129,6 +129,7 @@ members:
 - brianpursley
 - bridgetkromhout
 - bswartz
+- bugoverdose
 - byako
 - bzub
 - caesarxuchao


### PR DESCRIPTION
I need the authorization for contributing to kustomize.