### PR TITLE
etcd: Revert "Update release-etcd team for release window"

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -158,7 +158,7 @@ teams:
     description: Granted permission to release etcd-io/etcd
     # The member list is intentionally empty. It should only include the release
     # lead during release windows.
-    members: [ivanvc]
+    members: []
     privacy: closed
     repos:
       etcd: maintain


### PR DESCRIPTION
With v3.6.0-rc.3 and v3.5.21 out, we can revert the previous commit and set back the original state of the team members.

/cc @jmhbnz @ahrtr 

This reverts commit 7b957583280150baa9d4851cdbc8394fb532b303.