### PR TITLE
Sync CAAPH maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -26,6 +26,7 @@ teams:
     - fabriziopandini
     - jackfrancis
     - Jont828
+    - mboersma
     privacy: closed
     repos:
       cluster-api-addon-provider-helm: admin
@@ -35,6 +36,7 @@ teams:
     - fabriziopandini
     - jackfrancis
     - Jont828
+    - mboersma
     privacy: closed
     repos:
       cluster-api-addon-provider-helm: write


### PR DESCRIPTION
Syncs up maintainers with the [OWNERS_ALIASES](https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/blob/main/OWNERS_ALIASES) in CAAPH. Specifically, @mboersma moves to maintainer from reviewer.

/assign @Jont828