### PR TITLE
Add dipesh-rawat to sig-docs-hi-owners and sig-docs-hi-reviews

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -88,15 +88,15 @@ teams:
   sig-docs-hi-owners:
     description: Approvers for Hindi content
     members:
-    - anubha-v-ardhan
+    - dipesh-rawat
     - divya-mohan0209
     privacy: closed
   sig-docs-hi-reviews:
     description: PR reviews for Hindi content
     members:
-    - anubha-v-ardhan
     - Babapool
     - bishal7679
+    - dipesh-rawat    
     - divya-mohan0209
     privacy: closed
   sig-docs-id-owners:


### PR DESCRIPTION
This pull request adds myself as part of  `sig-docs-hi-owners` and `sig-docs-hi-reviews` for the Hindi language. These changes already been included in the [OWNERS file (here)](https://github.com/kubernetes/website/blob/6efe7f32137ccc08ff0f33ccc7d484fa7af9d13f/OWNERS_ALIASES#L100-L107) under [k/website](https://github.com/kubernetes/website/blob/main/OWNERS_ALIASES) as part of PR [kubernetes/website#46573](https://github.com/kubernetes/website/pull/46573/files) and I have been actively participating in PR reviews and approvals as usual. Adding myself here to ensure consistency across the board.