### PR TITLE
sig-storage: add team repo permissions for external-snapshot-metadata repo

### DIFF
--- a/config/kubernetes-csi/org.yaml
+++ b/config/kubernetes-csi/org.yaml
@@ -533,6 +533,28 @@ teams:
     privacy: closed
     repos:
       external-resizer: write
+  external-snapshot-metadata-admins:
+    description: Admin access to external-snapshot-metadata repo
+    members:
+    - ihcsim
+    - jsafrane
+    - msau42
+    - saad-ali
+    - xing-yang
+    privacy: closed
+    repos:
+      external-snapshot-metadata: admin
+  external-snapshot-metadata-maintainers:
+    description: Write access to external-snapshot-metadata repo
+    members:
+    - ihcsim
+    - jsafrane
+    - msau42
+    - saad-ali
+    - xing-yang
+    privacy: closed
+    repos:
+      external-snapshot-metadata: write
   external-snapshotter-admins:
     description: Admin access to external-snapshotter repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -358,6 +358,7 @@ restrictions:
     - "^external-health-monitor"
     - "^external-provisioner"
     - "^external-resizer"
+    - "^external-snapshot-metadata"
     - "^external-snapshotter"
     - "^kubernetes-csi.github.io"
     - "^lib-volume-populator"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/4874

/assign @kubernetes/sig-storage-leads 

cc: @kubernetes/owners