### PR TITLE
Update korg tool to recognise etcd-io org

### DIFF
--- a/cmd/korg/korg.go
+++ b/cmd/korg/korg.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	validOrgs = []string{
+		"etcd-io",
 		"kubernetes",
 		"kubernetes-client",
 		"kubernetes-csi",

--- a/hack/default-branches-report.sh
+++ b/hack/default-branches-report.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 readonly kubernetes_orgs=(
+    etcd-io
     kubernetes
     kubernetes-sigs
     kubernetes-client


### PR DESCRIPTION
This PR:
- updates the `korg` tool to add etcd-io as a valid org