### PR TITLE
docs: add Mattia Lavacca as a Gateway API maintainer

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -165,6 +165,7 @@ teams:
   gateway-api-admins:
     description: Admin access to the gateway-api repo
     members:
+    - mlavacca
     - robscott
     - shaneutt
     - youngnick
@@ -176,6 +177,7 @@ teams:
   gateway-api-maintainers:
     description: Write access to the gateway-api repo
     members:
+    - mlavacca
     - robscott
     - shaneutt
     - youngnick

--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -165,7 +165,6 @@ teams:
   gateway-api-admins:
     description: Admin access to the gateway-api repo
     members:
-    - bowei
     - robscott
     - shaneutt
     - youngnick
@@ -177,7 +176,6 @@ teams:
   gateway-api-maintainers:
     description: Write access to the gateway-api repo
     members:
-    - bowei
     - robscott
     - shaneutt
     - youngnick


### PR DESCRIPTION
As per the [mailing list discussion](https://groups.google.com/g/kubernetes-sig-network/c/nFN64I33zUo), this adds @mlavacca as a Gateway API maintainer.

The project-specific PR for this update is https://github.com/kubernetes-sigs/gateway-api/pull/3231

This also removes bowei while we're in here, who was a historical maintainer but no longer an active one.