### PR TITLE
Update cluster-api-operator-admins

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -75,6 +75,7 @@ teams:
     members:
     - alexander-demicev
     - damdo
+    - Danil-Grigorev
     - Fedosin
     - JoelSpeed
     privacy: closed


### PR DESCRIPTION
Current list of cluster-api-operator admins is oudated. This PR syncs it with what we have in the repository itself:
https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/OWNERS_ALIASES#L17