### PR TITLE
fix: update sig-scheduling-misc team

### DIFF
--- a/config/kubernetes/sig-scheduling/teams.yaml
+++ b/config/kubernetes/sig-scheduling/teams.yaml
@@ -6,11 +6,13 @@ teams:
     members:
     - ahg-g
     - alculquicondor
-    - chendave
+    - AxeZhan
     - damemi
     - denkensk
+    - dom4ha
     - Huang-Wei
     - kerthcet
+    - macsko
     - sanposhiho
     privacy: closed
   sig-scheduling-approvers:


### PR DESCRIPTION
This PR updates sig-scheduling-misc team members based on the current reviewers/approvers:
https://github.com/kubernetes/kubernetes/blob/master/OWNERS_ALIASES

I added @dom4ha as well since I think will join the list soon ;)