### PR TITLE
Add mcbenjemaa as cluster-api-ipam-provider-in-cluster maintainer

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -69,6 +69,13 @@ teams:
     privacy: closed
     repos:
       cluster-api-ipam-provider-in-cluster: admin
+  cluster-api-ipam-provider-in-cluster-maintainers:
+    description: "write access to cluster-api-ipam-provider-in-cluster"
+    members:
+    - mcbenjemaa
+    privacy: closed
+    repos:
+      cluster-api-ipam-provider-in-cluster: write
   cluster-api-operator-admins:
     description: "admin access to cluster-api-operator"
     members:


### PR DESCRIPTION
Adds a new maintainer group for the  k-sigs/cluster-api-ipam-provider-in-cluster repo to give write access to @mcbenjemaa.