### PR TITLE
Kubespray/maintainers: add VannTeen

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -420,6 +420,7 @@ teams:
     - floryut
     - mzaian
     - oomichi
+    - VannTen
     - yankay
     privacy: closed
     repos:


### PR DESCRIPTION
Hi all, 

@VannTen has been a core maintainer of [kubernetes-sigs/kubespray ](https://github.com/kubernetes-sigs/kubespray)some time now, and he made significant contribution🥳.
It will help us manging the repo/issues to add him to our github team !  
![image](https://github.com/kubernetes/org/assets/1044332/42285435-b827-4421-9ae2-b4be54fc1d4f)

Best,
Antoine