### PR TITLE
Update prow location and rate limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SHELL := /usr/bin/env bash
 
 # available for override
 GITHUB_TOKEN_PATH ?=
-TEST_INFRA_PATH ?= $(OUTPUT_DIR)/tmp/test-infra
+PROW_PATH ?= $(OUTPUT_DIR)/tmp/prow
 
 # intentionally hardcoded list to ensure it's high friction to remove someone
 ADMINS = cblecker MadhavJivrajani mrbobbytables nikhita palnabarun Priyankasaggu11929
@@ -72,7 +72,7 @@ add-members:
 # actual targets that only get built if they don't already exist
 $(MERGE_CMD):
 	mkdir -p "$(OUTPUT_BIN_DIR)"
-	go build -v -o "$(OUTPUT_BIN_DIR)" ./cmd/merge
+	go build -o "$(OUTPUT_BIN_DIR)" ./cmd/merge
 
 $(MERGED_CONFIG): clean $(MERGE_CMD) $(CONFIG_FILES)
 	mkdir -p "$(OUTPUT_DIR)"
@@ -81,10 +81,10 @@ $(MERGED_CONFIG): clean $(MERGE_CMD) $(CONFIG_FILES)
 		$(shell for o in $(ORGS); do echo "--org-part=$$o=config/$$o/org.yaml"; done) \
 		> $(MERGED_CONFIG)
 
-$(TEST_INFRA_PATH):
-	mkdir -p $(TEST_INFRA_PATH)
-	git clone --depth=1 https://github.com/kubernetes/test-infra $(TEST_INFRA_PATH)
+$(PROW_PATH):
+	mkdir -p $(PROW_PATH)
+	git clone --depth=1 https://github.com/kubernetes-sigs/prow $(PROW_PATH)
 
-$(PERIBOLOS_CMD): $(TEST_INFRA_PATH)
-	cd $(TEST_INFRA_PATH) && \
-		go build -v -o $(PERIBOLOS_CMD) ./prow/cmd/peribolos
+$(PERIBOLOS_CMD): $(PROW_PATH)
+	cd $(PROW_PATH) && \
+		go build -o $(PERIBOLOS_CMD) ./prow/cmd/peribolos

--- a/admin/update.sh
+++ b/admin/update.sh
@@ -30,6 +30,11 @@ readonly admins=(
   Priyankasaggu11929
 )
 
+# this is the hourly token limit for the GitHub API
+# if unset, the default is set in the peribolos code: https://github.com/kubernetes-sigs/prow/blob/0bca2f1416a9c15d75b9cee8704b56b38d5895c6/prow/cmd/peribolos/main.go#L41
+# if set to 0, rate limiting is disabled
+readonly HOURLY_TOKENS=3000
+
 cd "${REPO_ROOT}"
 make update-prep
 cmd="${REPO_ROOT}/_output/bin/peribolos"
@@ -40,6 +45,7 @@ args=(
   --fix-teams
   --fix-team-members
   --fix-team-repos
+  --github-hourly-tokens="${HOURLY_TOKENS}"
   "${admins[@]/#/--required-admins=}"
 )
 


### PR DESCRIPTION
This PR updates two things:
- Updates the prow source code location to the new repo
- Sets a variable to configure the number of hourly tokens we consume for peribolos. This should drastically speed up execution.