### PR TITLE
Add etcd release team

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -113,3 +113,19 @@ teams:
           gofail: triage
           raft: triage
           website: triage
+  release-etcd:
+    description: Granted permission to release etcd-io/etcd
+    members:
+      - ahrtr
+      - fuweid
+      - ivanvc
+      - jmhbnz
+      - serathius
+      - siyuanfoundation
+      - spzala
+      - wenjiaswe
+    privacy: closed
+    repos:
+      # Permission set to triage during bau activities
+      # During release windows this will be bumped to `maintain`
+      etcd: triage


### PR DESCRIPTION
We (sig-etcd leads) are creating a new GitHub team within our etcd-io org for the release team. 

The members of this team will act as leads or advisors for upcoming etcd releases, on an agreed rotation and have repository write permissions to carry out `etcd-io/etcd` releases.

Historically etcd releases have only been carried out by maintainers which is challenging due to our currently small number of project maintainers. We've been gradually making improvements over time to address this, through improving our release processes, introducing release shadow roles and rotating the release manager for each release.

We now think the time is right to extend the release team beyond maintainers, to also include reviewers, as reviewers are all future maintainers for etcd that we have a lot of trust and confidence in.

cc @wenjiaswe, @ahrtr, @serathius
