### PR TITLE
Add katcosgrove to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -430,6 +430,7 @@ members:
 - Karthik-K-N
 - Kasambx
 - kaslin
+- katcosgrove
 - Katharine
 - Kavinjsir
 - kavyashree-r


### PR DESCRIPTION
Adding myself to the kubernetes-sigs org for my role as a SIG Docs tech lead