### PR TITLE
Include Prajyot-Parab as an admin for cluster-api-provider-ibmcloud

### DIFF
--- a/config/kubernetes-sigs/provider-ibmcloud/teams.yaml
+++ b/config/kubernetes-sigs/provider-ibmcloud/teams.yaml
@@ -3,6 +3,7 @@ teams:
     description: Admin access to cluster-api-provider-ibmcloud repo
     members:
     - mkumatag
+    - Prajyot-Parab
     privacy: closed
     repos:
       cluster-api-provider-ibmcloud: admin


### PR DESCRIPTION
@Prajyot-Parab is one of the active member and approver for the project, hence adding him as an admin to the repository for an additional maintenance required for the project.