### PR TITLE
Add slashpai to kubernetes org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1067,6 +1067,7 @@ members:
 - skitt
 - skriss
 - sladyn98
+- slashpai
 - Smana
 - smarterclayton
 - smarticu5


### PR DESCRIPTION
already part of kubernetes-sigs org
For adding to instrumentation team https://github.com/kubernetes/org/pull/5583 
