### PR TITLE
config: phase out contribex leads

### DIFF
--- a/config/kubernetes/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes/sig-contributor-experience/teams.yaml
@@ -2,10 +2,7 @@ teams:
   community-admins:
     description: ""
     maintainers:
-    - cblecker
     - MadhavJivrajani
-    - mrbobbytables
-    - nikhita
     - palnabarun
     - Priyankasaggu11929
     members:
@@ -16,10 +13,7 @@ teams:
   community-maintainers:
     description: ""
     maintainers:
-    - cblecker
     - MadhavJivrajani
-    - mrbobbytables
-    - nikhita
     - Priyankasaggu11929
     members:
     - kaslin
@@ -158,23 +152,17 @@ teams:
       sig-contributor-experience-leads:
         description: Chairs and Technical Leads for SIG Contributor Experience
         maintainers:
-        - cblecker
         - MadhavJivrajani
-        - mrbobbytables
-        - nikhita
         - palnabarun
         - Priyankasaggu11929
         members:
-        - jberkus
         - kaslin
         privacy: closed
       sig-contributor-experience-pr-reviews:
         description: PR reviews for contributor-experience infrastructure, such as the
           PR bot, etc.
         maintainers:
-        - cblecker
         - MadhavJivrajani
-        - nikhita
         - palnabarun
         - Priyankasaggu11929
         members:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -17,9 +17,7 @@ teams:
     description: Contributors who can use `/milestone` or `/status` commands on
       issues/PRs and have triage access to the kubernetes/enhancements repo
     maintainers:
-    - cblecker # ContribEx
-    - mrbobbytables # ContribEx
-    - nikhita # ContribEx
+    - MadhavJivrajani # ContribEx
     - palnabarun # Release Manager
     - Priyankasaggu11929 # ContribEx / 1.29 RT Lead
     members:
@@ -112,8 +110,6 @@ teams:
     - npolshakova # 1.29 Enhancements Lead
     - oxddr # Scalability
     - pacoxu # Cluster Lifecycle
-    - parispittman # ContribEx
-    - phillels # ContribEx
     - pmorie # Multicluster
     - prydonius # Apps
     - puerco # Release Manager


### PR DESCRIPTION
Ref: https://github.com/kubernetes/community/issues/7623

/assign @kubernetes/sig-contributor-experience-leads 