### PR TITLE
Elevate etcd team permissions for release window

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -60,7 +60,7 @@ teams:
     privacy: closed
     repos:
       dbtester: maintain
-      etcd: maintain
+      etcd: admin
       gofail: maintain
   maintainers-jetcd:
     description: Granted write access to jetcd
@@ -151,4 +151,4 @@ teams:
     repos:
       # Permission set to triage during bau activities
       # During release windows this will be bumped to `maintain`
-      etcd: triage
+      etcd: maintain


### PR DESCRIPTION
Tomorrow we are releasing etcd v3.5.16.

Part of: https://github.com/etcd-io/etcd/issues/18485

Elevated permissions required as per https://github.com/etcd-io/etcd/blob/main/Documentation/contributor-guide/release.md#release-steps

Permissions will be returned to normal after release completed by a subsequent pr.

cc @serathius, @ahrtr, @ivanvc 