### PR TITLE
add dims to etcd-io

### DIFF
--- a/config/etcd-io/org.yaml
+++ b/config/etcd-io/org.yaml
@@ -20,6 +20,7 @@ members:
 - cenkalti
 - chalin
 - chaochn47
+- dims
 - eduartua
 - elbehery
 - erikgrinaker


### PR DESCRIPTION
Is kubernetes/kubernetes-sigs github org membership enough to be added here in etcd-io github org? if so, please add me as well. 

thanks!