### PR TITLE
sig-storage: remove container-object-storage-interface-csi-adapter teams for repo archival

### DIFF
--- a/config/kubernetes-sigs/sig-storage/teams.yaml
+++ b/config/kubernetes-sigs/sig-storage/teams.yaml
@@ -41,27 +41,6 @@ teams:
     privacy: closed
     repos:
       container-object-storage-interface-controller: write
-  container-object-storage-interface-csi-adapter-admins:
-    description: Admin access to container-object-storage-interface-csi-adapter
-    members:
-    - jsafrane
-    - msau42
-    - saad-ali
-    - xing-yang
-    privacy: closed
-    repos:
-      container-object-storage-interface-csi-adapter: admin
-  container-object-storage-interface-csi-adapter-maintainers:
-    description: Write access to container-object-storage-interface-csi-adapter
-    members:
-    - jsafrane
-    - msau42
-    - saad-ali
-    - wlan0
-    - xing-yang
-    privacy: closed
-    repos:
-      container-object-storage-interface-csi-adapter: write
   container-object-storage-interface-provisioner-sidecar-admins:
     description: Admin access to container-object-storage-interface-provisioner-sidecar
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -302,7 +302,6 @@ restrictions:
     allowedRepos:
     - "^container-object-storage-interface-api"
     - "^container-object-storage-interface-controller"
-    - "^container-object-storage-interface-csi-adapter"
     - "^container-object-storage-interface-provisioner-sidecar"
     - "^container-object-storage-interface-spec"
     - "^cosi-driver-sample"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/4875

/assign @kubernetes/sig-storage-leads 

cc: @kubernetes/owners 