### PR TITLE
update sig-network-leads team

### DIFF
--- a/config/kubernetes/sig-network/teams.yaml
+++ b/config/kubernetes/sig-network/teams.yaml
@@ -77,6 +77,8 @@ teams:
   sig-network-leads:
     description: ""
     members:
+    - aojea
+    - danwinship
     - MikeZappa87
     - shaneutt
     - thockin


### PR DESCRIPTION
Antonio and I were added to the `sig-network-leads` _group_ but not the `sig-network-leads` _team_ I guess? Which apparently means we can't set `lead-opted-in` on KEPs? (https://github.com/kubernetes/enhancements/issues/784#issuecomment-1924751192)

/assign @thockin 
cc @shaneutt @MikeZappa87 @aojea 