### PR TITLE
add alimaazamat to kubernetes org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -74,6 +74,7 @@ members:
 - alexkats
 - AlexNPavel
 - alexzielenski
+- alimaazamat
 - AlmogBaku
 - alvaroaleman
 - amacaskill


### PR DESCRIPTION
This PR adds `alimaazamat` to the kubernetes org.

She is already a member of the kubernetes-sigs org:

- https://github.com/kubernetes/org/commit/42f0a644c1641dc999cc58c77cf372c237f7366f

In order more force multiply her value across the Kubernetes community, let's add her to kubernetes as well.