### PR TITLE
Revert "Elevate etcd team permissions for release window"

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -60,7 +60,7 @@ teams:
     privacy: closed
     repos:
       dbtester: maintain
-      etcd: admin
+      etcd: maintain
       gofail: maintain
   maintainers-jetcd:
     description: Granted write access to jetcd
@@ -151,4 +151,4 @@ teams:
     repos:
       # Permission set to triage during bau activities
       # During release windows this will be bumped to `maintain`
-      etcd: maintain
+      etcd: triage


### PR DESCRIPTION
Reverts permissions now that the release of etcd `v3.5.16` and `v3.4.34` has been completed to return to bau least privilege settings.

cc @ahrtr, @ivanvc 

