### PR TITLE
Add thelinuxfoundation to etcd org

### DIFF
--- a/config/etcd-io/org.yaml
+++ b/config/etcd-io/org.yaml
@@ -7,6 +7,7 @@ admins:
 - nikhita
 - palnabarun
 - Priyankasaggu11929
+- thelinuxfoundation
 billing_email: github@kubernetes.io
 default_repository_permission: read
 description: etcd Development and Communities


### PR DESCRIPTION
`thelinuxfoundation` is the LF's bot account which has ownership of all CNCF projects. 

In particular, it's needed at this point in order to add etcd to LFX Insights via a GitHub app. 

This is a follow up to a discussion with @mrbobbytables @palnabarun @Priyankasaggu11929 and @MadhavJivrajani on Monday May 20.