### PR TITLE
sig-release: add github teams for release-actions repo

### DIFF
--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -100,6 +100,30 @@ teams:
     - k8s-container-image-promoter-maintainers
     repos:
       promo-tools: write
+  release-actions-admins:
+    description: admin access to the release-actions repo
+    members:
+    - cpanato
+    - jeremyrickard
+    - justaugustus
+    - puerco
+    - saschagrunert
+    - Verolop
+    privacy: closed
+    repos:
+      release-actions: admin
+  release-actions-maintainers:
+    description: write access to the release-actions repo
+    members:
+    - cpanato
+    - jeremyrickard
+    - justaugustus
+    - puerco
+    - saschagrunert
+    - Verolop
+    privacy: closed
+    repos:
+      release-actions: write
   release-engineering:
     description: Members of the Release Engineering subproject, including
       Release Managers and Release Manager Associates.

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -274,6 +274,7 @@ restrictions:
     - "^downloadkubernetes"
     - "^mdtoc"
     - "^promo-tools"
+    - "^release-actions"
     - "^release-notes"
     - "^release-sdk"
     - "^release-team-shadow-stats"


### PR DESCRIPTION
Part of https://github.com/kubernetes/org/issues/4170

/assign @kubernetes/sig-release-leads 

cc: @kubernetes/owners 