### PR TITLE
sig-storage: remove container-object-storage-interface-api gh teams

### DIFF
--- a/config/kubernetes-sigs/sig-storage/teams.yaml
+++ b/config/kubernetes-sigs/sig-storage/teams.yaml
@@ -21,27 +21,6 @@ teams:
     privacy: closed
     repos:
       container-object-storage-interface: write
-  container-object-storage-interface-api-admins:
-    description: Admin access to container-object-storage-interface-api
-    members:
-    - jsafrane
-    - msau42
-    - saad-ali
-    - xing-yang
-    privacy: closed
-    repos:
-      container-object-storage-interface-api: admin
-  container-object-storage-interface-api-maintainers:
-    description: Write access to container-object-storage-interface-api
-    members:
-    - jsafrane
-    - msau42
-    - saad-ali
-    - wlan0
-    - xing-yang
-    privacy: closed
-    repos:
-      container-object-storage-interface-api: write
   cosi-driver-sample-admins:
     description: Admin access to cosi-driver-sample
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -311,7 +311,6 @@ restrictions:
   - path: "kubernetes-sigs/sig-storage/teams.yaml"
     allowedRepos:
     - "^container-object-storage-interface"
-    - "^container-object-storage-interface-api"
     - "^cosi-driver-sample"
     - "^gcp-compute-persistent-disk-csi-driver"
     - "^gcp-filestore-csi-driver"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5238

cc: @kubernetes/owners

/assign @kubernetes/sig-storage-leads