### PR TITLE
sig-api-machinery: add github teams for crdify repo

### DIFF
--- a/config/kubernetes-sigs/sig-api-machinery/teams.yaml
+++ b/config/kubernetes-sigs/sig-api-machinery/teams.yaml
@@ -88,6 +88,24 @@ teams:
     privacy: closed
     repos:
       controller-tools: write
+  crdify-admins:
+    description: admin access to crdify
+    members:
+    - everettraven
+    - JoelSpeed
+    - jpbetz
+    privacy: closed
+    repos:
+      crdify: admin
+  crdify-maintainers:
+    description: write access to crdify
+    members:
+    - everettraven
+    - JoelSpeed
+    - jpbetz
+    privacy: closed
+    repos:
+      crdify: write
   json-admins:
     description: Admin access to the json repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -134,6 +134,7 @@ restrictions:
     - "^apiserver-builder-alpha"
     - "^apiserver-runtime"
     - "^clientgofix"
+    - "^crdify"
     - "^controller-runtime"
     - "^controller-tools"
     - "^json"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/pull/5282

/assign @kubernetes/sig-api-machinery-leads 

cc: @kubernetes/owners