### PR TITLE
Revert "Grant maintainers-etcd admin permission on etcd-io/etcd"

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -38,7 +38,7 @@ teams:
     privacy: closed
     repos:
       dbtester: maintain
-      etcd: admin
+      etcd: maintain
       gofail: maintain
   maintainers-jetcd:
     description: Granted write access to jetcd


### PR DESCRIPTION
This reverts commit efc4526d26f10962c6f31aa83fbc858393b5a105.

The remedial repo admin work has now been completed so we can return to least required day to day privilege of `maintain`.
