### PR TITLE
Revert "Temporarily elevate etcd maintainer permissions."

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -38,7 +38,7 @@ teams:
     privacy: closed
     repos:
       dbtester: maintain
-      etcd: admin
+      etcd: maintain
       gofail: maintain
   maintainers-jetcd:
     description: Granted write access to jetcd


### PR DESCRIPTION
This reverts commit 2c459d858f267575d2a0473fbcdcef82dbb9e7b0 as the needed GitHub settings tweaks have been applied so we can revert to least privilege permissions.

cc @wenjiaswe, @ahrtr, @serathius 