### PR TITLE
Use main branch instead of latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,4 +81,4 @@ $(MERGED_CONFIG): clean $(MERGE_CMD) $(CONFIG_FILES)
 		> $(MERGED_CONFIG)
 
 $(PERIBOLOS_CMD):
-	GOBIN=$(OUTPUT_BIN_DIR) go install sigs.k8s.io/prow/cmd/peribolos@latest
+	GOBIN=$(OUTPUT_BIN_DIR) go install sigs.k8s.io/prow/cmd/peribolos@main


### PR DESCRIPTION
As @BenTheElder pointed out https://github.com/kubernetes/org/pull/4887#discussion_r1569209311, it's better for us to use the pseudo version for the main branch, as opposed to the "latest" tag, in the case that the prow repo starts using versioned tags in the future.