### PR TITLE
Add 1.30 Docs Shadows to GitHub teams

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -359,7 +359,7 @@ teams:
     - bene2k1
     - bradtopol
     - celestehorgan # 1.30 Docs Shadow
-    - chanieljdan # 1.30 Docs Shadow
+    # - chanieljdan # 1.30 Docs Shadow
     - divya-mohan0209
     - drewhagen # 1.30 RT Docs Lead
     - femrtnz

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -358,12 +358,10 @@ teams:
     - awkif
     - bene2k1
     - bradtopol
-    - divya-mohan0209
-    - drewhagen # 1.30 RT Docs Lead
-    - Vyom-Yadav # 1.30 Docs Shadow
-    - Princesso # 1.30 Docs Shadow
     - celestehorgan # 1.30 Docs Shadow
     - chanieljdan # 1.30 Docs Shadow
+    - divya-mohan0209
+    - drewhagen # 1.30 RT Docs Lead
     - femrtnz
     - girikuncoro
     - gochist
@@ -378,6 +376,7 @@ teams:
     - onlydole
     - perriea
     - potapy4
+    - Princesso # 1.30 Docs Shadow
     - raelga
     - rekcah78
     - remyleone
@@ -391,6 +390,7 @@ teams:
     - tengqm
     - tfogo
     - truongnh1992
+    - Vyom-Yadav # 1.30 Docs Shadow
     - xichengliudui
     - ysyukr
     privacy: closed

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -360,6 +360,10 @@ teams:
     - bradtopol
     - divya-mohan0209
     - drewhagen # 1.30 RT Docs Lead
+    - Vyom-Yadav # 1.30 Docs Shadow
+    - Princesso # 1.30 Docs Shadow
+    - celestehorgan # 1.30 Docs Shadow
+    - chanieljdan # 1.30 Docs Shadow
     - femrtnz
     - girikuncoro
     - gochist

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -340,11 +340,11 @@ teams:
           release-team-docs:
             description: Members of the Docs team for the current release cycle.
             members:
-            - drewhagen # 1.30 Docs Lead
-            - Vyom-Yadav # 1.30 Docs Shadow
-            - Princesso # 1.30 Docs Shadow
             - celestehorgan # 1.30 Docs Shadow
             - chanieljdan # 1.30 Docs Shadow
+            - drewhagen # 1.30 Docs Lead
+            - Princesso # 1.30 Docs Shadow
+            - Vyom-Yadav # 1.30 Docs Shadow
             privacy: closed
           release-team-comms:
             description: Members of the Comms team for the current release cycle.

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -341,10 +341,10 @@ teams:
             description: Members of the Docs team for the current release cycle.
             members:
             - drewhagen # 1.30 Docs Lead
-            # - X # 1.30 Docs Shadow
-            # - X # 1.30 Docs Shadow
-            # - X # 1.30 Docs Shadow
-            # - X # 1.30 Docs Shadow
+            - Vyom-Yadav # 1.30 Docs Shadow
+            - Princesso # 1.30 Docs Shadow
+            - celestehorgan # 1.30 Docs Shadow
+            - chanieljdan # 1.30 Docs Shadow
             privacy: closed
           release-team-comms:
             description: Members of the Comms team for the current release cycle.

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -341,7 +341,7 @@ teams:
             description: Members of the Docs team for the current release cycle.
             members:
             - celestehorgan # 1.30 Docs Shadow
-            - chanieljdan # 1.30 Docs Shadow
+            # - chanieljdan # 1.30 Docs Shadow
             - drewhagen # 1.30 Docs Lead
             - Princesso # 1.30 Docs Shadow
             - Vyom-Yadav # 1.30 Docs Shadow


### PR DESCRIPTION
#### What type of PR is this:
/kind documentation

#### What this PR does / why we need it:
Add 1.30 Docs Shadows to sig-docs and sig-release teams

/assign @katcosgrove @gracenng @neoaggelos @ramrodo @sanchita-07 @fsmunoz