### PR TITLE
updating Release Signal shadows

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -318,7 +318,7 @@ teams:
             members:
             - drewhagen # 1.32 Release Signal Lead
             - knabben # 1.32 Release Signal Shadow
-            - michaelfromyeg # 1.32 Release Signal Shadow
+            - SimonBaeumer # 1.32 Release Signal Shadow
             - tico88612 # 1.32 Release Signal Shadow
             - Vyom-Yadav # 1.32 Release Lead Shadow + Release Signal Temp
             - wendy-ha18 # 1.32 Release Signal Shadow


### PR DESCRIPTION
A release signal shadow has become completely inactive. I have worked with EAs/subproject leads @gracenng @katcosgrove to select a shadow who is eager to support us for the rest of the cycle.

This will help us continue load balancing our sub-team. Thanks for your help, we appreciate it!
cc: @fsmunoz