### PR TITLE
Add 1.34 release signal team permissions

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -119,6 +119,7 @@ teams:
     - tallclair # Auth
     - tashimi # Usability
     - thockin # Network
+    - tico88612 # 1.32 ~ 1.34 Release Signal Shadow
     - timothysc # Cluster Lifecycle / Testing
     - towca # Autoscaling
     - upodroid # K8s Infra
@@ -310,7 +311,12 @@ teams:
             description: Members of the Release Signal team for the current release
               cycle.
             members:
+            - adilGhaffarDev # 1.34 Release Signal Shadow
+            - elieser1101 # 1.34 Release Signal Shadow
+            - Prajyot-Parab # 1.34 Release Signal Shadow
             - Rajalakshmi-Girish # 1.34 Release Signal Lead
+            - sarthaksarthak9 # 1.34 Release Signal Shadow
+            - tico88612 # 1.34 Release Signal Shadow
             - wendy-ha18 # 1.34 Release Lead Shadow
             privacy: closed
           release-team-docs:


### PR DESCRIPTION
- Added 1.34 Release Signal shadows to Release signal Team
- Added experienced shadow @tico88612 as one of milestone maintainer.