### PR TITLE
Add tonyzhc to kubernetes-sigs/sig-storage/gcp-compute-persistent-disk-csi-driver org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -930,6 +930,7 @@ members:
 - tobiasgiese
 - tokt
 - tomasaschan
+- tonyzhc
 - tormath1
 - torredil
 - tpantelis

--- a/config/kubernetes-sigs/sig-storage/teams.yaml
+++ b/config/kubernetes-sigs/sig-storage/teams.yaml
@@ -55,6 +55,7 @@ teams:
     - saad-ali
     - saikat-royc
     - songjiaxun
+    - tonyzhc
     - tyuchn
     privacy: closed
     repos:
@@ -73,6 +74,7 @@ teams:
     - sneha-at
     - songjiaxun
     - sunnylovestiramisu
+    - tonyzhc
     - tyuchn
     privacy: closed
     repos:


### PR DESCRIPTION
This add write permissions for @tonyzhc to [gcp-compute-persistent-disk-csi-driver](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver).