### PR TITLE
Add jihoon-seo to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -374,6 +374,7 @@ members:
 - JiaoDean
 - Jiawei0227
 - jichenjc
+- jihoon-seo
 - jimangel
 - JimBugwadia
 - jimmidyson


### PR DESCRIPTION
Recently I have been contributing to https://github.com/kubernetes-sigs/prow, but am not a member of kubernetes-sigs org yet, which makes other kubernetes-sigs members comment `/ok-to-test` every time to trigger the CI tests of my PRs.

Hence I want to be a member of kubernetes-sigs org by opening this PR.
(I am already a member of kubernetes org.)

PTAL!