### PR TITLE
Add Kubermatic to apisnoop and verify-conformance repos

### DIFF
--- a/config/kubernetes-sigs/sig-architecture/teams.yaml
+++ b/config/kubernetes-sigs/sig-architecture/teams.yaml
@@ -17,6 +17,9 @@ teams:
     - cooldracula
     - heyste
     - hh
+    - koksay
+    - mfahlandt
+    - xmudrii
     privacy: closed
     repos:
       apisnoop: admin
@@ -27,6 +30,9 @@ teams:
     - cooldracula
     - heyste
     - hh
+    - koksay
+    - mfahlandt
+    - xmudrii
     privacy: closed
     repos:
       apisnoop: write
@@ -36,6 +42,9 @@ teams:
     - BobyMCbobs
     - heyste
     - hh
+    - koksay
+    - mfahlandt
+    - xmudrii
     privacy: closed
     repos:
       verify-conformance: admin


### PR DESCRIPTION
Admin access is needed to maintain Kubernetes conformance on these 2 repos:

- apisnoop
- verify-conformace

Fyi: @mfahlandt @xmudrii @jeefy 

/cc @BobyMCbobs 
