### PR TITLE
add sttts to sig-api-machinery-leads

### DIFF
--- a/config/kubernetes/sig-api-machinery/teams.yaml
+++ b/config/kubernetes/sig-api-machinery/teams.yaml
@@ -114,4 +114,5 @@ teams:
     - deads2k
     - fedebongio
     - jpbetz
+    - sttts
     privacy: closed


### PR DESCRIPTION
I noticed the discrepancy when going to ping on https://github.com/kubernetes/test-infra/pull/34210

cc @sttts @kubernetes/sig-api-machinery-leads 