### PR TITLE
Remove 1.29 docs shadows from SIG Docs team

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -359,11 +359,10 @@ teams:
     - bene2k1
     - bradtopol
     - divya-mohan0209
-    - drewhagen # 1.29 RT Docs Shadow
+    - drewhagen # 1.30 RT Docs Lead
     - femrtnz
     - girikuncoro
     - gochist
-    - harshitasao # 1.29 RT Docs Shadow
     - huynguyennovem
     - inductor
     - jcjesus
@@ -375,7 +374,6 @@ teams:
     - onlydole
     - perriea
     - potapy4
-    - princesso # 1.29 RT Docs Shadow
     - raelga
     - rekcah78
     - remyleone
@@ -385,7 +383,6 @@ teams:
     - seokho-son
     - sftim
     - shurup
-    - taniaduggal # 1.29 RT Docs Shadow
     - tanjunchen
     - tengqm
     - tfogo


### PR DESCRIPTION
Remove v1.29 Docs shadows from website-milestone-maintainers, aside from @drewhagen (v1.30 Docs Lead)

cc: @kubernetes/sig-docs-leads 