### PR TITLE
sig-network: add github teams for network-policy-finalizer repo

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -334,6 +334,24 @@ teams:
     privacy: closed
     repos:
       network-policy-api: admin
+  network-policy-finalizer-admins:
+    description: Admin access to the network-policy-finalizer repo
+    members:
+    - aojea
+    - danwinship
+    - thockin
+    privacy: closed
+    repos:
+      network-policy-finalizer: admin
+  network-policy-finalizer-maintainers:
+    description: Write access to the network-policy-finalizer repo
+    members:
+    - aojea
+    - danwinship
+    - thockin
+    privacy: closed
+    repos:
+      network-policy-finalizer: write
   node-ipam-controller-admins:
     description: Admin access to the node-ipam-controller repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -280,6 +280,7 @@ restrictions:
     - "^multi-network-api"
     - "^nat64"
     - "^network-policy-api"
+    - "^network-policy-finalizer"
     - "^node-ipam-controller"
   - path: "kubernetes-sigs/sig-node/teams.yaml"
     allowedRepos:


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5433

/assign @kubernetes/sig-network-leads 

cc: @kubernetes/owners