### PR TITLE
Add 1.32 RT Docs team to website milestone maintainers

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -352,16 +352,20 @@ teams:
     description: Contributors who can use `/milestone` in the website repo
     members:
     - a-mccarthy
+    - anshumantripathi # 1.32 RT Docs Shadow
     - bene2k1
     - bradtopol
+    - chanieljdan # 1.32 Docs Lead
     - divya-mohan0209
     - drewhagen # 1.31 RT Docs Lead temporary access for the release
     - femrtnz
     - girikuncoro
     - gochist
+    - hacktivist123 # 1.32 RT Docs Shadow
     - huynguyennovem
     - inductor
     - jcjesus
+    - michellengnx # 1.32 RT Docs Shadow
     - mickeyboxell
     - nasa9084
     - natalisucks
@@ -370,6 +374,7 @@ teams:
     - perriea
     - Princesso # 1.31 Docs Lead
     - raelga
+    - rdalbuquerque # 1.32 RT Docs Shadow
     - rekcah78
     - remyleone
     - reylejano
@@ -379,6 +384,7 @@ teams:
     - seokho-son
     - sftim
     - shurup
+    - spurin # 1.32 RT Docs Shadow
     - tanjunchen
     - tengqm
     - truongnh1992


### PR DESCRIPTION
Add 1.32 Docs Shadows to `website-milestone-maintainers` in sig-docs/teams.yaml