### PR TITLE
infra/testing teams cleanup

### DIFF
--- a/config/kubernetes-sigs/sig-k8s-infra/teams.yaml
+++ b/config/kubernetes-sigs/sig-k8s-infra/teams.yaml
@@ -14,7 +14,6 @@ teams:
     members:
       - ameukam
       - dims
-      - spiffxp
       - thockin
     privacy: closed
     repos:
@@ -24,7 +23,6 @@ teams:
     members:
     - ameukam
     - dims
-    - spiffxp
     - thockin
     privacy: closed
     repos:
@@ -36,7 +34,6 @@ teams:
     - bentheelder
     - dims
     - justinsb
-    - spiffxp
     - thockin
     - upodroid
     privacy: closed
@@ -49,7 +46,6 @@ teams:
       - bentheelder
       - dims
       - justinsb
-      - spiffxp
       - thockin
     privacy: closed
     repos:
@@ -61,7 +57,6 @@ teams:
     - bentheelder
     - dims
     - justinsb
-    - spiffxp
     - thockin
     privacy: closed
     repos:

--- a/config/kubernetes-sigs/sig-testing/teams.yaml
+++ b/config/kubernetes-sigs/sig-testing/teams.yaml
@@ -91,7 +91,6 @@ teams:
     description: Admin access to kubetest2
     members:
     - MushuEE
-    - spiffxp
     privacy: closed
     repos:
       kubetest2: admin
@@ -99,7 +98,6 @@ teams:
     description: Write access to kubetest2
     members:
     - MushuEE
-    - spiffxp
     privacy: closed
     repos:
       kubetest2: write

--- a/config/kubernetes-sigs/sig-testing/teams.yaml
+++ b/config/kubernetes-sigs/sig-testing/teams.yaml
@@ -91,6 +91,7 @@ teams:
     description: Admin access to kubetest2
     members:
     - MushuEE
+    - upodroid
     privacy: closed
     repos:
       kubetest2: admin
@@ -98,6 +99,7 @@ teams:
     description: Write access to kubetest2
     members:
     - MushuEE
+    - upodroid
     privacy: closed
     repos:
       kubetest2: write

--- a/config/kubernetes-sigs/sig-testing/teams.yaml
+++ b/config/kubernetes-sigs/sig-testing/teams.yaml
@@ -90,7 +90,6 @@ teams:
   kubetest2-admins:
     description: Admin access to kubetest2
     members:
-    - MushuEE
     - upodroid
     privacy: closed
     repos:
@@ -98,7 +97,6 @@ teams:
   kubetest2-maintainers:
     description: Write access to kubetest2
     members:
-    - MushuEE
     - upodroid
     privacy: closed
     repos:

--- a/config/kubernetes/sig-architecture/teams.yaml
+++ b/config/kubernetes/sig-architecture/teams.yaml
@@ -101,7 +101,6 @@ teams:
         - logicalhan    # shadow
         - richabanker   # shadow
         - soltysh       # approver
-        - spiffxp       # shadow
         - tallclair     # shadow
         - wojtek-t      # approver
         privacy: closed

--- a/config/kubernetes/sig-k8s-infra/teams.yaml
+++ b/config/kubernetes/sig-k8s-infra/teams.yaml
@@ -81,7 +81,6 @@ teams:
         - cblecker
         members:
         - dims
-        - spiffxp
         - thockin
         privacy: closed
       registry.k8s.io-admins:
@@ -100,7 +99,6 @@ teams:
         - ameukam
         - bentheelder
         - dims
-        - spiffxp
         - thockin
         privacy: closed
         repos:

--- a/config/kubernetes/sig-k8s-infra/teams.yaml
+++ b/config/kubernetes/sig-k8s-infra/teams.yaml
@@ -100,6 +100,7 @@ teams:
         - bentheelder
         - dims
         - thockin
+        - upodroid
         privacy: closed
         repos:
           registry.k8s.io: write

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -1,18 +1,4 @@
 teams:
-  build-admins:
-    description: Kubernetes Build Admins are the current set of Googlers with
-      access to publish packages (debs/rpms) on behalf of the Kubernetes
-      project. This team is a notification-only group, which includes the SIG
-      Release Chairs/TLs for continuity.
-    members:
-    - BenjaminKazemi
-    - cpanato
-    - justaugustus
-    - MushuEE
-    - puerco
-    - saschagrunert
-    - spiffxp
-    privacy: closed
   milestone-maintainers:
     description: Contributors who can use `/milestone` or `/status` commands on
       issues/PRs and have triage access to the kubernetes/enhancements repo


### PR DESCRIPTION
- delete defunct build-admins team (we don't depend on googlers to publish debian/rpm packages anymore and haven't for some time, this was an alias for the people handling publishing, these packages are on community infra now)
- drop @spiffxp from more places (Aaron is long inactive now and some of these teams are highly privileged)
- add @upodroid to kubetest2 maintainers / admins (OWNER and only person with 10+ commits for the past year ..) 
- drop @MushuEE from kubetest2 maintainers / admins (inactive github-wide since June 2023)
- add @upodroid to registry.k8s.io admins/maintainers as SIG K8s Infra TL