### PR TITLE
Remove temporary accesses

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -337,7 +337,6 @@ teams:
     - Okabe-Junya #L10n: Japanese
     - onlydole # L10n: English
     - raelga # L10n: Spanish
-    - rayandas # 1.33 temporary release docs lead access
     - remyleone # L10n: French
     - reylejano # L10n: English
     - rlenferink # L10n: German
@@ -373,7 +372,6 @@ teams:
     - onlydole
     - perriea
     - raelga
-    - rayandas # 1.33 Docs Lead
     - rekcah78
     - remyleone
     - reylejano


### PR DESCRIPTION
This PR removed myself from website maintainers and milestone maintainers which I had added for 1.33 release. 

cc: @kubernetes/sig-docs-leads 