### PR TITLE
sig-network: add github teams for nat64 repo

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -303,6 +303,24 @@ teams:
     privacy: closed
     repos:
       multi-network-api: admin
+  nat64-admins:
+    description: Admin access to the nat64 repo
+    members:
+    - aojea
+    - danwinship
+    - thockin
+    privacy: closed
+    repos:
+      nat64: admin
+  nat64-maintainers:
+    description: Write access to the nat64 repo
+    members:
+    - aojea
+    - danwinship
+    - thockin
+    privacy: closed
+    repos:
+      nat64: write
   network-policy-api-admins:
     description: Admin access to the network-policy-api repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -274,6 +274,7 @@ restrictions:
     - "^kube-network-policies"
     - "^multi-network"
     - "^multi-network-api"
+    - "^nat64"
     - "^network-policy-api"
     - "^node-ipam-controller"
   - path: "kubernetes-sigs/sig-node/teams.yaml"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/5299

cc: @kubernetes/owners 

/assign @kubernetes/sig-network-leads 