### PR TITLE
k-sigs: rename and move inference project from sig-apps to sig-net

### DIFF
--- a/config/kubernetes-sigs/sig-apps/teams.yaml
+++ b/config/kubernetes-sigs/sig-apps/teams.yaml
@@ -46,16 +46,6 @@ teams:
     privacy: closed
     repos:
       kjob: write
-  llm-instance-gateway-admins:
-    description: Admin access to llm-instance-gateway repo
-    members:
-    - ArangoGutierrez
-    - Jeffwan
-    - SergeyKanzhelev
-    - terrytangyuan
-    privacy: closed
-    repos:
-      llm-instance-gateway: admin
   lws-admins:
     description: Admin access to lws repo
     members:

--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -221,6 +221,16 @@ teams:
     privacy: closed
     repos:
       iptables-wrappers: write
+  gateway-api-inference-extension-admins:
+    description: Admin access to gateway-api-inference-extension
+    members:
+    - ArangoGutierrez
+    - Jeffwan
+    - SergeyKanzhelev
+    - terrytangyuan
+    privacy: closed
+    repos:
+      gateway-api-inference-extension: admin
   gateway-api-admins:
     description: Admin access to the gateway-api repo
     members:


### PR DESCRIPTION
Ref https://github.com/kubernetes/org/issues/5302 and https://github.com/kubernetes/community/pull/8211