### PR TITLE
Revert "etcd: Update release-etcd team for release window"

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -172,7 +172,7 @@ teams:
     description: Granted permission to release etcd-io/etcd
     # The member list is intentionally empty. It should only include the release
     # lead during release windows.
-    members: [ivanvc]
+    members: []
     privacy: closed
     repos:
       etcd: maintain


### PR DESCRIPTION
With v3.6.1 released, we can return to our BAU state.

/cc @jmhbnz 

This reverts commit cf8fbdc02691f795324106648eafab06b489d618.