### PR TITLE
Create a separate group with etcd admin access

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -1,4 +1,16 @@
 teams:
+  etcd-admins:
+    description: Admin access to etcd repo
+    members:
+    - ahrtr
+    - fuweid
+    - jmhbnz
+    - serathius
+    - spzala
+    - wenjiaswe
+    privacy: closed
+    repos:
+      etcd: admin
   etcd-operator-admins:
     description: Admin access to etcd-operator repo
     members:


### PR DESCRIPTION
I'm working on Antithesis integration as proposed in https://github.com/etcd-io/etcd/issues/19299.

We would like to setup a github workflow that calls a third party service with credentials. This should be doable by setting up a secret in github actions as described in https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions. At the moment no etcd maintainer has permissions to do that. 

I get permission I copied the the etcd-operator-admins group and I would like to give `admin` access to SIG etcd leads. 
Can be temporary just for the secret setup.

/cc @ahrtr @jmhbnz @ivanvc @wenjiaswe 

