### PR TITLE
Update team members for CAAPH

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -24,7 +24,6 @@ teams:
   cluster-api-addon-provider-helm-admins:
     description:  Admin access to cluster-api-addon-provider-helm repo
     members:
-    - CecileRobertMichon
     - fabriziopandini
     - jackfrancis
     - Jont828
@@ -34,7 +33,6 @@ teams:
   cluster-api-addon-provider-helm-maintainers:
     description: Write access to cluster-api-addon-provider-helm repo
     members:
-    - CecileRobertMichon
     - fabriziopandini
     - jackfrancis
     - Jont828


### PR DESCRIPTION
Syncs up the team members for `cluster-api-addon-provider-helm` with current reality in [cluster-api-addon-provider-helm](https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/blob/main/OWNERS_ALIASES).

/cc @jackfrancis @Jont828