### PR TITLE
Add tico88612 to kubespray-maintainers team

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -408,6 +408,7 @@ teams:
     - floryut
     - mzaian
     - oomichi
+    - tico88612
     - VannTen
     - yankay
     privacy: closed


### PR DESCRIPTION
Add myself to kubespray-maintainers team.

I'm driving the releases of Kubespray (see https://github.com/kubernetes-sigs/kubespray/issues/12175), discussed with @yankay and joined the kubespray-maintainer team.

I'll be able to help manage milestones for each release.