### PR TITLE
sig-cloud-provider: add teams for k-sigs/cloud-pv-admission-labeler repo

### DIFF
--- a/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
+++ b/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
@@ -122,6 +122,22 @@ teams:
    privacy: closed
    repos:
      blob-csi-driver: write
+  cloud-pv-admission-labeler-admins:
+    description: admin access to the cloud-pv-admission-labeler repo
+    members:
+    - andrewsykim
+    - cheftako
+    privacy: closed
+    repos:
+      cloud-pv-admission-labeler: admin
+  cloud-pv-admission-labeler-maintainers:
+    description: write access to the cloud-pv-admission-labeler repo
+    members:
+    - andrewsykim
+    - cheftako
+    privacy: closed
+    repos:
+      cloud-pv-admission-labeler: write       
   cloud-provider-baiducloud-admins:
    description: Admin access to the cloud-provider-baiducloud repo
    members:

--- a/config/kubernetes/sig-cloud-provider/teams.yaml
+++ b/config/kubernetes/sig-cloud-provider/teams.yaml
@@ -14,22 +14,6 @@ teams:
     - yastij
     privacy: closed
     teams:
-      cloud-pv-admission-labeler-admins:
-        description: admin access to the cloud-pv-admission-labeler repo
-        members:
-        - andrewsykim
-        - cheftako
-        privacy: closed
-        repos:
-          cloud-pv-admission-labeler: admin
-      cloud-pv-admission-labeler-maintainers:
-        description: write access to the cloud-pv-admission-labeler repo
-        members:
-        - andrewsykim
-        - cheftako
-        privacy: closed
-        repos:
-          cloud-pv-admission-labeler: write
       cloud-provider-sample-admins:
         description: ""
         members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -181,6 +181,7 @@ restrictions:
     - "^aws-fsx-openzfs-csi-driver"
     - "^aws-iam-authenticator"
     - "^blob-csi-driver"
+    - "^cloud-pv-admission-labeler"
     - "^cloud-provider-baiducloud"
     - "^cloud-provider-equinix-metal"
     - "^cloud-provider-huaweicloud"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/4438

The PR does following in order to fix the failing `post-org-peribolos` CI Job - https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-org-peribolos/1701202482555785216

- correctly add the GitHub teams and the respective repo perms for new [cloud-pv-admission-labeler](https://github.com/kubernetes-sigs/cloud-pv-admission-labeler) repo under path - `config/kubernetes-sigs/sig-cloud-provider`.
- revert the changes from PR - https://github.com/kubernetes/org/pull/4445 (53950cf3)
- update `config/restrictions.yaml` to whitelist the new repo.

/assign @MadhavJivrajani