### PR TITLE
Revert "Elevate etcd team permissions for release window."

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -60,7 +60,7 @@ teams:
     privacy: closed
     repos:
       dbtester: maintain
-      etcd: admin
+      etcd: maintain
       gofail: maintain
   maintainers-jetcd:
     description: Granted write access to jetcd
@@ -152,4 +152,4 @@ teams:
     repos:
       # Permission set to triage during bau activities
       # During release windows this will be bumped to `maintain`
-      etcd: maintain
+      etcd: triage


### PR DESCRIPTION


We released today etcd v3.5.17 and v3.4.35. So we can remove the elevated permissions.

Part of:
* etcd-io/etcd#18845
* etcd-io/etcd#18846

Elevated permissions required as per https://github.com/etcd-io/etcd/blob/main/Documentation/contributor-guide/release.md#release-steps

This reverts commit b80bfcfcf6b7410909cf719a6e95ba37b08db56a.

/cc @serathius, @ahrtr, @jmhbnz 
/hold (@jmhbnz, please ensure branch protection is enabled again)