### PR TITLE
Add Release Signal Shadows to the team

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -88,7 +88,6 @@ teams:
     - maciaszczykm # UI
     - maciekpytel # Autoscaling
     - marosset # Windows
-    - MaryamTavakkoli # 1.30 Release Signal Shadow
     - mborsz # Scalability
     - mehabhalodiya # 1.29 Lead Shadow
     - michelle192837 # Testing
@@ -124,13 +123,14 @@ teams:
     - soltysh # CLI
     - spzala # IBM Cloud
     - sttts # API Machinery
+    - SubhasmitaSw # 1.31 Release Signal Shadow
     - tallclair # Auth
     - tashimi # Usability
     - thockin # Network
     - timothysc # Cluster Lifecycle / Testing
     - upodroid # K8s Infra
     - Verolop # Release Manager
-    - Vyom-Yadav # 1.29 CI Signal Lead
+    - Vyom-Yadav # 1.31 Release Signal Lead
     - wojtek-t # Scalability
     - xing-yang # Storage
     - xmcqueen # Testing
@@ -321,13 +321,11 @@ teams:
             description: Members of the Release Signal team for the current release
               cycle.
             members:
-            - MaryamTavakkoli # 1.30 CI Signal Shadow
-            - neoaggelos # 1.30 Release Lead Shadow
-            - pacoxu # 1.30 CI Signal Lead
-            - sanchita-07 # 1.30 Release Lead Shadow
-            - SubhasmitaSw # 1.30 CI Signal Shadow
-            - Vyom-Yadav # 1.30 CI Signal Co-Lead
-            - zelenushechka # 1.30 CI Signal Shadow
+            - AdminTurnedDevOps # 1.31 Release Signal Shadow
+            - Atharva-Shinde # 1.31 Release Signal Shadow
+            - SubhasmitaSw # 1.31 Release Signal Shadow
+            - Vyom-Yadav # 1.31 Release Signal Lead
+            - wendy-ha18 # 1.31 Release Signal Shadow
             privacy: closed
           release-team-docs:
             description: Members of the Docs team for the current release cycle.


### PR DESCRIPTION
- Added v1.31 release signal shadows to the team.
- Added `@SubhasmitaSw` to milestone maintainers ([more experienced shadow](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks/release-signal#onboarding)), removed prev. shadow `@MaryamTavakkoli`

/cc @Priyankasaggu11929 @neoaggelos 
/cc @Atharva-Shinde @SubhasmitaSw @wendy-ha18 @AdminTurnedDevOps 