### PR TITLE
Revert "etcd: Update release-etcd team for release window"

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -156,8 +156,7 @@ teams:
     description: Granted permission to release etcd-io/etcd
     # The member list is intentionally empty. It should only include the release
     # lead during release windows.
-    members:
-    - ivanvc
+    members: []
     privacy: closed
     repos:
       etcd: maintain


### PR DESCRIPTION
Returning the `release-etcd` team members to its empty state after releasing v3.4.36 and v3.6.0-rc.1.

/cc @jmhbnz 

This reverts commit dc557c3c244f2bd278fe026f50877dbab5717bfe.