### PR TITLE
add dchen1107 to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -224,6 +224,7 @@ members:
 - dbonfigli
 - dcantah
 - dcbw
+- dchen1107
 - ddebroy
 - deads2k
 - Debanitrkl

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -1012,6 +1012,7 @@ members:
 - vyncent-t
 - Vyom-Yadav
 - wangchen615
+- wangzhen127
 - weilaaa
 - weiling61
 - weizhouapache


### PR DESCRIPTION
Prerequisite of https://github.com/kubernetes/org/pull/5640

dchen1107 is kubernetes member, sig-node TL and node-problem-detector maintainer.