### PR TITLE
Add Okabe-Junya to sig-docs-ja-owners

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -133,6 +133,7 @@ teams:
     - bells17
     - inductor
     - nasa9084
+    - Okabe-Junya
     privacy: closed
   sig-docs-ja-reviews:
     description: PR reviews for Japanese content
@@ -324,6 +325,7 @@ teams:
     - natalisucks # L10n: English
     - nate-double-u # L10n: English
     - nvtkaszpir # L10n: Polish
+    - Okabe-Junya #L10n: Japanese
     - onlydole # L10n: English
     - raelga # L10n: Spanish
     - remyleone # L10n: French


### PR DESCRIPTION
xref https://github.com/kubernetes/website/pull/47301

### Description

- Add @Okabe-Junya (myself) to `sig-docs-ja-owners`

### Requirement

- merged PR (labeled `language/ja`): [35+](https://github.com/pulls?q=is%3Amerged+is%3Apr+author%3AOkabe-Junya+archived%3Afalse+repo%3Akubernetes%2Fwebsite+label%3Alanguage%2Fja+)
- reviewed PR (labeled `language/ja`): [85+](https://github.com/pulls?q=is%3Apr+reviewed-by%3AOkabe-Junya+archived%3Afalse+repo%3Akubernetes%2Fwebsite+label%3A%22language%2Fja%22)
- exactly three months since I became a reviewer: https://github.com/kubernetes/org/pull/4922