### PR TITLE
add ellistarn to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -296,6 +296,7 @@ members:
 - EleanorRigby
 - electrocucaracha
 - elezar
+- ellistarn
 - elmiko
 - EmilienM
 - endocrimes


### PR DESCRIPTION
@ellistarn is an existing member of `kubernetes` org. 

This PR is to extend their membership to `kubernetes-sigs` org as well.