### PR TITLE
Remove jacobwolfaws + others permissions for aws repos

### DIFF
--- a/config/kubernetes-sigs/sig-aws/teams.yaml
+++ b/config/kubernetes-sigs/sig-aws/teams.yaml
@@ -55,26 +55,17 @@ teams:
     description: admin access to aws-fsx-csi-driver
     members:
     - dims
-    - jacobwolfaws
-    - justinsb
     - khoang98
-    - leakingtapan
     - torredil
-    - wongma7
     privacy: closed
     repos:
       aws-fsx-csi-driver: admin
   aws-fsx-csi-driver-maintainers:
     description: write access to aws-fsx-csi-driver
     members:
-    - d-nishi
-    - jacobwolfaws
-    - jsafrane
-    - justinsb
+    - dims
     - khoang98
-    - leakingtapan
     - torredil
-    - wongma7
     privacy: closed
     repos:
       aws-fsx-csi-driver: write

--- a/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
+++ b/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
@@ -40,7 +40,6 @@ teams:
     description: Admin access to the aws-file-cache-csi-driver repo
     members:
       - dims
-      - jacobwolfaws
       - khoang98
       - nckturner
     privacy: closed
@@ -49,7 +48,6 @@ teams:
   aws-file-cache-csi-driver-maintainers:
     description: Write access to the aws-file-cache-csi-driver repo
     members:
-      - jacobwolfaws
       - khoang98
       - nckturner
     privacy: closed
@@ -61,7 +59,6 @@ teams:
       - dims
       - gomesjason
       - hughdanliu
-      - jacobwolfaws
       - nckturner
     privacy: closed
     repos:
@@ -71,7 +68,6 @@ teams:
     members:
       - gomesjason
       - hughdanliu
-      - jacobwolfaws
       - nckturner
     privacy: closed
     repos:


### PR DESCRIPTION
Removing jacobwolfaws from admin/write permissions to the 3 aws repos I have access to.

Also removing non-admins/maintainers for the aws-fsx-csi-driver + adding @dims to write permissions for the aws-fsx-csi-driver. This just cleans things up 