### PR TITLE
add wangzhen127 to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -1012,6 +1012,7 @@ members:
 - vyncent-t
 - Vyom-Yadav
 - wangchen615
+- wangzhen127
 - weilaaa
 - weiling61
 - weizhouapache


### PR DESCRIPTION
Prerequisite of https://github.com/kubernetes/org/pull/5640

wangzhen127 is kubernetes member and node-problem-detector maintainer.