### PR TITLE
sig apps: add team repo permissions for lws repo

### DIFF
--- a/config/kubernetes-sigs/sig-apps/teams.yaml
+++ b/config/kubernetes-sigs/sig-apps/teams.yaml
@@ -30,3 +30,17 @@ teams:
     privacy: closed
     repos:
       jobset: write
+  lws-admins:
+    description: Admin access to lws repo
+    members:
+    - ahg-g
+    privacy: closed
+    repos:
+      lws: admin
+  lws-maintainers:
+    description: Write access to lws repo
+    members:
+    - ahg-g
+    privacy: closed
+    repos:
+      lws: write

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -147,6 +147,7 @@ restrictions:
     allowedRepos:
     - "^execution-hook"
     - "^jobset"
+    - "^lws"
   - path: "kubernetes-sigs/sig-architecture/teams.yaml"
     allowedRepos:
     - "^apisnoop"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/4737

/assign @kubernetes/sig-apps-leads 

cc: @kubernetes/owners 