### PR TITLE
Migrating away from deprecated ioutil

### DIFF
--- a/cmd/helpers/helper.go
+++ b/cmd/helpers/helper.go
@@ -18,7 +18,7 @@ package helpers
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"k8s.io/test-infra/prow/config/org"
@@ -58,7 +58,7 @@ func (fm FlagMap) Set(s string) error {
 }
 
 func UnmarshalPathToOrgConfig(path string) (*org.Config, error) {
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read: %v", err)
 	}

--- a/cmd/merge/main.go
+++ b/cmd/merge/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -98,7 +97,7 @@ func main() {
 }
 
 func unmarshalFromFile(path string) (*org.Config, error) {
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read: %v", err)
 	}

--- a/cmd/restrictions/main.go
+++ b/cmd/restrictions/main.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -107,7 +106,7 @@ func main() {
 }
 
 func unmarshalPathToRestrictionsConfig(path string) (*Config, error) {
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read restrictions config: %v", err)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -40,7 +39,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	raw, err := ioutil.ReadFile(configPath)
+	raw, err := os.ReadFile(configPath)
 	if err != nil {
 		fmt.Printf("cannot read generated config.yaml from %s: %v\n", configPath, err)
 		os.Exit(1)
@@ -60,7 +59,7 @@ type owners struct {
 }
 
 func readInto(path string, i interface{}) error {
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("read: %v", err)
 	}


### PR DESCRIPTION
This PR removes the use of ioutil package as it has been deprecated since Go 1.16