### PR TITLE
Sync CAPZ admins with Azure provider project

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -109,8 +109,10 @@ teams:
     description: ""
     members:
     - jackfrancis
+    - Jont828
     - mboersma
     - nojnhuh
+    - willie-yao
     privacy: closed
     repos:
       cluster-api-provider-azure: admin
@@ -118,8 +120,10 @@ teams:
     description: ""
     members:
     - jackfrancis
+    - Jont828
     - mboersma
     - nojnhuh
+    - willie-yao
     privacy: closed
     repos:
       cluster-api-provider-azure: write


### PR DESCRIPTION
Syncs up with recent changes to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

Specifically, adds @Jont828 and @willie-yao to admins/maintainers.

/cc @jackfrancis @Jont828 @nojnhuh