### PR TITLE
etcd: allow etcd-operator triage permission for etcd members

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -131,6 +131,7 @@ teams:
       bbolt: triage
       dbtester: triage
       etcd: triage
+      etcd-operator: triage
       gofail: triage
       raft: triage
       website: triage


### PR DESCRIPTION
As spotted on https://github.com/etcd-io/etcd-operator/issues/43, the etcd members don't have triage permissions on the etcd-operator repository.

Would this be okay? Or do we want to keep the etcd-operator repository with more independence, and add a new team that has triage permissions?