### PR TITLE
Update inference-perf admins to active maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-scalability/teams.yaml
+++ b/config/kubernetes-sigs/sig-scalability/teams.yaml
@@ -2,20 +2,20 @@ teams:
   inference-perf-admins:
     description: Admin access to the inference-perf repo
     members:
-    - ArangoGutierrez
-    - Jeffwan
-    - SergeyKanzhelev
     - terrytangyuan
+    - achandrasekar
+    - wangchen615
+    - SachinVarghese
     privacy: closed
     repos:
       inference-perf: admin
   inference-perf-maintainers:
     description: Write access to the inference-perf repo
     members:
-    - ArangoGutierrez
-    - Jeffwan
-    - SergeyKanzhelev
     - terrytangyuan
+    - achandrasekar
+    - wangchen615
+    - SachinVarghese
     privacy: closed
     repos:
       inference-perf: write

--- a/config/kubernetes-sigs/sig-scalability/teams.yaml
+++ b/config/kubernetes-sigs/sig-scalability/teams.yaml
@@ -2,20 +2,20 @@ teams:
   inference-perf-admins:
     description: Admin access to the inference-perf repo
     members:
-    - terrytangyuan
     - achandrasekar
-    - wangchen615
     - SachinVarghese
+    - terrytangyuan
+    - wangchen615
     privacy: closed
     repos:
       inference-perf: admin
   inference-perf-maintainers:
     description: Write access to the inference-perf repo
     members:
-    - terrytangyuan
     - achandrasekar
-    - wangchen615
     - SachinVarghese
+    - terrytangyuan
+    - wangchen615
     privacy: closed
     repos:
       inference-perf: write


### PR DESCRIPTION
This change updates inference-perf admins to active maintainers at https://github.com/kubernetes-sigs/inference-perf/blob/main/OWNERS_ALIASES