### PR TITLE
Extend gjtempleton org membership to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -363,6 +363,7 @@ members:
 - girikuncoro
 - giuseppe
 - gjkim42
+- gjtempleton
 - gkarthiks
 - gnoam
 - gnufied
@@ -613,6 +614,7 @@ members:
 - m00nf1sh
 - macaptain
 - maciaszczykm
+- MaciekPytel
 - Madhan-SWE
 - Madhur97
 - maelvls


### PR DESCRIPTION
Extending org membership to kubernetes-sigs org given adoption of [karpenter](https://github.com/kubernetes-sigs/karpenter) under SIG Autoscaling.