### PR TITLE
Add etcd-io org to repo templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.yml
+++ b/.github/ISSUE_TEMPLATE/membership.yml
@@ -24,6 +24,7 @@ body:
     - kubernetes-client
     - kubernetes-csi
     - kubernetes-sigs
+    - etcd-io
   validations:
     required: true
 - id: requirements

--- a/.github/ISSUE_TEMPLATE/repo-create.yml
+++ b/.github/ISSUE_TEMPLATE/repo-create.yml
@@ -38,6 +38,7 @@ body:
     - kubernetes-client
     - kubernetes-csi
     - kubernetes-sigs
+    - etcd-io
   validations:
     required: true
 - id: admin_access


### PR DESCRIPTION
In https://github.com/kubernetes/org/pull/4498 we added the `etcd-io` org following the creation of [sig-etcd](https://kubernetes.io/blog/2023/11/07/introducing-sig-etcd/).

This is a quick follow-up to ensure the repo templates work for managing the etcd-io org.