### PR TITLE
Add mtardy to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -623,6 +623,7 @@ members:
 - msau42
 - mskanth972
 - mszadkow
+- mtardy
 - mtaufen
 - mtougeron
 - mtulio


### PR DESCRIPTION
I'm pushing some patches to kubernetes-sigs repo these days https://github.com/kubernetes-sigs/controller-tools/pull/1122#issuecomment-2572903244.