### PR TITLE
Add 1.30 Comms shadows to github teams

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -350,7 +350,6 @@ teams:
           release-team-comms:
             description: Members of the Comms team for the current release cycle.
             members:
-            - kcmartin # 1.30 Comms Lead
             - a-mccarthy # 1.30 Comms Shadow
             - checksumz # 1.30 Comms Shadow
             - fkautz # 1.30 Comms Shadow

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -353,6 +353,7 @@ teams:
             - a-mccarthy # 1.30 Comms Shadow
             - checksumz # 1.30 Comms Shadow
             - fkautz # 1.30 Comms Shadow
+            - kcmartin # 1.30 Comms Lead
             - natalisucks # 1.30 Comms Shadow
             privacy: closed
           release-team-enhancements:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -351,10 +351,10 @@ teams:
             description: Members of the Comms team for the current release cycle.
             members:
             - kcmartin # 1.30 Comms Lead
-            # - X # 1.30 Comms Shadow
-            # - X # 1.30 Comms Shadow
-            # - X # 1.30 Comms Shadow
-            # - X # 1.30 Comms Shadow
+            - a-mccarthy # 1.30 Comms Shadow
+            - checksumz # 1.30 Comms Shadow
+            - fkautz # 1.30 Comms Shadow
+            - natalisucks # 1.30 Comms Shadow
             privacy: closed
           release-team-enhancements:
             description: Members of the Enhancments team for the current release


### PR DESCRIPTION
What type of PR is this:
/kind documentation

What this PR does / why we need it:
Add 1.30 Comms Shadows to sig-release team

/assign @katcosgrove @gracenng @neoaggelos @ramrodo @sanchita-07 @fsmunoz