### PR TITLE
Add jefftrojan to website maintainer team for release 1.32 shadow maintainers 

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -7,6 +7,7 @@ teams:
     - nate-double-u
     - onlydole
     - sftim
+    - jefftrojan
     privacy: closed
   sig-docs-de-owners:
     description: Approvers for German content


### PR DESCRIPTION
Adding to 1.32 Release Team Shadow  maintainers
/sig docs

/assign @onlydole  @sftim @nate-double-u