### PR TITLE
added terrytangyuan as an org member

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1035,6 +1035,7 @@ members:
 - tengqm
 - tenzen-y
 - TerryHowe
+- terrytangyuan
 - TessaIO
 - therc
 - thockin


### PR DESCRIPTION
Adding #4904 

Fixes #4904

Following example from https://github.com/kubernetes/org/pull/4905

Just to expedite the merge of WG Serving charter.