### PR TITLE
Remove stale invites

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -596,7 +596,6 @@ members:
 - marwanad
 - mashby2022
 - mateiidavid
-- matglas
 - mattcary
 - mattfarina
 - mattfenwick

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -1012,7 +1012,6 @@ members:
 - vrabbi
 - Vyom-Yadav
 - wangchen615
-- wanyufe
 - wawa0210
 - weilaaa
 - weiling61

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -588,7 +588,6 @@ members:
 - mariantalla
 - mark-nc
 - markmc
-- markyjackson-taulia
 - marosset
 - marquiz
 - mars1024

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -927,7 +927,6 @@ members:
 - mariantalla
 - markmc
 - markthink
-- markyjackson-taulia
 - marosset
 - marquiz
 - mars1024

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -764,7 +764,6 @@ members:
 - jygastaud
 - jyotimahapatra
 - jyz0309
-- jzhupup
 - k-toyoda-pi
 - k82cn
 - k8s-infra-cherrypick-robot

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -937,7 +937,6 @@ members:
 - masap
 - MasayaAoyama
 - mashby2022
-- matglas
 - mattcary
 - mattfarina
 - mattfenwick

--- a/config/kubernetes/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes/sig-contributor-experience/teams.yaml
@@ -196,7 +196,6 @@ teams:
     - jbeda
     - jdumars
     - jeefy
-    - markyjackson-taulia
     - onlydole
     - parispittman
     - sarahnovotny


### PR DESCRIPTION
There are a number of users who have either left the org or never accepted their invitation. This revokes those stale invitations.