### PR TITLE
chore: update custom-metrics-apiserver teams

### DIFF
--- a/config/kubernetes-sigs/sig-instrumentation/teams.yaml
+++ b/config/kubernetes-sigs/sig-instrumentation/teams.yaml
@@ -2,14 +2,22 @@ teams:
   custom-metrics-apiserver-admins:
     description: Admin access to the custom-metrics-apiserver repo
     members:
+    - dashpole
     - dgrisonnet
+    - RainbowMango
+    - rexagod
+    - richabanker
     privacy: closed
     repos:
       custom-metrics-apiserver: admin
   custom-metrics-apiserver-maintainers:
     description: Write access to the custom-metrics-apiserver repo
     members:
+    - dashpole
     - dgrisonnet
+    - RainbowMango
+    - rexagod
+    - richabanker
     privacy: closed
     repos:
       custom-metrics-apiserver: write


### PR DESCRIPTION
Reflect the change from https://github.com/kubernetes-sigs/custom-metrics-apiserver/pull/199 and give permissions to the SIG leads on the repo.