### PR TITLE
issue-templates: clarify org membership equivalence criteria

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.yml
+++ b/.github/ISSUE_TEMPLATE/membership.yml
@@ -6,7 +6,7 @@ body:
 - type: markdown
   attributes:
     value: |
-      Thank you for filling out this membership request! Please note, if you are already part of any Kubernetes GitHub organization like kubernetes-sigs and you are filing this request to be added to kubernetes, you do not need to open this request and can add yourself directly! The org memberships are now equivalent and sponsorship is not needed to join additional Kubernetes GitHub orgs.
+      Thank you for filling out this membership request! Please note, if you are already part of any Kubernetes GitHub organization like kubernetes-sigs and you are filing this request to be added to kubernetes, you do not need to open this request and can add yourself directly! The org memberships are now equivalent and sponsorship is not needed to join additional Kubernetes GitHub orgs. This includes the etcd-io organization as well.
 - id: github
   type: input
   attributes:


### PR DESCRIPTION
It's been a while since we have implemented org membership equivalence across Kubernetes GitHub organizations. Recently, we also inherited the https://github.com/etcd-io organization and it is now part of the Kubernetes managed GitHub organizations. The organization equivalence equally applies to the members of etcd-io org and vice-versa. This PR clarifies that by adding a short note to the issue template.

/cc @kubernetes/owners 

Signed-off-by: Nabarun Pal <pal.nabarun95@gmail.com>
