### PR TITLE
Add ianychoi to sig-docs-ko-*

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -154,6 +154,7 @@ teams:
     description: Approvers for Korean content
     members:
     - gochist
+    - ianychoi
     - jihoon-seo
     - seokho-son
     - ysyukr
@@ -162,6 +163,7 @@ teams:
     description: Reviews for Korean docs PRs
     members:
     - gochist
+    - ianychoi
     - jihoon-seo
     - jmyung
     - jongwooo


### PR DESCRIPTION
I'd like to re-apply for sig-docs-ko-owners & sig-docs-ko-reviews role.

I had sig-docs-ko-owners & sig-docs-ko-reviews roles by 2023.
After stabilizing some personal status through 2025(moving job position), I would like to re-apply for the roles to facilitate Korean L10n progress.

Thank you for the discussion @seokho-son , and appreciate so much in advance if you are supportive on this PR.

Note that this PR aligns with https://github.com/kubernetes/website/pull/49551 