### PR TITLE
Temporarily elevate `maintainers-etcd` team permissions

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -38,7 +38,7 @@ teams:
     privacy: closed
     repos:
       dbtester: maintain
-      etcd: maintain
+      etcd: admin
       gofail: maintain
   maintainers-jetcd:
     description: Granted write access to jetcd


### PR DESCRIPTION
So that we can fix the branch protection settings for `etcd-io/etcd` as discussed in maintainer slack.

Permissions to be reverted to `maintain` via subsequent pr after updates made.

cc @serathius, @ahrtr, @wenjiaswe 