### PR TITLE
Update org membership – LappleApple

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -628,7 +628,6 @@ members:
 - lambdanis
 - landreasyan
 - lapee79
-- LappleApple
 - lauchokyip
 - lauralorenz
 - LaurentGoderre

--- a/config/kubernetes/sig-architecture/teams.yaml
+++ b/config/kubernetes/sig-architecture/teams.yaml
@@ -48,7 +48,6 @@ teams:
     - johnbelamaric # subproject owner
     - justaugustus # subproject owner
     - kikisdeliveryservice # subproject owner
-    - LappleApple # subproject owner
     - salehsedghpour # 1.30 RT Enhancements Lead
     - shecodesmagic # 1.32 Enhancements Shadow
     - tjons # 1.32 Enhancements Lead
@@ -63,7 +62,6 @@ teams:
         - johnbelamaric # subproject owner
         - justaugustus # subproject owner
         - kikisdeliveryservice # subproject owner
-        - LappleApple # subproject owner
         privacy: closed
         repos:
           enhancements: admin
@@ -76,7 +74,6 @@ teams:
         - johnbelamaric # subproject owner
         - justaugustus # subproject owner
         - kikisdeliveryservice # subproject owner
-        - LappleApple # subproject owner
         previously:
         - features-maintainers
         privacy: closed

--- a/config/kubernetes/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes/sig-contributor-experience/teams.yaml
@@ -97,7 +97,6 @@ teams:
     - jdumars
     - justaugustus
     - lachie83
-    - LappleApple
     privacy: closed
   sig-contributor-experience:
     description: Improve contributor productivity


### PR DESCRIPTION
Addressing failing peribolos CI jobs – https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-org-peribolos/1854208102841192448


Refer below slack thread, providing context and confirmation for org membership removal – https://kubernetes.slack.com/archives/C01672LSZL0/p1730967827429449?thread_ts=1730734412.432269&cid=C01672LSZL0


cc: @kubernetes/owners 