### PR TITLE
Add sig-autoscaling-milestone-maintainers

### DIFF
--- a/config/kubernetes/sig-autoscaling/teams.yaml
+++ b/config/kubernetes/sig-autoscaling/teams.yaml
@@ -92,3 +92,4 @@ teams:
     - omerap12
     - raywainman
     - voelzmo
+    privacy: closed

--- a/config/kubernetes/sig-autoscaling/teams.yaml
+++ b/config/kubernetes/sig-autoscaling/teams.yaml
@@ -84,3 +84,11 @@ teams:
     - gjtempleton
     - maciekpytel
     privacy: closed
+  sig-autoscaling-milestone-maintainers:
+    description: Contributors who can use `/milestone` in the autoscaling repo
+    members:
+    - adrianmoisey
+    - kwiesmueller
+    - omerap12
+    - raywainman
+    - voelzmo


### PR DESCRIPTION
The VPA project would like to start using milestones to track PRs and issues for review. In order to do so we need access to manage milestones.

cc'ing @gjtempleton, who is the chair of sig-autoscaling

Note: I'm unsure if this is the correct process, please point me in the right direction if it is not