### PR TITLE
Add erikgrinaker to etcd-io members

### DIFF
--- a/config/etcd-io/org.yaml
+++ b/config/etcd-io/org.yaml
@@ -19,6 +19,7 @@ members:
 - chalin
 - chaochn47
 - eduartua
+- erikgrinaker
 - fanminshi
 - fuweid
 - idvoretskyi
@@ -135,6 +136,7 @@ teams:
     members:
     - cenkalti
     - chaochn47
+    - erikgrinaker
     - fuweid
     - jmhbnz
     - lavacat


### PR DESCRIPTION
Fixes https://github.com/kubernetes/org/issues/4763.

/hold
Hold pending https://github.com/kubernetes/org/pull/4765.

This pr will be the first test of using k/org automation to add new etcd-io org members.

cc @ahrtr, @serathius, @wenjiaswe