### PR TITLE
Cleanup SIG Docs teams.yaml after 1.32 release and prepare for 1.33 release

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -315,7 +315,6 @@ teams:
     - a-mccarthy # Localization subproject owner
     - bells17 # L10n: Japanese
     - bradtopol # L10n: English
-    - chanieljdan # 1.32 temporary release docs lead access
     - devlware # L10: Portuguese
     - divya-mohan0209 # L10n: English
     - femrtnz # L10n: Portuguese
@@ -354,29 +353,23 @@ teams:
     description: Contributors who can use `/milestone` in the website repo
     members:
     - a-mccarthy
-    - anshumantripathi # 1.32 RT Docs Shadow
     - bene2k1
     - bradtopol
-    - chanieljdan # 1.32 Docs Lead
     - divya-mohan0209
-    - drewhagen # 1.31 RT Docs Lead temporary access for the release
     - femrtnz
     - girikuncoro
     - gochist
-    - hacktivist123 # 1.32 RT Docs Shadow
     - huynguyennovem
     - inductor
     - jcjesus
-    - michellengnx # 1.32 RT Docs Shadow
     - mickeyboxell
     - nasa9084
     - natalisucks
     - nate-double-u
     - onlydole
     - perriea
-    - Princesso # 1.31 Docs Lead
     - raelga
-    - rdalbuquerque # 1.32 RT Docs Shadow
+    - rayandas # 1.33 Docs Lead
     - rekcah78
     - remyleone
     - reylejano
@@ -386,7 +379,6 @@ teams:
     - seokho-son
     - sftim
     - shurup
-    - spurin # 1.32 RT Docs Shadow
     - tanjunchen
     - tengqm
     - truongnh1992


### PR DESCRIPTION
This is a cleanup PR for the SIG Docs' teams.yaml after the 1.32 release:
- remove 1.32 release team docs lead from website maintainers
- remove prior release team members from website milestone maintainers
- add the 1.33 release team docs lead as a website milestone maintainer

See https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/docs/Release-Timeline.md#clean-up-access for cleanup tasks

cc @chendave @rayandas 