### PR TITLE
remove kbhawkey from sig docs leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -44,7 +44,6 @@ aliases:
     - palnabarun
   sig-docs-leads:
     - divya-mohan0209
-    - kbhawkey
     - natalisucks
     - onlydole
     - reylejano

--- a/config/kubernetes-sigs/sig-docs/teams.yaml
+++ b/config/kubernetes-sigs/sig-docs/teams.yaml
@@ -11,7 +11,6 @@ teams:
   reference-docs-maintainers:
     description: write access to the reference-docs repo
     members:
-    - kbhawkey
     - onlydole
     - sftim
     - tengqm


### PR DESCRIPTION
Remove `kbhawkey` from sig-docs-leads and reference-docs-maintainers.