### PR TITLE
chore: specify go patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/org
 
-go 1.22
+go 1.22.4
 
 require (
 	github.com/bmatcuk/doublestar v1.3.4


### PR DESCRIPTION
## Change List

- specify go patch version to clarify forwards compatibility

## Note

[Go 1.21 Release Notes](https://tip.golang.org/doc/go1.21)

> To improve forwards compatibility, Go 1.21 now reads the go line in a go.work or go.mod file as a strict minimum requirement: go 1.21.0 means that the workspace or module cannot be used with Go 1.20 or with Go 1.21rc1. This allows projects that depend on fixes made in later versions of Go to ensure that they are not used with earlier versions. It also gives better error reporting for projects that make use of new Go features: when the problem is that a newer Go version is needed, that problem is reported clearly, instead of attempting to build the code and printing errors about unresolved imports or syntax errors.