### PR TITLE
Add MrFreezeex to kubernetes org members

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -728,6 +728,7 @@ members:
 - mpuckett159
 - MrErlison
 - mresvanis
+- MrFreezeex
 - mrgiles
 - MrHohn
 - mrueg


### PR DESCRIPTION
Hello :wave:,

I am planning to contribute to some kubernetes KEP very soon and as I am already a kubernetes-sigs member and that the org membership is equivalent I figured it could be nice to be added to the kubernetes org beforehand! Let me know if that's ok :pray:!