### PR TITLE
Remove ehashman as SIG Instrumentation lead

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -56,7 +56,6 @@ aliases:
   sig-instrumentation-leads:
     - dashpole
     - dgrisonnet
-    - ehashman
     - logicalhan
     - rexagod
   sig-k8s-infra-leads:

--- a/config/kubernetes-sigs/sig-instrumentation/teams.yaml
+++ b/config/kubernetes-sigs/sig-instrumentation/teams.yaml
@@ -18,7 +18,6 @@ teams:
     members:
     - dashpole
     - dgrisonnet
-    - ehashman
     - logicalhan
     - rexagod
     privacy: closed
@@ -29,7 +28,6 @@ teams:
     members:
     - dashpole
     - dgrisonnet
-    - ehashman
     - logicalhan
     - rexagod
     privacy: closed
@@ -40,7 +38,6 @@ teams:
     members:
     - dashpole
     - dgrisonnet
-    - ehashman
     - logicalhan
     - rexagod
     privacy: closed
@@ -49,7 +46,6 @@ teams:
   logtools-admins:
     description: Admin access to the logtools repo
     members:
-      - ehashman
       - logicalhan
       - pohly
       - rexagod
@@ -60,7 +56,6 @@ teams:
   logtools-maintainers:
     description: Write access to the logtools repo
     members:
-      - ehashman
       - logicalhan
       - pohly
       - rexagod

--- a/config/kubernetes/sig-instrumentation/teams.yaml
+++ b/config/kubernetes/sig-instrumentation/teams.yaml
@@ -4,7 +4,6 @@ teams:
     members:
     - dashpole
     - dgrisonnet
-    - ehashman
     - logicalhan
     - rexagod
     privacy: closed
@@ -49,7 +48,6 @@ teams:
     members:
     - dashpole
     - dgrisonnet
-    - ehashman
     - fpetkovski
     - logicalhan
     - mrueg


### PR DESCRIPTION
I've removed myself from the alias/team for Instrumentation leads as well as repos I am not active in. POLA, etc.

/cc @kubernetes/sig-instrumentation-leads 