### PR TITLE
Add kirkonru to sig-docs-ru

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -189,12 +189,14 @@ teams:
     description: Approvers for Russian content
     members:
     - Arhell
+    - kirkonru
     - shurup
     privacy: closed
   sig-docs-ru-reviews:
     description: Reviews for Russian docs PRs
     members:
     - Arhell
+    - kirkonru
     - shurup
     privacy: closed
   sig-docs-pr-reviews:


### PR DESCRIPTION
@kirkonru has formally joined the organisation (#4757), and we want to have him in sig-docs-ru, so he will be able to review the Russian-related PRs for the website.