### PR TITLE
drop kubernetes-feature-branch-admins group with admin rights to k/k

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1560,14 +1560,6 @@ teams:
     privacy: closed
     repos:
       kubectl: write
-  kubernetes-feature-branch-admins:
-    description: Admin access to the kubernetes repo, for maintaining feature branches.
-      Will deprecate when this access is no longer needed.
-    members:
-    - lavalamp
-    privacy: closed
-    repos:
-      kubernetes: admin
   kubernetes-maintainers:
     description: Write access to the kubernetes repo. Follow the process in https://github.com/kubernetes/community/blob/master/community-membership.md
     maintainers:


### PR DESCRIPTION
We haven't done feature branches in quite a while. lavalamp@ has stepped down from several roles as well (thanks!)

let's cleanup this group as it has admin rights to k/k repository