### PR TITLE
Update Steering members following 2023 election cycle

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -169,12 +169,12 @@ aliases:
     - tabbysable
   committee-steering:
     - BenTheElder
-    - cblecker
-    - cpanato
     - justaugustus
     - mrbobbytables
+    - pacoxu
     - palnabarun
-    - tpepper
+    - pohly
+    - soltysh
 ## BEGIN CUSTOM CONTENT
   provider-aws:
     - justinsb

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -2303,14 +2303,14 @@ teams:
   steering-committee:
     description: Kubernetes Steering Committee
     maintainers:
-    - cblecker
     - mrbobbytables
     - palnabarun
     members:
     - BenTheElder
-    - cpanato
     - justaugustus
-    - tpepper
+    - pacoxu
+    - pohly
+    - soltysh
     privacy: closed
     repos:
       funding: admin


### PR DESCRIPTION
(Part of https://github.com/kubernetes/steering/issues/273.)

Add:

- Maciej Szulik - @soltysh
- Paco Xu 徐俊杰 - @pacoxu
- Patrick Ohly - @pohly

Now Emeritus:

- Carlos Tadeu Panato Jr. - @cpanato
- Christoph Blecker - @cblecker
- Tim Pepper - @tpepper

Thanks to all of the Emeritus members for your service and welcome to the new Steering Committee members!

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @mrbobbytables @BenTheElder @palnabarun 
/cc @kubernetes/steering-committee 
/hold