### PR TITLE
Add sig-scheduling-approvers and cleanup teams

### DIFF
--- a/config/kubernetes/sig-scheduling/teams.yaml
+++ b/config/kubernetes/sig-scheduling/teams.yaml
@@ -1,56 +1,8 @@
 teams:
-  sig-scheduling-api-reviews:
-    description: ""
-    members:
-    - ahg-g
-    - alculquicondor
-    - chendave
-    - damemi
-    - denkensk
-    - Huang-Wei
-    - kerthcet
-    - sanposhiho
-    privacy: closed
-  sig-scheduling-bugs:
-    description: ""
-    members:
-    - ahg-g
-    - alculquicondor
-    - chendave
-    - damemi
-    - denkensk
-    - Huang-Wei
-    - kerthcet
-    - sanposhiho
-    privacy: closed
-  sig-scheduling-feature-requests:
-    description: ""
-    members:
-    - ahg-g
-    - alculquicondor
-    - chendave
-    - damemi
-    - denkensk
-    - Huang-Wei
-    - kerthcet
-    - sanposhiho
-    privacy: closed
   sig-scheduling-misc:
     description: Scheduling algorithms, scheduling/scheduler architecture and extensibility,
       rescheduling/continuous re-optimization, cluster-level resource allocation and
       resource management
-    members:
-    - ahg-g
-    - alculquicondor
-    - chendave
-    - damemi
-    - denkensk
-    - Huang-Wei
-    - kerthcet
-    - sanposhiho
-    privacy: closed
-  sig-scheduling-pr-reviews:
-    description: ""
     members:
     - ahg-g
     - alculquicondor
@@ -66,30 +18,6 @@ teams:
     members:
     - ahg-g
     - alculquicondor
-    - Huang-Wei
-    - kerthcet
-    - sanposhiho
-    privacy: closed
-  sig-scheduling-proposals:
-    description: ""
-    members:
-    - ahg-g
-    - alculquicondor
-    - chendave
-    - damemi
-    - denkensk
-    - Huang-Wei
-    - kerthcet
-    - sanposhiho
-    privacy: closed
-  sig-scheduling-test-failures:
-    description: ""
-    members:
-    - ahg-g
-    - alculquicondor
-    - chendave
-    - damemi
-    - denkensk
     - Huang-Wei
     - kerthcet
     - sanposhiho

--- a/config/kubernetes/sig-scheduling/teams.yaml
+++ b/config/kubernetes/sig-scheduling/teams.yaml
@@ -61,6 +61,15 @@ teams:
     - kerthcet
     - sanposhiho
     privacy: closed
+  sig-scheduling-approvers:
+    description: ""
+    members:
+    - ahg-g
+    - alculquicondor
+    - Huang-Wei
+    - kerthcet
+    - sanposhiho
+    privacy: closed
   sig-scheduling-proposals:
     description: ""
     members:


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/pull/119396#issuecomment-1717022820

---

Sometimes, we want to ping approvers only especially when we want to ask for `/approve`.
I always do that with @ kubernetes/sig-scheduling-leads + @ kerthcet ([example](https://github.com/kubernetes/kubernetes/pull/119396#pullrequestreview-1623468480)), it's easier to have a group for approvers for such cases.

---

Also, we have several teams with the same members. This PR also removes them, and only keeps sig-scheduling-leads, sig-scheduling-approvers and sig-scheduling-misc.