### PR TITLE
Remove inactive member from etcd-io

### DIFF
--- a/config/etcd-io/org.yaml
+++ b/config/etcd-io/org.yaml
@@ -36,7 +36,6 @@ members:
 - justinsb
 - lavacat
 - lburgazzoli
-- mitake
 - nate-double-u
 - pav-kv
 - ptabor


### PR DESCRIPTION
This user hasn't accepted their invite to etcd-io in 7 months. Removing them from the file. They can re-apply for membership if needed at a later date.