### PR TITLE
Give maintainers-website permissions for etcd-io/protodoc

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -97,6 +97,7 @@ teams:
     privacy: closed
     repos:
       website: admin
+      protodoc: admin
   maintainers-labs:
     description: Granted write access to etcdlabs
     members:


### PR DESCRIPTION
So that we can maintain the proto docs that get generated and hosted on https://etcd.io

cc @ahrtr, @serathius, @ivanvc 