### PR TITLE
NMC: promote jasonbraganza as approver for active orgs

### DIFF
--- a/config/kubernetes-client/OWNERS
+++ b/config/kubernetes-client/OWNERS
@@ -1,12 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+  - jasonbraganza
   - MadhavJivrajani
   - palnabarun
   - Priyankasaggu11929
   - savitharaghunathan
 approvers:
   - cblecker
+  - jasonbraganza
   - MadhavJivrajani
   - mrbobbytables
   - nikhita

--- a/config/kubernetes-client/OWNERS
+++ b/config/kubernetes-client/OWNERS
@@ -5,7 +5,6 @@ reviewers:
   - MadhavJivrajani
   - palnabarun
   - Priyankasaggu11929
-  - savitharaghunathan
 approvers:
   - cblecker
   - jasonbraganza
@@ -14,10 +13,10 @@ approvers:
   - nikhita
   - palnabarun
   - Priyankasaggu11929
-  - savitharaghunathan
 emeritus_approvers:
   - ameukam
   - calebamiles
   - fejta
   - idvoretskyi
+  - savitharaghunathan
   - spiffxp

--- a/config/kubernetes-csi/OWNERS
+++ b/config/kubernetes-csi/OWNERS
@@ -1,12 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+  - jasonbraganza
   - MadhavJivrajani
   - palnabarun
   - Priyankasaggu11929
   - savitharaghunathan
 approvers:
   - cblecker
+  - jasonbraganza
   - MadhavJivrajani
   - mrbobbytables
   - nikhita

--- a/config/kubernetes-csi/OWNERS
+++ b/config/kubernetes-csi/OWNERS
@@ -5,7 +5,6 @@ reviewers:
   - MadhavJivrajani
   - palnabarun
   - Priyankasaggu11929
-  - savitharaghunathan
 approvers:
   - cblecker
   - jasonbraganza
@@ -14,10 +13,10 @@ approvers:
   - nikhita
   - palnabarun
   - Priyankasaggu11929
-  - savitharaghunathan
 emeritus_approvers:
   - ameukam
   - calebamiles
   - fejta
   - idvoretskyi
+  - savitharaghunathan
   - spiffxp

--- a/config/kubernetes-sigs/OWNERS
+++ b/config/kubernetes-sigs/OWNERS
@@ -1,12 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+  - jasonbraganza
   - MadhavJivrajani
   - palnabarun
   - Priyankasaggu11929
   - savitharaghunathan
 approvers:
   - cblecker
+  - jasonbraganza
   - MadhavJivrajani
   - mrbobbytables
   - nikhita

--- a/config/kubernetes-sigs/OWNERS
+++ b/config/kubernetes-sigs/OWNERS
@@ -5,7 +5,6 @@ reviewers:
   - MadhavJivrajani
   - palnabarun
   - Priyankasaggu11929
-  - savitharaghunathan
 approvers:
   - cblecker
   - jasonbraganza
@@ -14,10 +13,10 @@ approvers:
   - nikhita
   - palnabarun
   - Priyankasaggu11929
-  - savitharaghunathan
 emeritus_approvers:
   - ameukam
   - calebamiles
   - fejta
   - idvoretskyi
+  - savitharaghunathan
   - spiffxp

--- a/config/kubernetes/OWNERS
+++ b/config/kubernetes/OWNERS
@@ -1,12 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+  - jasonbraganza
   - MadhavJivrajani
   - palnabarun
   - Priyankasaggu11929
   - savitharaghunathan
 approvers:
   - cblecker
+  - jasonbraganza
   - MadhavJivrajani
   - mrbobbytables
   - nikhita

--- a/config/kubernetes/OWNERS
+++ b/config/kubernetes/OWNERS
@@ -5,7 +5,6 @@ reviewers:
   - MadhavJivrajani
   - palnabarun
   - Priyankasaggu11929
-  - savitharaghunathan
 approvers:
   - cblecker
   - jasonbraganza
@@ -14,10 +13,10 @@ approvers:
   - nikhita
   - palnabarun
   - Priyankasaggu11929
-  - savitharaghunathan
 emeritus_approvers:
   - ameukam
   - calebamiles
   - fejta
   - idvoretskyi
+  - savitharaghunathan
   - spiffxp


### PR DESCRIPTION
This PR promotes @jasonbraganza to approver for all active Kubernetes orgs! 🎉

@jasonbraganza has been consistently managing the influx of new org membership requests with thorough reviews over the past several months.

The decision was discussed in the GitHub Admin group, with many +1 votes.

Additionally, the PR rotates the previous cohort of NMC, adding them as emeritus.
Thank you @savitharaghunathan, for all your work in the NMC role :pray: 

/hold
for ack by other approvers

/cc @kubernetes/owners
/assign  @cblecker @MadhavJivrajani @mrbobbytables @nikhita @palnabarun

_PS: while onboarding @jasonbraganza as NMC earlier, the step to add them as reviewer was missed. PR address that change as well._