### PR TITLE
sig-testing: add gh teams for randfill repo

### DIFF
--- a/config/kubernetes-sigs/sig-testing/teams.yaml
+++ b/config/kubernetes-sigs/sig-testing/teams.yaml
@@ -125,6 +125,32 @@ teams:
     privacy: closed
     repos:
       prow: write
+  randfill-admins:
+    description: Admin access to randfill repo
+    members:
+    - aojea
+    - BenTheElder
+    - jbpratt
+    - michelle192837
+    - pohly
+    - thockin
+    - xmcqueen
+    privacy: closed
+    repos:
+      randfill: admin
+  randfill-maintainers:
+    description: Write access to randfill repo
+    members:
+    - aojea
+    - BenTheElder
+    - jbpratt
+    - michelle192837
+    - pohly
+    - thockin
+    - xmcqueen
+    privacy: closed
+    repos:
+      randfill: write
   testgrid-admins:
     description: Admin access to testgrid
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -338,6 +338,7 @@ restrictions:
     - "^kind"
     - "^kubetest2"
     - "^prow"
+    - "^randfill"
     - "^testgrid"
   - path: "kubernetes-sigs/sig-usability/teams.yaml"
     allowedRepos:


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5414

/assign @thockin @kubernetes/sig-testing-leads 

cc: @kubernetes/owners 
