### PR TITLE
Add Sreeram and Fyka to LWKD admins

### DIFF
--- a/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
@@ -21,9 +21,9 @@ teams:
     description: admin access to the lwkd repo
     members:
     - coderanger
+    - fykaa
     - jberkus
     - sreeram-venkitesh
-    - fykaa
     privacy: closed
     repos:
       lwkd: admin

--- a/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
@@ -22,6 +22,8 @@ teams:
     members:
     - coderanger
     - jberkus
+    - sreeram-venkitesh
+    - fykaa
     privacy: closed
     repos:
       lwkd: admin


### PR DESCRIPTION
Since we do branch-based development of each week's edition, they need to be admins in order to create new editions. 

/sig contributor-experience
