### PR TITLE
SIG Cloud Provider update

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,11 +27,9 @@ aliases:
     - mpuckett159
     - soltysh
   sig-cloud-provider-leads:
-    - andrewsykim
     - bridgetkromhout
     - cheftako
     - elmiko
-    - nckturner
   sig-cluster-lifecycle-leads:
     - fabriziopandini
     - justinsb

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -25,7 +25,6 @@ teams:
     - ahg-g # Scheduling
     - alculquicondor # Scheduling
     - ameukam # Release Manager Associate / K8s Infra
-    - andrewsykim # Cloud Provider
     - aojea # Testing / Network
     - aravindhp # Windows
     - ardaguclu # CLI
@@ -98,7 +97,6 @@ teams:
     - mpuckett159 # CLI
     - mrunalp # Node
     - msau42 # Storage
-    - nckturner # AWS
     - neoaggelos # 1.30 RT Lead Shadow
     - neolit123 # Cluster Lifecycle
     - pacoxu # Cluster Lifecycle / 1.30 Release Signal Lead


### PR DESCRIPTION
Updated [OWNERS_ALIASES](https://git.k8s.io/org/OWNERS_ALIASES) in [kubernetes/org](https://git.k8s.io/org/) for https://github.com/kubernetes/community/issues/7865.
Updated [milestone maintainers team](https://git.k8s.io/org/config/kubernetes/sig-release/teams.yaml) in [kubernetes/org](https://git.k8s.io/org/).

/sig cloud-provider