### PR TITLE
SIG Autoscaling - Leads Update

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,7 +20,7 @@ aliases:
     - ritazh
   sig-autoscaling-leads:
     - gjtempleton
-    - mwielgus
+    - maciekpytel
   sig-cli-leads:
     - ardaguclu
     - eddiezane

--- a/config/kubernetes-sigs/sig-autoscaling/teams.yaml
+++ b/config/kubernetes-sigs/sig-autoscaling/teams.yaml
@@ -6,8 +6,7 @@ teams:
     - ellistarn
     - gjtempleton
     - jonathan-innis
-    - MaciekPytel
-    - mwielgus
+    - maciekpytel
     - njtran
     - tzneal
     privacy: closed
@@ -20,8 +19,7 @@ teams:
     - ellistarn
     - gjtempleton
     - jonathan-innis
-    - MaciekPytel
-    - mwielgus
+    - maciekpytel
     - njtran
     - tzneal
     privacy: closed
@@ -41,5 +39,5 @@ teams:
     description: "leads of the SIG Autoscaling"
     members:
     - gjtempleton
-    - mwielgus
+    - maciekpytel
     privacy: closed

--- a/config/kubernetes/sig-autoscaling/teams.yaml
+++ b/config/kubernetes/sig-autoscaling/teams.yaml
@@ -4,8 +4,7 @@ teams:
     members:
     - bigdarkclown
     - gjtempleton
-    - MaciekPytel
-    - mwielgus
+    - maciekpytel
     - towca
     - x13n
     privacy: closed
@@ -16,8 +15,7 @@ teams:
     members:
     - bigdarkclown
     - gjtempleton
-    - MaciekPytel
-    - mwielgus
+    - maciekpytel
     - towca
     - x13n
     privacy: closed
@@ -29,8 +27,7 @@ teams:
     - bigdarkclown
     - feiskyer
     - gjtempleton
-    - MaciekPytel
-    - mwielgus
+    - maciekpytel
     - x13n
     privacy: closed
     repos:
@@ -39,30 +36,27 @@ teams:
     description: ""
     members:
     - gjtempleton
-    - MaciekPytel
+    - maciekpytel
     - mwielgus
     privacy: closed
   sig-autoscaling-bugs:
     description: ""
     members:
     - gjtempleton
-    - MaciekPytel
-    - mwielgus
+    - maciekpytel
     privacy: closed
   sig-autoscaling-feature-requests:
     description: ""
     members:
     - gjtempleton
-    - MaciekPytel
-    - mwielgus
+    - maciekpytel
     privacy: closed
   sig-autoscaling-misc:
     description: ""
     members:
     - bigdarkclown
     - gjtempleton
-    - MaciekPytel
-    - mwielgus
+    - maciekpytel
     - towca
     - x13n
     privacy: closed
@@ -70,26 +64,23 @@ teams:
     description: ""
     members:
     - gjtempleton
-    - MaciekPytel
-    - mwielgus
+    - maciekpytel
     privacy: closed
   sig-autoscaling-proposals:
     description: ""
     members:
     - gjtempleton
-    - MaciekPytel
-    - mwielgus
+    - maciekpytel
     privacy: closed
   sig-autoscaling-test-failures:
     description: ""
     members:
     - gjtempleton
-    - MaciekPytel
-    - mwielgus
+    - maciekpytel
     privacy: closed
   sig-autoscaling-leads:
     description: ""
     members:
     - gjtempleton
-    - mwielgus
+    - maciekpytel
     privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -86,6 +86,7 @@ teams:
     - logicalhan # Instrumentation
     - luxas # Cluster Lifecycle
     - maciaszczykm # UI
+    - maciekpytel # Autoscaling
     - marosset # Windows
     - MaryamTavakkoli # 1.30 Release Signal Shadow
     - mborsz # Scalability
@@ -97,7 +98,6 @@ teams:
     - mpuckett159 # CLI
     - mrunalp # Node
     - msau42 # Storage
-    - mwielgus # Autoscaling
     - nckturner # AWS
     - neoaggelos # 1.30 RT Lead Shadow
     - neolit123 # Cluster Lifecycle


### PR DESCRIPTION
Relates to https://github.com/kubernetes/community/issues/7834

Also standardised casing on @MaciekPytel's handle.

Have currently left @mwielgus as a member `sig-autoscaling-api-reviews` as the current lone approver for the core HPA API code.