### PR TITLE
Update capi v1.8 release team members

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -343,23 +343,22 @@ teams:
     # members added in commented lines have a pending membership
     # and will be added back once it is acquired.
     - adilGhaffarDev
-    # - adityabhatia
-    # - akshay196
-    - cahillsf
     # - chandankumar4
-    # - Dhairya-Arora01
-    - Fedosin
-    # - mansikulkarni96
-    - mcbenjemaa
-    - nawazkh
-    # - ssuriyan7
-    - SubhasmitaSw
+    - chiukapoor
+    # - dhij
+    - hackeramitkumar
+    - jayesh-srivastava
+    # - kperath
+    # - meatballhat
+    # - Nivedita-coder
+    - pravarag
+    # - rajankumary2k
+    # - shipra101
+    # - smoshiur1237
     # - Sunnatillo
     - troy0820
-    # - typeid
-    - VibhorChinda
+    - vishalanarase
     - willie-yao
-    - yrs147
     privacy: closed
   etcdadm-admins:
     description: Admin access to the etcdadm repo


### PR DESCRIPTION


This PR updates the release team users for the new Cluster API release v1.8 team.
