### PR TITLE
add tallaxes to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -1004,6 +1004,7 @@ members:
 - tabbysable
 - tahsinrahman
 - Tal-or
+- tallaxes
 - tallclair
 - tam7t
 - taniaduggal


### PR DESCRIPTION
@tallaxes is an existing member of `kubernetes` org. 

This PR is to extend their membership to `kubernetes-sigs` org as well.