### PR TITLE
Add Enhancements team for 1.33 to appropriate groups

### DIFF
--- a/config/kubernetes/sig-architecture/teams.yaml
+++ b/config/kubernetes/sig-architecture/teams.yaml
@@ -40,16 +40,18 @@ teams:
     maintainers:
     - mrbobbytables # subproject owner
     members:
+    - ArkaSaha30 # 1.33 Enhancements Shadow
     - Atharva-Shinde # 1.28 RT Enhancements Lead
-    - dipesh-rawat # 1.32 Enhancements Shadow
-    - jenshu # 1.32 Enhancements Shadow
+    - bianbbc87 # 1.33 Enhancements Shadow
+    - dipesh-rawat # 1.33 Enhancements Lead
+    - fykaa # 1.33 Enhancements Shadow
+    - jenshu # 1.33 Enhancements Shadow
     - jeremyrickard # subproject owner
     - johnbelamaric # subproject owner
     - justaugustus # subproject owner
     - kikisdeliveryservice # subproject owner
+    - lzung # 1.33 Enhancements Shadow
     - salehsedghpour # 1.30 RT Enhancements Lead
-    - shecodesmagic # 1.32 Enhancements Shadow
-    - tjons # 1.32 Enhancements Lead
     privacy: closed
     teams:
       enhancements-admins:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -14,8 +14,10 @@ teams:
     - aojea # Testing / Network
     - aravindhp # Windows
     - ardaguclu # CLI
+    - ArkaSaha30 # 1.33 Enhancements Shadow
     - BenTheElder # Testing / K8s Infra
     - bgrant0607 # Architecture
+    - bianbbc87 # 1.33 Enhancements Shadow
     - brancz # Instrumentation
     - bridgetkromhout # Cloud Provider
     - cantbewong # VMware
@@ -44,6 +46,7 @@ teams:
     - floreks # UI
     - frapposelli # VMware
     - fsmunoz # 1.32 Release Lead
+    - fykaa # 1.33 Enhancements Shadow
     - gjtempleton # Autoscaling
     - gracenng # Release Manager Associate / 1.30 RT EA
     - haircommander # Node
@@ -53,7 +56,7 @@ teams:
     - jberkus # Release
     - jbpratt # Testing
     - jdumars # Architecture / PM
-    - jenshu # 1.32 Enhancements Shadow
+    - jenshu # 1.33 Enhancements Shadow
     - jeremyrickard # Release
     - jimangel # Docs / Release Manager Associate / 1.32 Release Branch Manager
     - johnbelamaric # Architecture
@@ -73,6 +76,7 @@ teams:
     - lingxiankong # OpenStack
     - logicalhan # Instrumentation
     - luxas # Cluster Lifecycle
+    - lzung # 1.33 Enhancements Shadow
     - maciaszczykm # UI
     - maciekpytel # Autoscaling
     - marosset # Windows
@@ -334,7 +338,12 @@ teams:
             description: Members of the Enhancements team for the current release
               cycle.
             members:
+            - ArkaSaha30 # 1.33 Enhancements Shadow
+            - bianbbc87 # 1.33 Enhancements Shadow
             - dipesh-rawat # 1.33 Enhancements Lead
+            - fykaa # 1.33 Enhancements Shadow
+            - jenshu # 1.33 Enhancements Shadow
+            - lzung # 1.33 Enhancements Shadow
             privacy: closed
           release-team-leads:
             description: Release Team Leads for the current Kubernetes release


### PR DESCRIPTION
This PR adds the members of the 1.33 Enhancements team to the appropriate groups for their role.

cc @npolshakova @neoaggelos @katcosgrove @gracenng