### PR TITLE
fix repo name for cve-feed-osv repo

### DIFF
--- a/config/kubernetes-sigs/sig-security/teams.yaml
+++ b/config/kubernetes-sigs/sig-security/teams.yaml
@@ -16,7 +16,7 @@ teams:
         - tabbysable
         privacy: closed
         repos:
-          cve-feed-osv-admins: admin
+          cve-feed-osv: admin
       cve-feed-osv-maintainers:
         description: write access to the cve-feed-osv repo
         members:
@@ -24,7 +24,7 @@ teams:
         - pushkarj
         privacy: closed
         repos:
-          cve-feed-osv-admins: write
+          cve-feed-osv: write
       sig-security-leads:
         description: SIG Security Leads
         members:


### PR DESCRIPTION
lol
follow up from https://github.com/kubernetes/org/pull/5049
Ref https://github.com/kubernetes/org/issues/4873

/assign @Priyankasaggu11929 