### PR TITLE
Revert "etcd: Update release-etcd team for release window"

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -158,7 +158,7 @@ teams:
     description: Granted permission to release etcd-io/etcd
     # The member list is intentionally empty. It should only include the release
     # lead during release windows.
-    members: [ivanvc]
+    members: []
     privacy: closed
     repos:
       etcd: maintain


### PR DESCRIPTION
This reverts commit 703d708075a1f0241649a553bbe57383c0b71542.

With release 3.5.20 done, we can now restore the team with empty team members.

/cc @ahrtr 