### PR TITLE
sig-network: add gh teams for cni-dra-driver repo

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -55,6 +55,22 @@ teams:
     privacy: closed
     repos:
       cluster-proportional-vertical-autoscaler: write
+  cni-dra-driver-admins:
+    description: Admin access to the cni-dra-driver repo
+    members:
+    - aojea
+    - LionelJouin
+    privacy: closed
+    repos:
+      cni-dra-driver: admin
+  cni-dra-driver-maintainers:
+    description: Admin access to the cni-dra-driver epo
+    members:
+    - aojea
+    - LionelJouin
+    privacy: closed
+    repos:
+      cni-dra-driver: write
   gwctl-admins:
     description: Admin access to the gwctl repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -260,6 +260,7 @@ restrictions:
     - "^blixt"
     - "^cluster-proportional-autoscaler"
     - "^cluster-proportional-vertical-autoscaler"
+    - "^cni-dra-driver"
     - "^gwctl"
     - "^ip-masq-agent"
     - "^external-dns"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5228

/assign @kubernetes/sig-network-leads 

cc: @kubernetes/owners 