### PR TITLE
sig-storage: sync team members & OWNERS of external-snapshot-metadata

### DIFF
--- a/config/kubernetes-csi/org.yaml
+++ b/config/kubernetes-csi/org.yaml
@@ -546,7 +546,7 @@ teams:
   external-snapshot-metadata-admins:
     description: Admin access to external-snapshot-metadata repo
     members:
-    - ihcsim
+    - carlbraganza
     - jsafrane
     - msau42
     - saad-ali
@@ -557,9 +557,13 @@ teams:
   external-snapshot-metadata-maintainers:
     description: Write access to external-snapshot-metadata repo
     members:
+    - carlbraganza
+    - hairyhum
     - ihcsim
     - jsafrane
     - msau42
+    - PrasadG193
+    - rakshith-r
     - saad-ali
     - xing-yang
     privacy: closed


### PR DESCRIPTION
This commit syncs external-snapshot-metadata repo OWNERS with the corresponding external-snapshot-metadata-maintainers and external-snapshot-metadata-admins teams.

This is required in order for the missing members to be able to create release branches and tag releases.

refer:
- https://github.com/kubernetes-csi/external-snapshot-metadata/blob/main/OWNERS
- https://github.com/orgs/kubernetes-csi/teams/external-snapshot-metadata-maintainers
- https://github.com/orgs/kubernetes-csi/teams/external-snapshot-metadata-admins
- https://github.com/kubernetes/org/issues/4874