### PR TITLE
Update etcd website maintainers

### DIFF
--- a/config/etcd-io/org.yaml
+++ b/config/etcd-io/org.yaml
@@ -87,8 +87,6 @@ teams:
     members:
     - ahrtr
     - jmhbnz
-    - mitake
-    - ptabor
     - serathius
     - spzala
     - wenjiaswe
@@ -110,7 +108,6 @@ teams:
     description: raft maintainers
     members:
     - ahrtr
-    - mitake
     - ptabor
     - serathius
     - spzala
@@ -125,9 +122,7 @@ teams:
     - chalin
     - jberkus
     - jmhbnz
-    - mitake
     - nate-double-u
-    - ptabor
     - serathius
     - spzala
     - wenjiaswe

--- a/config/etcd-io/org.yaml
+++ b/config/etcd-io/org.yaml
@@ -124,6 +124,7 @@ teams:
     - ahrtr
     - chalin
     - jberkus
+    - jmhbnz
     - mitake
     - nate-double-u
     - ptabor


### PR DESCRIPTION
Following https://github.com/etcd-io/website/pull/816 and https://github.com/kubernetes/org/pull/4838 this pull request adds me to the etcd website maintainers team.

Also added a second commit to tidy up some permissions to reflect emeritus maintainers that are no longer active or listed in `OWNERS` files as approvers.