### PR TITLE
Grant maintainers-etcd admin permission on etcd-io/etcd

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -38,7 +38,7 @@ teams:
     privacy: closed
     repos:
       dbtester: maintain
-      etcd: maintain
+      etcd: admin
       gofail: maintain
   maintainers-jetcd:
     description: Granted write access to jetcd


### PR DESCRIPTION
To edit an incorrect security advisory repo admin permission is required. Refer:
- https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/editing-a-repository-security-advisory
- https://docs.google.com/document/d/1Pl2e8YTtgt3pYeIZSXJIn4gknp6tTW14htMat1JaM4k
- https://github.com/etcd-io/etcd/security/advisories/GHSA-5x4g-q5rc-36jp

This commit will be reverted once the remedial work is done.
