### PR TITLE
Sync CAPZ owners with Azure provider project

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -104,29 +104,24 @@ teams:
   cluster-api-provider-azure-admins:
     description: ""
     members:
-    - CecileRobertMichon
     - jackfrancis
     - mboersma
     - nojnhuh
-    - sonasingh46
     privacy: closed
     repos:
       cluster-api-provider-azure: admin
   cluster-api-provider-azure-maintainers:
     description: ""
     members:
-    - CecileRobertMichon
     - jackfrancis
     - mboersma
     - nojnhuh
-    - sonasingh46
     privacy: closed
     repos:
       cluster-api-provider-azure: write
   cluster-api-provider-azure-pms:
     description: ""
     members:
-    - CecileRobertMichon
     - devigned
     - dtzar
     - jackfrancis
@@ -136,7 +131,6 @@ teams:
     - mboersma
     - nawazkh
     - nojnhuh
-    - sonasingh46
     - willie-yao
     privacy: closed
     repos:
@@ -362,11 +356,11 @@ teams:
     # - ssuriyan7
     - SubhasmitaSw
     # - Sunnatillo
-    - troy0820 
+    - troy0820
     # - typeid
     - VibhorChinda
     - willie-yao
-    - yrs147 
+    - yrs147
     privacy: closed
   etcdadm-admins:
     description: Admin access to the etcdadm repo


### PR DESCRIPTION
Syncs up with recent changes to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

Specifically, removes @CecileRobertMichon and @sonasingh46, since they have moved on to emeritus status on the CAPZ project. Thanks again Cecile and Ashutosh! ❤️ 