### PR TITLE
Add missing maintainers + headlamp-reviewers team to the sig-ui teams

### DIFF
--- a/config/kubernetes-sigs/sig-ui/teams.yaml
+++ b/config/kubernetes-sigs/sig-ui/teams.yaml
@@ -10,7 +10,8 @@ teams:
     description: Write access to the headlamp repo
     members:
     - joaquimrocha
+    - sniok
+    - illume
     privacy: closed
     repos:
-      headlamp: write
-  
+      headlamp: maintain

--- a/config/kubernetes-sigs/sig-ui/teams.yaml
+++ b/config/kubernetes-sigs/sig-ui/teams.yaml
@@ -9,9 +9,20 @@ teams:
   headlamp-maintainers:
     description: Write access to the headlamp repo
     members:
+    - illume
     - joaquimrocha
     - sniok
-    - illume
     privacy: closed
     repos:
       headlamp: maintain
+  headlamp-reviewers:
+    description: Triage access to the headlamp repo
+    members:
+    - ashu8912
+    - knrt10
+    - skoeva
+    - vyncent-t
+    - yolossn
+    privacy: closed
+    repos:
+      headlamp: write


### PR DESCRIPTION
I know normally reviewers do not have write permissions in the repo, but in this case the headlamp core team is used to push branches directly, so it's more convenient than having forks outside.