### PR TITLE
Update capi v1.9 release team members

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -350,22 +350,19 @@ teams:
     # members added in commented lines have a pending membership
     # and will be added back once it is acquired.
     - adilGhaffarDev
+    - cahillsf
     # - chandankumar4
-    - chiukapoor
-    # - dhij
-    - hackeramitkumar
     - jayesh-srivastava
-    # - kperath
-    # - meatballhat
-    # - Nivedita-coder
     - pravarag
     # - rajankumary2k
-    # - shipra101
-    # - smoshiur1237
-    # - Sunnatillo
-    - troy0820
+    - SD-13
+    # - serngawy
+    - sivchari
+    - Sunnatillo
+    # - tasdikrahman
+    - tormath1
+    # - varshasuryawanshi
     - vishalanarase
-    - willie-yao
     privacy: closed
   image-builder-admins:
     description: admin access to image-builder


### PR DESCRIPTION
New CAPI v1.9 RT members announced here: https://kubernetes.slack.com/archives/C8TSNPY4T/p1723216277709389

This PR removes old and adds new v1.9 RT members from/to the list in alphabetical order