### PR TITLE
Add pegasas to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -733,6 +733,7 @@ members:
 - pasqualet
 - PatrickLang
 - pbnj
+- pegasas
 - Pensu
 - perithompson
 - petr-muller


### PR DESCRIPTION
I am an active member of `kubernetes org` and would like to apply to join the `kubernetes-sigs org`, and look forward to contributing more.

Eligibility to apply has been met as follows:

* Meet the conditions for [community membership](https://github.com/kubernetes/community/blob/master/community-membership.md#kubernetes-ecosystem)
* [REQUEST: New membership for @pegasas  #4405](https://github.com/kubernetes/org/issues/4405)

SIG projects I am involved with:
* https://github.com/kubernetes-sigs/gateway-api
* https://github.com/kubernetes-sigs/kueue

