### PR TITLE
Add 1.34 Docs shadows to release-team-docs and website milestone maintainers

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -358,6 +358,7 @@ teams:
     description: Contributors who can use `/milestone` in the website repo
     members:
     - a-mccarthy
+    - ArvindParekh
     - bene2k1
     - bradtopol
     - divya-mohan0209
@@ -368,6 +369,7 @@ teams:
     - inductor
     - jcjesus
     - lmktfy
+    - michellengnx
     - mickeyboxell
     - nasa9084
     - natalisucks
@@ -375,10 +377,12 @@ teams:
     - onlydole
     - perriea
     - raelga
+    - rashansmith
     - rekcah78
     - remyleone
     - reylejano
     - rlenferink
+    - ryan-su-12
     - salaxander
     - SataQiu
     - seokho-son
@@ -386,6 +390,8 @@ teams:
     - tanjunchen
     - tengqm
     - truongnh1992
+    - Urvashi0109
     - xichengliudui
     - ysyukr
+    - yujen77300
     privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -315,7 +315,12 @@ teams:
           release-team-docs:
             description: Members of the Docs team for the current release cycle.
             members:
+            - ArvindParekh # 1.34 Docs Shadow
             - michellengnx # 1.34 Docs Lead
+            - rashansmith # 1.34 Docs Shadow
+            - ryan-su-12 # 1.34 Docs Shadow
+            - Urvashi0109 # 1.34 Docs Shadow
+            - yujen77300 # 1.34 Docs Shadow
             privacy: closed
           release-team-comms:
             description: Members of the Comms team for the current release cycle.


### PR DESCRIPTION
Update Release Docs team in release-team-docs in sig-release/teams.yaml and website-milestone-maintainers
cc @katcosgrove @Vyom-Yadav 

