### PR TITLE
sig-network: add team repo permissions for kube-network-policies repo

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -212,6 +212,24 @@ teams:
     privacy: closed
     repos:
       kpng: admin
+  kube-network-policies-admins:
+    description: Admin access to the kube-network-policies repo
+    members:
+    - aojea
+    - danwinship
+    - thockin
+    privacy: closed
+    repos:
+      kube-network-policies: admin
+  kube-network-policies-maintainers:
+    description: Write access to the kube-network-policies repo
+    members:
+    - aojea
+    - danwinship
+    - thockin
+    privacy: closed
+    repos:
+      kube-network-policies: write
   network-policy-api-admins:
     description: Admin access to the network-policy-api repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -263,6 +263,7 @@ restrictions:
     - "^gateway-api"
     - "^knftables"
     - "^kpng"
+    - "^kube-network-policies"
     - "^network-policy-api"
     - "^node-ipam-controller"
   - path: "kubernetes-sigs/sig-node/teams.yaml"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/4856

/assign @kubernetes/sig-network-leads 

cc: @kubernetes/owners 