### PR TITLE
Add maintainer into kubectl-validate repo

### DIFF
--- a/config/kubernetes-sigs/sig-cli/teams.yaml
+++ b/config/kubernetes-sigs/sig-cli/teams.yaml
@@ -94,6 +94,7 @@ teams:
     members:
     - alexzielenski
     - apelisse
+    - cici37
     privacy: closed
     repos:
       kubectl-validate: admin
@@ -102,6 +103,7 @@ teams:
     members:
     - alexzielenski
     - apelisse
+    - cici37
     privacy: closed
     repos:
       kubectl-validate: write


### PR DESCRIPTION
The existing maintainers for repo kubectl-validate have all switched jobs and add maintainer to maintain the repo and cut release for existing customers.