### PR TITLE
SIG-MC leadership change: pmorie emeritus, skitt co-chair

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -68,7 +68,7 @@ aliases:
     - upodroid
   sig-multicluster-leads:
     - jeremyot
-    - pmorie
+    - skitt
   sig-network-leads:
     - aojea
     - danwinship

--- a/config/kubernetes-sigs/sig-multicluster/teams.yaml
+++ b/config/kubernetes-sigs/sig-multicluster/teams.yaml
@@ -3,7 +3,7 @@ teams:
     description: admin access for the about-api repo
     members:
     - jeremyot
-    - pmorie
+    - skitt
     privacy: closed
     repos:
       about-api: admin
@@ -29,7 +29,7 @@ teams:
     description: Admin access to the mcs-api repo
     members:
     - JeremyOT
-    - pmorie
+    - skitt
     privacy: closed
     repos:
       mcs-api: admin
@@ -38,7 +38,7 @@ teams:
     members:
     - jeremyot
     - lauralorenz
-    - pmorie
+    - skitt
     privacy: closed
     repos:
       sig-multicluster-site: admin
@@ -47,7 +47,7 @@ teams:
     members:
     - jeremyot
     - lauralorenz
-    - pmorie
+    - skitt
     privacy: closed
     repos:
       sig-multicluster-site: write
@@ -55,7 +55,7 @@ teams:
     description: Admin access for the work-api repo
     members:
     - jeremyot
-    - pmorie
+    - skitt
     privacy: closed
     repos:
       work-api: admin

--- a/config/kubernetes/sig-multicluster/teams.yaml
+++ b/config/kubernetes/sig-multicluster/teams.yaml
@@ -58,5 +58,5 @@ teams:
     description: ""
     members:
     - jeremyot
-    - pmorie
+    - skitt
     privacy: closed


### PR DESCRIPTION
pmorie moving to emeritus, skitt becoming co-chair, jeremyot unchanged; see
https://groups.google.com/g/kubernetes-sig-multicluster/c/xhj2OnFO-8M for the discussion and lazy consensus (deadline July 1, 2024).