### PR TITLE
Drop sftim as org member

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -48,7 +48,6 @@ aliases:
     - onlydole
     - reylejano
     - salaxander
-    - sftim
     - tengqm
   sig-etcd-leads:
     - ahrtr

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -851,7 +851,6 @@ members:
 - serbrech
 - SergeyKanzhelev
 - serngawy
-- sftim
 - Sh4d1
 - shalini-b
 - shanduur

--- a/config/kubernetes-sigs/sig-docs/teams.yaml
+++ b/config/kubernetes-sigs/sig-docs/teams.yaml
@@ -12,7 +12,6 @@ teams:
     description: write access to the reference-docs repo
     members:
     - onlydole
-    - sftim
     - tengqm
     privacy: closed
     repos:

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1032,7 +1032,6 @@ members:
 - SergeyKanzhelev
 - sergeyshevch
 - sfotony
-- sftim
 - Sh4d1
 - shanduur
 - shaneutt

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -6,7 +6,6 @@ teams:
     members:
     - nate-double-u
     - onlydole
-    - sftim
     privacy: closed
   sig-docs-de-owners:
     description: Approvers for German content
@@ -34,7 +33,6 @@ teams:
     - onlydole
     - reylejano
     - salaxander
-    - sftim
     - tengqm
     privacy: closed
   sig-docs-en-reviews:
@@ -51,7 +49,6 @@ teams:
     - onlydole
     - reylejano
     - salaxander
-    - sftim
     - shannonxtreme
     - tengqm
     - windsonsea
@@ -179,7 +176,6 @@ teams:
     - onlydole
     - reylejano
     - salaxander
-    - sftim
     - tengqm
     privacy: closed
   sig-docs-pl-owners:
@@ -342,7 +338,6 @@ teams:
     - salaxander # L10n: English
     - SataQiu # L10n: Chinese
     - seokho-son # L10n: Korean
-    - sftim # L10n: English
     - shurup # L10n: Russian
     - tengqm # L10n: Chinese
     - truongnh1992 # L10n: Vietnamese
@@ -379,7 +374,6 @@ teams:
     - salaxander
     - SataQiu
     - seokho-son
-    - sftim
     - shurup
     - tanjunchen
     - tengqm


### PR DESCRIPTION
Replacement GitHub username will be: @lmktfy. Previous GitHub user @sftim is superseded.

For corroboration that I'm the same Tim, see https://kubernetes.slack.com/archives/C05PWRWPZSQ/p1743165608442659 (message on Kubernetes Slack) or https://github.com/sftim

I will send in follow-up PRs to add lmktfy (depends on issue https://github.com/kubernetes/org/issues/5497) and to update other related repos in light of this change.