### PR TITLE
Add riteshghorse as maintainer for gcp-filestore-csi-driver

### DIFF
--- a/config/kubernetes-sigs/sig-storage/teams.yaml
+++ b/config/kubernetes-sigs/sig-storage/teams.yaml
@@ -104,6 +104,7 @@ teams:
     - mattcary
     - msau42
     - pwschuurman
+    - riteshghorse
     - saad-ali
     - saikat-royc
     - sneha-at
@@ -112,7 +113,7 @@ teams:
     - tyuchn
     privacy: closed
     repos:
-      gcp-filestore-csi-driver: write      
+      gcp-filestore-csi-driver: write
   gluster-block-external-provisioner-admins:
     description: Admin access to gluster-block-external-provisioner
     members:


### PR DESCRIPTION
Contributing to Filestore CSI driver release process. Add `riteshghorse` so that I can create release tags etc.