### PR TITLE
Sync CAPZ admins with Azure provider project

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -118,6 +118,7 @@ teams:
     - jackfrancis
     - Jont828
     - mboersma
+    - nawazkh
     - nojnhuh
     - willie-yao
     privacy: closed
@@ -129,6 +130,7 @@ teams:
     - jackfrancis
     - Jont828
     - mboersma
+    - nawazkh
     - nojnhuh
     - willie-yao
     privacy: closed


### PR DESCRIPTION
Syncs up with recent changes to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

Specifically, moves @nawazkh to maintainers / admins.

/cc @jackfrancis @Jont828 @nojnhuh @willie-yao