### PR TITLE
fix: move to sigs.k8s.io/yaml

### DIFF
--- a/cmd/helpers/helper.go
+++ b/cmd/helpers/helper.go
@@ -23,7 +23,7 @@ import (
 
 	"sigs.k8s.io/prow/pkg/config/org"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 func ParseKeyValue(s string) (string, string) {

--- a/cmd/restrictions/main.go
+++ b/cmd/restrictions/main.go
@@ -27,8 +27,8 @@ import (
 	"k8s.io/org/cmd/helpers"
 
 	"github.com/bmatcuk/doublestar"
-	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 )
 
 var (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/prow/pkg/config/org"
 	"sigs.k8s.io/prow/pkg/github"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 var cfg org.FullConfig

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.22.4
 
 require (
 	github.com/bmatcuk/doublestar v1.3.4
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.6.1
 	github.com/hound-search/hound v0.7.1
 	github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5

--- a/go.sum
+++ b/go.sum
@@ -600,7 +600,6 @@ github.com/envoyproxy/protoc-gen-validate v0.6.7/go.mod h1:dyJXwwfPK2VSqiB9Klm1J
 github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0++PMirau2/yoOwVac3AbF2w=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
 github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=


### PR DESCRIPTION
Move to standard usage of `sigs.k8s.io/yaml`