### PR TITLE
add sig-contributor-experience GH team & sub-teams to k-sigs org

### DIFF
--- a/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
@@ -57,6 +57,46 @@ teams:
     privacy: closed
     repos:
       maintainers: write
+  sig-contributor-experience:
+    description: Improve contributor productivity
+    maintainers:
+    - cblecker
+    - MadhavJivrajani
+    - mrbobbytables
+    - nikhita
+    - palnabarun
+    - Priyankasaggu11929
+    members:
+    - castrojo
+    - dims
+    - idealhack
+    - idvoretskyi
+    - kaslin
+    - lavalamp
+    - parispittman
+    - pwittrock
+    - thockin
+    privacy: closed
+    teams:
+      sig-contributor-experience-leads:
+        description: Chairs and Technical Leads for SIG Contributor Experience
+        maintainers:
+        - MadhavJivrajani
+        - palnabarun
+        - Priyankasaggu11929
+        members:
+        - kaslin
+        privacy: closed
+      sig-contributor-experience-pr-reviews:
+        description: PR reviews for contributor-experience infrastructure, such as the
+          PR bot, etc.
+        maintainers:
+        - MadhavJivrajani
+        - palnabarun
+        - Priyankasaggu11929
+        members:
+        - kaslin
+        privacy: closed
   sigs-github-actions-admins:
     description: admin access to the sigs-github-actions repo
     maintainers:


### PR DESCRIPTION
PR adds the  `sig-contributor-experience` GH team & sub-teams to kubernetes-sigs org.

Derived from: https://github.com/kubernetes/org/blob/747db2142f493cdaf7cfa52535dc1cab0d0bc853/config/kubernetes/sig-contributor-experience/teams.yaml#L102-L155