### PR TITLE
Update capi v1.7 release team members

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -347,21 +347,24 @@ teams:
     members:
     # members added in commented lines have a pending membership
     # and will be added back once it is acquired.
-    # - adilGhaffarDev
+    - adilGhaffarDev
+    # - adityabhatia
+    # - akshay196
     - cahillsf
-    - chiukapoor
-    - furkatgofurov7
-    - g-gaston
-    - hackeramitkumar
-    # - kranurag7
-    - mjlshen
+    # - chandankumar4
+    # - Dhairya-Arora01
+    - Fedosin
+    # - mansikulkarni96
+    - mcbenjemaa
     - nawazkh
-    - nprokopic
-    - Prajyot-Parab
-    # - razashahid107
+    # - ssuriyan7
+    - SubhasmitaSw
     # - Sunnatillo
-    - vincepri
+    - troy0820 
+    # - typeid
+    - VibhorChinda
     - willie-yao
+    - yrs147 
     privacy: closed
   etcdadm-admins:
     description: Admin access to the etcdadm repo


### PR DESCRIPTION
This PR updates the release team users  for the new Cluster API release v1.7 team.