### PR TITLE
Adding zylxjtu and removing jayunit100 in milestone-maintainers

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -49,7 +49,6 @@ teams:
     - haircommander # Node
     - jackfrancis # Autoscaling
     - janetkuo # Apps
-    - jayunit100 # Windows
     - jberkus # Release
     - jbpratt # Testing
     - jdumars # Architecture / PM
@@ -128,6 +127,7 @@ teams:
     - xing-yang # Storage
     - xmcqueen # Testing
     - xmudrii # Release Manager / K8s Infra
+    - zylxjtu # Windows
     privacy: closed
     previously:
     - kubernetes-milestone-maintainers


### PR DESCRIPTION
Adding @zylxjtu and removing @jayunit100 to milestone-maintainers on behalf of SIG-Windows

This is a follow up to https://github.com/kubernetes/org/pull/5616