### PR TITLE
Add `rexagod` to `milestone-maintainers`

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -94,6 +94,7 @@ teams:
     - puerco # Release Manager
     - quinton-hoole # Multicluster
     - RainbowMango # Instrumentation
+    - rexagod # Instrumentation
     - ritazh # Auth
     - saad-ali # Storage
     - salaxander # Release Manager Associate / 1.29 RT EA


### PR DESCRIPTION
👋 Hello, I'd like to be able to use [certain commands](https://github.com/kubernetes/enhancements/issues/2305#issuecomment-1902271611), as well as edit descriptions for outstanding issues (that come under the SIG) in `k/enhancements` which have inactive author(s) who've left.

I believe adding myself to the `milestone-maintainers` list should address this.