### PR TITLE
cmd/merge: use strict unmarshalling for merging configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ peribolos: $(PERIBOLOS_CMD)
 
 .PHONY: test
 test: config
-	go test ./... --config=$(MERGED_CONFIG)
+	MERGED_CONFIG=$(MERGED_CONFIG) go test ./...
 
 .PHONY: verify
 verify:

--- a/cmd/merge/main.go
+++ b/cmd/merge/main.go
@@ -26,8 +26,8 @@ import (
 
 	"k8s.io/test-infra/prow/config/org"
 
-	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 )
 
 func parseKeyValue(s string) (string, string) {
@@ -97,13 +97,18 @@ func main() {
 	fmt.Println(string(out))
 }
 
-func unmarshal(path string) (*org.Config, error) {
+func unmarshalFromFile(path string) (*org.Config, error) {
 	buf, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read: %v", err)
 	}
+
+	return unmarshal(buf)
+}
+
+func unmarshal(buf []byte) (*org.Config, error) {
 	var cfg org.Config
-	if err := yaml.Unmarshal(buf, &cfg); err != nil {
+	if err := yaml.Unmarshal(buf, &cfg, yaml.DisallowUnknownFields); err != nil {
 		return nil, fmt.Errorf("unmarshal: %v", err)
 	}
 	return &cfg, nil
@@ -112,7 +117,7 @@ func unmarshal(path string) (*org.Config, error) {
 func loadOrgs(o options) (map[string]org.Config, error) {
 	config := map[string]org.Config{}
 	for name, path := range o.orgs {
-		cfg, err := unmarshal(path)
+		cfg, err := unmarshalFromFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("error in %s: %v", path, err)
 		}
@@ -134,7 +139,7 @@ func loadOrgs(o options) (map[string]org.Config, error) {
 				case !info.IsDir() && filepath.Dir(path) == prefix:
 					return nil // Ignore prefix/foo files
 				case filepath.Base(path) == "teams.yaml":
-					teamCfg, err := unmarshal(path)
+					teamCfg, err := unmarshalFromFile(path)
 					if err != nil {
 						return fmt.Errorf("error in %s: %v", path, err)
 					}

--- a/cmd/merge/main_test.go
+++ b/cmd/merge/main_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+const testOrgConfig = `admins:
+- admin1
+- admin2
+billing_email: github@kubernetes.io
+default_repository_permission: read
+description: Org desc
+has_organization_projects: true
+has_repository_projects: true
+members:
+- member1
+- member2
+members_can_create_repositories: false
+name: Org
+teams:
+  team-abc:
+    description: team-abc desc
+    members:
+    - team-member1
+    privacy: closed
+    %s:
+      abc: write
+`
+
+func TestStrictUnmarshalling(t *testing.T) {
+	cases := []struct {
+		repoKey     string
+		expectError bool
+		desc        string
+	}{
+		{
+			repoKey:     "repos",
+			expectError: false,
+			desc:        "with a valid field",
+		},
+		{
+			repoKey:     "somethingBizzare",
+			expectError: true,
+			desc:        "with an invalid field",
+		},
+	}
+
+	for _, c := range cases {
+		_, err := unmarshal(
+			bytes.NewBufferString(fmt.Sprintf(testOrgConfig, c.repoKey)).Bytes(),
+		)
+		if !c.expectError && err != nil {
+			t.Errorf("unexpected error for %s: %v", c.desc, err)
+		}
+		if c.expectError && err == nil {
+			t.Errorf("expected error for %s", c.desc)
+		}
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -32,25 +31,23 @@ import (
 	"github.com/ghodss/yaml"
 )
 
-var configPath = flag.String("config", "config.yaml", "Path to generated config")
-
 var cfg org.FullConfig
 
 func TestMain(m *testing.M) {
-	flag.Parse()
-	if *configPath == "" {
-		fmt.Println("--config must be set")
+	configPath := os.Getenv("MERGED_CONFIG")
+	if configPath == "" {
+		fmt.Println("MERGED_CONFIG env variable must be set")
 		os.Exit(1)
 	}
 
-	raw, err := ioutil.ReadFile(*configPath)
+	raw, err := ioutil.ReadFile(configPath)
 	if err != nil {
-		fmt.Printf("cannot read generated config.yaml from %s: %v\n", *configPath, err)
+		fmt.Printf("cannot read generated config.yaml from %s: %v\n", configPath, err)
 		os.Exit(1)
 	}
 
 	if err := yaml.Unmarshal(raw, &cfg); err != nil {
-		fmt.Printf("cannot unmarshal generated config.yaml from %s: %v\n", *configPath, err)
+		fmt.Printf("cannot unmarshal generated config.yaml from %s: %v\n", configPath, err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
### Commit 1
Strict unmarshalling allows us to fail when we see an unrecognised
key. This helps prevent subtle issues like `repo` being written instead
of `repos`. Previously, the unmarshalling would have ignored this. This
is quite serious because now this means that the desired state of a team
is that there is no repo under it when there clearly is a repo mentioned.
Hence, peribolos would remove this repo.

Strict unmarshalling prevents us from doing that.

Plus, this uses the yaml packages maintained by the Kubernetes community,
and this is also used in test-infra.

### Commit 2

There are now more than 1 test files in the repo, using
`./...` with a flag will not suffice if that flag is not
defined in those test files.

---

One such issue that could've been prevented by strict unmarshalling: https://kubernetes.slack.com/archives/C01672LSZL0/p1692808314288179 

/assign @Priyankasaggu11929 @palnabarun @nikhita 