### PR TITLE
Remove fpetkovski from kube-state-metrics groups

### DIFF
--- a/config/kubernetes/sig-instrumentation/teams.yaml
+++ b/config/kubernetes/sig-instrumentation/teams.yaml
@@ -48,7 +48,6 @@ teams:
     members:
     - dashpole
     - dgrisonnet
-    - fpetkovski
     - logicalhan
     - mrueg
     - rexagod
@@ -59,7 +58,6 @@ teams:
     description: Write access to the kube-state-metrics repo
     members:
     - dgrisonnet
-    - fpetkovski
     - mrueg
     - rexagod
     privacy: closed


### PR DESCRIPTION
@fpetkovski became an emeritus maintainer a [while ago](https://github.com/kubernetes/kube-state-metrics/commit/dc679e1b3afc94005f1a99ec33cfdffec5ff13da), removing access to the repo here. 

CC: @rexagod @dgrisonnet @logicalhan @dashpole 