### PR TITLE
CAPI: Add adilGhaffarDev to the release team after membership was obtained

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -347,7 +347,7 @@ teams:
     members:
     # members added in commented lines have a pending membership
     # and will be added back once it is acquired.
-    # - adilGhaffarDev
+    - adilGhaffarDev
     - cahillsf
     - chiukapoor
     - furkatgofurov7


### PR DESCRIPTION
I am uncommenting myself in the capi release team because now I am a member Kubernetes-sigs