### PR TITLE
sig-network: add gh teams for gwctl repo

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -55,6 +55,28 @@ teams:
     privacy: closed
     repos:
       cluster-proportional-vertical-autoscaler: write
+  gwctl-admins:
+    description: Admin access to the gwctl repo
+    members:
+    - gauravkghildiyal
+    - mlavacca
+    - robscott
+    - shaneutt
+    - youngnick
+    privacy: closed
+    repos:
+      gwctl: admin
+  gwctl-maintainers:
+    description: Write access to the gwctl repo
+    members:
+    - gauravkghildiyal
+    - mlavacca
+    - robscott
+    - shaneutt
+    - youngnick
+    privacy: closed
+    repos:
+      gwctl: write
   ip-masq-agent-admins:
     description: Admin access to the ip-masq-agent repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -259,6 +259,7 @@ restrictions:
     - "^blixt"
     - "^cluster-proportional-autoscaler"
     - "^cluster-proportional-vertical-autoscaler"
+    - "^gwctl"
     - "^ip-masq-agent"
     - "^external-dns"
     - "^ingress2gateway"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/5121

/assign @kubernetes/sig-network-leads 
/area github-repo

cc: @kubernetes/owners

