### PR TITLE
Revert "etcd: Update release-etcd team for release window"

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -157,7 +157,7 @@ teams:
     description: Granted permission to release etcd-io/etcd
     # The member list is intentionally empty. It should only include the release
     # lead during release windows.
-    members: [ivanvc]
+    members: []
     privacy: closed
     repos:
       etcd: maintain


### PR DESCRIPTION
With the releases done today, we can get back to bau.

This reverts commit 648496c9a5fd960af9e9ace428638f5d7df558e1.

/hold due to discussion from #5445/Slack.