### PR TITLE
Grant admin permisssion for auger to maintainers-auger team

### DIFF
--- a/config/etcd-io/org.yaml
+++ b/config/etcd-io/org.yaml
@@ -130,7 +130,7 @@ teams:
     - wenjiaswe
     privacy: closed
     repos:
-      auger: maintain
+      auger: admin
   members:
     description: ""
     members:


### PR DESCRIPTION
We (etcd auger maintainers) are having issues figuring out why github actions workflows are not running on the `etcd-io/auger` repository so need to temporarily increase the permissions the `maintainers-auger` team has until we can get to the bottom of it.

Relates to: https://github.com/etcd-io/auger/pull/12 

cc @wenjiaswe, @siyuanfoundation 
