### PR TITLE
Add etcd-operator-admins to etcd-io org

### DIFF
--- a/config/etcd-io/org.yaml
+++ b/config/etcd-io/org.yaml
@@ -13,6 +13,8 @@ description: etcd Development and Communities
 has_organization_projects: false
 has_repository_projects: true
 members:
+- AlexGluck
+- Kirill-Garbar
 - ahrtr
 - caniszczyk
 - cenkalti
@@ -22,11 +24,14 @@ members:
 - erikgrinaker
 - fanminshi
 - fuweid
+- gecube
+- hiddenmarten
 - idvoretskyi
 - ivanvc
 - jasonbraganza
 - jberkus
 - jmhbnz
+- kvaps
 - lavacat
 - lburgazzoli
 - mitake
@@ -34,10 +39,13 @@ members:
 - pav-kv
 - ptabor
 - serathius
+- sergeyshevch
+- sircthulhu
 - siyuanfoundation
 - spzala
 - tbg
 - tjungblu
+- uburro
 - victortrac
 - vorburger
 - wenjiaswe
@@ -96,6 +104,17 @@ teams:
       dbtester: maintain
       etcd: maintain
       gofail: maintain
+  maintainers-etcd-operator:
+    description: Granted write access to etcd-operator
+    members:
+    - Kirill-Garbar
+    - hiddenmarten
+    - kvaps
+    - sergeyshevch
+    - sircthulhu
+    privacy: closed
+    repos:
+      etcd-operator: maintain
   maintainers-jetcd:
     description: Granted write access to jetcd
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -385,6 +385,7 @@ restrictions:
     - "^discovery.etcd.io$"
     - "^discoveryserver$"
     - "^etcd$"
+    - "^etcd-operator$"
     - "^etcdlabs$"
     - "^gofail$"
     - "^govanityurls$"


### PR DESCRIPTION
Hey everyone,

We've established a community to develop a unified etcd-operator. This project is entirely community-driven and currently comprises mainly members of the Russian-speaking Kubernetes community. Although we've just begun, there's already significant activity, with approximately 10 active developers onboard.

We want two things:<s>
1. To donate this project to CNCF:
   - https://github.com/cncf/sandbox/issues/91</s>
1. Get a place under kubernetes-sigs:
    - https://github.com/kubernetes/community/pull/7796
    - https://github.com/kubernetes/org/pull/4839