### PR TITLE
Add seanzatzdev-amazon as member/efs-csi admin/maintainer

### DIFF
--- a/config/kubernetes-sigs/sig-aws/teams.yaml
+++ b/config/kubernetes-sigs/sig-aws/teams.yaml
@@ -84,6 +84,7 @@ teams:
     - justinsb
     - leakingtapan
     - mskanth972
+    - seanzatzdev-amazon
     - torredil
     - wongma7
     privacy: closed
@@ -98,6 +99,7 @@ teams:
     - justinsb
     - leakingtapan
     - mskanth972
+    - seanzatzdev-amazon
     - torredil
     - wongma7
     privacy: closed


### PR DESCRIPTION
Add seanzatzdev-amazon as an admin/maintainer of the AWS EFS CSI Driver

See AWS EFS CSI Driver OWNERS File here:
https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/OWNERS