### PR TITLE
sig-contribex: remove sigs-github-actions teams for repo archival

### DIFF
--- a/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
@@ -97,28 +97,6 @@ teams:
         members:
         - kaslin
         privacy: closed
-  sigs-github-actions-admins:
-    description: admin access to the sigs-github-actions repo
-    maintainers:
-    - cblecker
-    - MadhavJivrajani
-    - mrbobbytables
-    - nikhita
-    - palnabarun
-    - Priyankasaggu11929
-    privacy: closed
-    repos:
-      sigs-github-actions: admin
-  sigs-github-actions-maintainers:
-    description: write access to the sigs-github-actions repo
-    maintainers:
-    - cblecker
-    - MadhavJivrajani
-    - nikhita
-    - Priyankasaggu11929
-    privacy: closed
-    repos:
-      sigs-github-actions: write
   slack-infra-admins:
     description: admin access to slack-infra
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -227,7 +227,6 @@ restrictions:
     - "^discuss-theme"
     - "^lwkd"
     - "^maintainers"
-    - "^sigs-github-actions"
     - "^slack-infra"
   - path: "kubernetes-sigs/sig-docs/teams.yaml"
     allowedRepos:


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/5397

/assign @kubernetes/sig-contributor-experience-leads 

cc: @kubernetes/owners