### PR TITLE
etcd: Update release-etcd team

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -60,7 +60,7 @@ teams:
     privacy: closed
     repos:
       dbtester: maintain
-      etcd: admin
+      etcd: maintain
       gofail: maintain
   maintainers-jetcd:
     description: Granted write access to jetcd
@@ -167,4 +167,4 @@ teams:
     repos:
       # Permission set to triage during bau activities
       # During release windows this will be bumped to `maintain`
-      etcd: maintain
+      etcd: triage

--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -154,17 +154,9 @@ teams:
           website: triage
   release-etcd:
     description: Granted permission to release etcd-io/etcd
-    members:
-      - ahrtr
-      - fuweid
-      - ivanvc
-      - jmhbnz
-      - serathius
-      - siyuanfoundation
-      - spzala
-      - wenjiaswe
+    # The member list is intentionally empty. It should only include the release
+    # lead during release windows.
+    members: []
     privacy: closed
     repos:
-      # Permission set to triage during bau activities
-      # During release windows this will be bumped to `maintain`
-      etcd: triage
+      etcd: maintain


### PR DESCRIPTION
* De-elevate permissions, as we pushed the v3.4.36 release one week.
* Update the release-etcd team to align with the change in the release process (https://github.com/etcd-io/etcd/pull/19450).