### PR TITLE
milestone-maintainers: add pohly

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -103,6 +103,7 @@ teams:
     - neolit123 # Cluster Lifecycle
     - pacoxu # Cluster Lifecycle / 1.30 Release Signal Lead
     - pmorie # Multicluster
+    - pohly # SIG Testing, Instrumentation, Node
     - puerco # Release Manager
     - pwittrock # CLI
     - quinton-hoole # Multicluster


### PR DESCRIPTION
I'd like to use the /milestone command to organize issues and PRs, in particular for the DRA work.

https://github.com/orgs/kubernetes/projects/95 would benefit from having proper milestones on the items listed there.