### PR TITLE
Fix typo in the GitHub word

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Kubernetes Github Organization
+# Kubernetes GitHub Organization
 
-This repository contains the metadata [configuration](/config) for the Kubernetes Github
+This repository contains the metadata [configuration](/config) for the Kubernetes GitHub
 Organizations. The data here is consumed by the
 [peribolos](https://docs.prow.k8s.io/docs/components/cli-tools/peribolos/)
 tool to organization and team membership, as well as team creation and deletion.

--- a/config/etcd-io/org.yaml
+++ b/config/etcd-io/org.yaml
@@ -47,7 +47,7 @@ members_can_create_repositories: false
 name: etcd-io
 teams:
   kubernetes-admins:
-    description: Kubernetes Github Admins
+    description: Kubernetes GitHub Admins
     maintainers:
     - cblecker
     - MadhavJivrajani


### PR DESCRIPTION
The PR corrects a typo in the "GitHub" company name.

Additionally, repo's description should be fixed:
<img width="367" alt="image" src="https://github.com/kubernetes/org/assets/3228886/62c4ca02-c554-4a98-a841-32d876d5a714">
