### PR TITLE
Update gw-inference-extension admins to match maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -222,10 +222,10 @@ teams:
   gateway-api-inference-extension-admins:
     description: Admin access to gateway-api-inference-extension
     members:
-    - ArangoGutierrez
-    - Jeffwan
-    - SergeyKanzhelev
-    - terrytangyuan
+    - ahg-g
+    - danehans
+    - jeffwan
+    - kfswain
     privacy: closed
     repos:
       gateway-api-inference-extension: admin


### PR DESCRIPTION
Updating github admins to match the list of maintainers created here: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/203