### PR TITLE
update sig-cloud-provider owners and leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,11 +27,9 @@ aliases:
     - mpuckett159
     - soltysh
   sig-cloud-provider-leads:
-    - andrewsykim
     - bridgetkromhout
     - cheftako
     - elmiko
-    - nckturner
   sig-cluster-lifecycle-leads:
     - fabriziopandini
     - justinsb

--- a/config/kubernetes/sig-cloud-provider/teams.yaml
+++ b/config/kubernetes/sig-cloud-provider/teams.yaml
@@ -2,11 +2,9 @@ teams:
   sig-cloud-provider:
     description: Parent Team for SIG Cloud Provider
     members:
-    - andrewsykim
+    - bridgetkromhout
     - cheftako
-    - justaugustus
-    - nckturner
-    - yastij
+    - elmiko
     privacy: closed
     teams:
       cloud-provider-sample-admins:
@@ -59,43 +57,58 @@ teams:
       sig-cloud-provider-api-reviews:
         description: ""
         members:
-        - andrewsykim
+        - bridgetkromhout
+        - cheftako
+        - elmiko
         privacy: closed
       sig-cloud-provider-bugs:
         description: ""
         members:
-        - andrewsykim
+        - bridgetkromhout
+        - cheftako
+        - elmiko
         privacy: closed
       sig-cloud-provider-feature-requests:
         description: ""
         members:
-        - andrewsykim
+        - bridgetkromhout
+        - cheftako
+        - elmiko
         privacy: closed
       sig-cloud-provider-misc:
         description: ""
         members:
-        - andrewsykim
+        - bridgetkromhout
+        - cheftako
+        - elmiko
         privacy: closed
       sig-cloud-provider-pr-reviews:
         description: ""
         members:
-        - andrewsykim
-        - nckturner
+        - bridgetkromhout
+        - cheftako
+        - elmiko
         privacy: closed
       sig-cloud-provider-proposals:
         description: ""
         members:
-        - andrewsykim
+        - bridgetkromhout
+        - cheftako
+        - elmiko
         privacy: closed
       sig-cloud-provider-test-failures:
         description: ""
         members:
-        - andrewsykim
+        - bridgetkromhout
+        - cheftako
+        - elmiko
         privacy: closed
   sig-cloud-provider-admins:
     description: ""
     members:
-    - andrewsykim
+    - bridgetkromhout
+    - cheftako
+    - elmiko
     privacy: closed
     repos:
       cloud-provider: admin
@@ -103,7 +116,7 @@ teams:
   sig-cloud-provider-leads:
     description: ""
     members:
-    - andrewsykim
+    - bridgetkromhout
     - cheftako
-    - nckturner
+    - elmiko
     privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -11,7 +11,6 @@ teams:
     - ahg-g # Scheduling
     - alculquicondor # Scheduling
     - ameukam # Release Manager Associate / K8s Infra
-    - andrewsykim # Cloud Provider
     - aojea # Testing / Network
     - aravindhp # Windows
     - ardaguclu # CLI
@@ -88,7 +87,6 @@ teams:
     - mpuckett159 # CLI
     - mrunalp # Node
     - msau42 # Storage
-    - nckturner # AWS
     - neolit123 # Cluster Lifecycle
     - npolshakova # 1.32 Release Lead Shadow
     - pacoxu # Cluster Lifecycle


### PR DESCRIPTION
this change brings the sig cloud-provider leads information up to date. Andrew Sy Kim and Nick Turner have become emeritus leads, and as such we are removing them from the day-to-day duties related to the leads positions. similarly we are also putting Bridget Kromhout, Walter Fender, and Michael McCune as the current contacts.

this is in support of https://github.com/kubernetes/community/issues/7865

this is a continuation of #4964 

/sig cloud-provider

cc @bridgetkromhout @cheftako @nckturner @andrewsykim 