### PR TITLE
add atiratree to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -98,6 +98,7 @@ members:
 - astefanutti
 - astoycos
 - Atharva-Shinde
+- atiratree
 - atoato88
 - Atoms
 - AverageMarcus


### PR DESCRIPTION
per https://github.com/kubernetes/org/blob/16ac965bebae325e775476a1c80aed414584da8b/config/kubernetes/org.yaml#L126

needed for the descheduler project: https://github.com/kubernetes-sigs/descheduler/pulls?q=is%3Apr+reviewed-by%3Aatiratree+is%3Aclosed