### PR TITLE
Add enhancements team for 1.32 to appropriate groups

### DIFF
--- a/config/kubernetes/sig-architecture/teams.yaml
+++ b/config/kubernetes/sig-architecture/teams.yaml
@@ -41,12 +41,17 @@ teams:
     - mrbobbytables # subproject owner
     members:
     - Atharva-Shinde # 1.28 RT Enhancements Lead
+    - dipesh-rawat # 1.32 Enhancements Shadow
+    - impact-maker # 1.32 Enhancements Shadow
+    - jenshu # 1.32 Enhancements Shadow
     - jeremyrickard # subproject owner
     - johnbelamaric # subproject owner
     - justaugustus # subproject owner
     - kikisdeliveryservice # subproject owner
     - LappleApple # subproject owner
     - salehsedghpour # 1.30 RT Enhancements Lead
+    - shecodesmagic # 1.32 Enhancements Shadow
+    - tjons # 1.32 Enhancements Lead
     privacy: closed
     teams:
       enhancements-admins:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -33,6 +33,7 @@ teams:
     - dchen1107 # Node
     - deads2k # API Machinery / Auth
     - derekwaynecarr # Architecture / Node
+    - dipesh-rawat # 1.32 Enhancements Shadow
     - dgrisonnet # Instrumentation
     - dims # Architecture / K8s Infra
     - drewhagen # 1.32 Release Signal Lead
@@ -49,11 +50,13 @@ teams:
     - gracenng # Release Manager Associate / 1.30 RT EA
     - haircommander # Node
     - Huang-Wei # Scheduling
+    - impact-maker # 1.32 Enhancements Shadow
     - janetkuo # Apps
     - jayunit100 # Windows
     - jberkus # Release
     - jbpratt # Testing
     - jdumars # Architecture / PM
+    - jenshu # 1.32 Enhancements Shadow
     - jeremyrickard # Release
     - jimangel # Docs / Release Manager Associate / 1.32 Release Branch Manager
     - johnbelamaric # Architecture
@@ -105,6 +108,7 @@ teams:
     - serathius # Instrumentation
     - SergeyKanzhelev # Node
     - shaneutt # Network
+    - shecodesmagic # 1.32 Enhancements Shadow
     - shu-mutou # UI
     - shyamjvs # Scalability
     - soltysh # CLI
@@ -283,9 +287,12 @@ teams:
         - Priyankasaggu11929 # subproject owner (1.29 RT Lead)
         members:
         - cpanato # subproject owner / Technical Lead
+        - dipesh-rawat # 1.32 Enhancements Shadow
         - fsmunoz # 1.32 Release Lead
         - gracenng # subproject owner (1.28 RT Lead)
+        - impact-maker # 1.32 Enhancements Shadow
         - jameslaverack # subproject owner (1.24 RT Lead)
+        - jenshu # 1.32 Enhancements Shadow
         - jeremyrickard # subproject owner / Technical Lead
         - jimangel # 1.32 RT Branch Manager
         - justaugustus # subproject owner / Chair
@@ -297,6 +304,7 @@ teams:
         - salaxander # subproject owner (1.27 RT Lead)
         - saschagrunert # subproject owner / Chair
         - savitharaghunathan # subproject owner (1.22 RT Lead)
+        - shecodesmagic # 1.32 Enhancements Shadow
         - tjons # 1.32 Enhancements Lead
         - Verolop # Release Manager
         - xmudrii # Release Manager
@@ -322,6 +330,10 @@ teams:
             description: Members of the Enhancments team for the current release
               cycle.
             members:
+            - dipesh-rawat # 1.32 Enhancements Shadow
+            - impact-maker # 1.32 Enhancements Shadow
+            - jenshu # 1.32 Enhancements Shadow
+            - shecodesmagic # 1.32 Enhancements Shadow
             - tjons # 1.32 Enhancements Lead
             privacy: closed
           release-team-release-notes:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -34,8 +34,8 @@ teams:
     - deads2k # API Machinery / Auth
     - derekwaynecarr # Architecture / Node
     - dgrisonnet # Instrumentation
-    - dipesh-rawat # 1.32 Enhancements Shadow
     - dims # Architecture / K8s Infra
+    - dipesh-rawat # 1.32 Enhancements Shadow
     - drewhagen # 1.32 Release Signal Lead
     - eddiezane # CLI
     - ehashman # Instrumentation

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -33,8 +33,8 @@ teams:
     - dchen1107 # Node
     - deads2k # API Machinery / Auth
     - derekwaynecarr # Architecture / Node
-    - dipesh-rawat # 1.32 Enhancements Shadow
     - dgrisonnet # Instrumentation
+    - dipesh-rawat # 1.32 Enhancements Shadow
     - dims # Architecture / K8s Infra
     - drewhagen # 1.32 Release Signal Lead
     - eddiezane # CLI


### PR DESCRIPTION
This PR adds the members of the enhancements team to the appropriate groups for their role. 

cc @fsmunoz @katcosgrove @gracenng