### PR TITLE
Add kmala to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -481,6 +481,7 @@ members:
 - KKtheGhost
 - klueska
 - KlwntSingh
+- kmala
 - kmova
 - knabben
 - knee-berts


### PR DESCRIPTION
I was already added to kubernetes org https://github.com/kubernetes/org/pull/5012 and want to join the kubernetes-sig 