### PR TITLE
etcd: Update release-etcd team for release window

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -156,7 +156,8 @@ teams:
     description: Granted permission to release etcd-io/etcd
     # The member list is intentionally empty. It should only include the release
     # lead during release windows.
-    members: []
+    members:
+    - ivanvc
     privacy: closed
     repos:
       etcd: maintain


### PR DESCRIPTION
In preparation for v3.4.36 and v3.6.0-rc.1 releases. Setting the group with me as the only team member to test the new workflow.

/cc @jmhbnz 