### PR TITLE
Revert "Elevate etcd team permissions for release window."

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -60,7 +60,7 @@ teams:
     privacy: closed
     repos:
       dbtester: maintain
-      etcd: admin
+      etcd: maintain
       gofail: maintain
   maintainers-jetcd:
     description: Granted write access to jetcd
@@ -167,4 +167,4 @@ teams:
     repos:
       # Permission set to triage during bau activities
       # During release windows this will be bumped to `maintain`
-      etcd: maintain
+      etcd: triage


### PR DESCRIPTION
With v3.6.0-rc.0 done, we can remove the elevated permissions.

This reverts commit 04a5ce869d72c7c72a4e486cdef958d102c80be8.

/cc @ahrtr 