### PR TITLE
chore: add shanduur and BlaineEXE to cosi-driver-sample

### DIFF
--- a/config/kubernetes-sigs/sig-storage/teams.yaml
+++ b/config/kubernetes-sigs/sig-storage/teams.yaml
@@ -34,9 +34,11 @@ teams:
   cosi-driver-sample-maintainers:
     description: Write access to cosi-driver-sample
     members:
+    - BlaineEXE
     - jsafrane
     - msau42
     - saad-ali
+    - shanduur
     - wlan0
     - xing-yang
     privacy: closed


### PR DESCRIPTION
Adding myself and @BlaineEXE to [kubernetes-sigs/cosi-driver-sample](https://github.com/kubernetes-sigs/cosi-driver-sample).