### PR TITLE
Create team directory for provider-gcp and update group members

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -186,7 +186,10 @@ aliases:
     - feiskyer
     - khenidak
   provider-gcp:
-    - abgworrall
+    - aojea
+    - bowei
+    - thockin
+    - wojtek-t
   provider-ibmcloud:
     - spzala
   provider-openstack:

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1333,29 +1333,6 @@ teams:
     privacy: closed
     repos:
       client-go: write
-  cloud-provider-gcp-admins:
-    description: Admin access to cloud-provider-gcp repo
-    members:
-    - aojea
-    - bowei
-    - thockin
-    - wojtek-t
-    privacy: closed
-    repos:
-      cloud-provider-gcp: admin
-  cloud-provider-gcp-maintainers:
-    description: Write access to cloud-provider-gcp repo
-    members:
-    - aojea
-    - cheftako
-    - cici37
-    - jpbetz
-    - jprzychodzen
-    - mskrocki
-    - sdmodi
-    privacy: closed
-    repos:
-      cloud-provider-gcp: write
   cloud-provider-vsphere-admins:
     description: Admin access to cloud-provider-vsphere repo
     members:

--- a/config/kubernetes/provider-gcp/OWNERS
+++ b/config/kubernetes/provider-gcp/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - provider-gcp
+approvers:
+  - provider-gcp
+labels:
+  - sig/cloud-provider
+  - area/provider/gcp

--- a/config/kubernetes/provider-gcp/teams.yaml
+++ b/config/kubernetes/provider-gcp/teams.yaml
@@ -1,0 +1,24 @@
+teams:
+  cloud-provider-gcp-admins:
+    description: Admin access to cloud-provider-gcp repo
+    members:
+    - aojea
+    - bowei
+    - thockin
+    - wojtek-t
+    privacy: closed
+    repos:
+      cloud-provider-gcp: admin
+  cloud-provider-gcp-maintainers:
+    description: Write access to cloud-provider-gcp repo
+    members:
+    - aojea
+    - cheftako
+    - cici37
+    - jpbetz
+    - jprzychodzen
+    - mmamczur
+    - mskrocki
+    privacy: closed
+    repos:
+      cloud-provider-gcp: write

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -54,6 +54,9 @@ restrictions:
     - "^perf-tests"
     - "^steering"
     - "^utils"
+  - path: "kubernetes/provider-gcp/teams.yaml"
+    allowedRepos:
+    - "^cloud-provider-gcp"
   - path: "kubernetes/provider-openstack/teams.yaml"
     allowedRepos:
     - "^cloud-provider-openstack"


### PR DESCRIPTION
Create team directory for provider-gcp and move cloud-provider-gcp-* groups there.

Also:
- remove @sdmodi who left the GKE team.
- add @mmamczur, member of the team that owns service controller part of cloupd-provider-gcp
- update OWNER_ALIASES, add a few people as OWNERS, remove @abgworrall since he is no longer at Google