### PR TITLE
sig-release: add team repo permissions for obscli

### DIFF
--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -65,6 +65,30 @@ teams:
     privacy: closed
     repos:
       mdtoc: write
+  obscli-admins:
+    description: admin access to obscli
+    members:
+    - cpanato # subproject owner
+    - jeremyrickard # subproject owner
+    - justaugustus # subproject owner
+    - puerco # subproject owner
+    - saschagrunert # subproject owner
+    - Verolop # subproject owner
+    privacy: closed
+    repos:
+      obscli: admin
+  obscli-maintainers:
+    description: write access to obscli
+    members:
+    - cpanato # subproject owner
+    - jeremyrickard # subproject owner
+    - justaugustus # subproject owner
+    - puerco # subproject owner
+    - saschagrunert # subproject owner
+    - Verolop # subproject owner
+    privacy: closed
+    repos:
+      obscli: write
   promo-tools-admins:
     description: admin access to promo-tools
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -273,6 +273,7 @@ restrictions:
     - "^bom"
     - "^downloadkubernetes"
     - "^mdtoc"
+    - "^obscli"
     - "^promo-tools"
     - "^release-actions"
     - "^release-notes"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/4550

/assign @kubernetes/sig-release-leads 