### PR TITLE
Add dipesh-rawat to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -223,6 +223,7 @@ members:
 - DimpleRajaVamsi
 - dims
 - dipankardas011
+- dipesh-rawat
 - DiptoChakrabarty
 - DirectXMan12
 - displague


### PR DESCRIPTION

Adding myself _(`dipesh-rawat`)_ to the kubernetes-sigs org.

 I’m already a member of the Kubernetes organization.
https://github.com/kubernetes/org/blob/4dcd914f4c1b622d2c29e9123a7488ba205839a6/config/kubernetes/org.yaml#L286