### PR TITLE
sig-network: update external-dns team

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -118,8 +118,7 @@ teams:
   external-dns-admins:
     description: Admin access to the external-dns repo
     members:
-    - linki
-    - njuettner
+    - mloiseleur
     - Raffo
     - szuecs
     privacy: closed
@@ -130,11 +129,9 @@ teams:
   external-dns-maintainers:
     description: Write access to the external-dns repo
     members:
-    - linki
-    - njuettner
+    - mloiseleur
     - Raffo
     - seanmalloy
-    - szuecs
     privacy: closed
     previously:
     - maintainers-external-dns

--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -131,7 +131,7 @@ teams:
     members:
     - mloiseleur
     - Raffo
-    - seanmalloy
+    - szuecs
     privacy: closed
     previously:
     - maintainers-external-dns


### PR DESCRIPTION
This PR removes emeritus approvers and add current approvers to the github teams.


