### PR TITLE
sig network: add teams for node-ipam-controller repo

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -213,3 +213,29 @@ teams:
     privacy: closed
     repos:
       network-policy-api: admin
+  node-ipam-controller-admins:
+    description: Admin access to the node-ipam-controller repo
+    members:
+    - ameukam
+    - aojea
+    - danwinship
+    - mneverov
+    - sarveshr7
+    - shaneutt
+    - thockin
+    privacy: closed
+    repos:
+      node-ipam-controller: admin
+  node-ipam-controller-maintainers:
+    description: Write access to the node-ipam-controller repo
+    members:
+    - ameukam
+    - aojea
+    - danwinship
+    - mneverov
+    - sarveshr7
+    - shaneutt
+    - thockin
+    privacy: closed
+    repos:
+      node-ipam-controller: write

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -261,6 +261,7 @@ restrictions:
     - "^gateway-api"
     - "^kpng"
     - "^network-policy-api"
+    - "^node-ipam-controller"
   - path: "kubernetes-sigs/sig-node/teams.yaml"
     allowedRepos:
     - "^dra-example-driver"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/4640

/assign @kubernetes/sig-network-leads 

**Note:** [@mikezappa87](https://github.com/mikezappa87) is not a member of kuberntes-sigs org at the moment, so the tool doesn't allow to add them as member in the GH teams.