### PR TITLE
Request: Add troy0820 to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -976,6 +976,7 @@ members:
 - torredil
 - tpepper
 - trasc
+- troy0820
 - truongnh1992
 - trutx
 - tssurya


### PR DESCRIPTION
I am an active member of kubernetes org and would like to apply to join the kubernetes-sigs org, and look forward to contributing more.

Eligibility to apply has been met as follows:

Meet the conditions for [community membership](https://github.com/kubernetes/community/blob/master/community-membership.md#kubernetes-ecosystem)

- [x] Member since Oct 2020 https://github.com/kubernetes/org/pull/2262
- [x] [PR(s) authored in k/k](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+author%3Atroy0820+is%3Aclosed)
- [x] [41 issues involved in k/k](https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+is%3Aopen+commenter%3Atroy0820)
- [x] [43 PR reviews involved with in k/k](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+is%3Aopen+commenter%3Atroy0820+)

SIG projects I am involved with:

https://github.com/kubernetes-sigs/controller-runtime


- [x] [PR(s) authored](https://github.com/kubernetes-sigs/controller-runtime/pulls/troy0820)
- [x] [19 Issues involved with in controller-runtime](https://github.com/kubernetes-sigs/controller-runtime/issues?q=is%3Aissue+is%3Aopen+commenter%3Atroy0820)
