### PR TITLE
Fix node-problem-detector repo teams

### DIFF
--- a/config/kubernetes-sigs/sig-node/teams.yaml
+++ b/config/kubernetes-sigs/sig-node/teams.yaml
@@ -32,26 +32,6 @@ teams:
     privacy: closed
     repos:
       node-feature-discovery-operator: write
-  node-problem-detector-admins:
-    description: Admin access to the node-problem-detector repo
-    members:
-    - dchen1107
-    - Random-Liu
-    - wangzhen127
-    privacy: closed
-    repos:
-      node-problem-detector: admin
-  node-problem-detector-maintainers:
-    description: Write access to the node-problem-detector repo. This group manages releases.
-    members:
-    - andyxning
-    - dchen1107
-    - hakman
-    - Random-Liu
-    - wangzhen127
-    privacy: closed
-    repos:
-      node-problem-detector: write
   noderesourcetopology-api-admins:
     description: Admin access to noderesourcetopology-api repo
     members:

--- a/config/kubernetes/sig-node/teams.yaml
+++ b/config/kubernetes/sig-node/teams.yaml
@@ -1,4 +1,24 @@
 teams:
+  node-problem-detector-admins:
+    description: Admin access to the node-problem-detector repo
+    members:
+    - dchen1107
+    - Random-Liu
+    - wangzhen127
+    privacy: closed
+    repos:
+      node-problem-detector: admin
+  node-problem-detector-maintainers:
+    description: Write access to the node-problem-detector repo. This group manages releases.
+    members:
+    - andyxning
+    - dchen1107
+    - hakman
+    - Random-Liu
+    - wangzhen127
+    privacy: closed
+    repos:
+      node-problem-detector: write
   sig-node-api-reviews:
     description: API Reviews for Kubernetes Node Special-Interest-Group
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -49,7 +49,6 @@ restrictions:
     - "^kubernetes"
     - "^kubernetes-template-project"
     - "^steering"
-    - "^node-problem-detector"
     - "^org"
     - "^perf-tests"
     - "^steering"
@@ -103,6 +102,9 @@ restrictions:
     allowedRepos:
     - "^k8s.io"
     - "^registry.k8s.io"
+  - path: "kubernetes/sig-node/teams.yaml"
+    allowedRepos:
+    - "^node-problem-detector"
   - path: "kubernetes/sig-security/teams.yaml"
     allowedRepos:
     - "^sig-security"
@@ -289,7 +291,6 @@ restrictions:
     - "^kernel-module-management"
     - "^noderesourcetopology-api"
     - "^node-feature-discovery-operator"
-    - "^node-problem-detector"
     - "^security-profiles-operator"
   - path: "kubernetes-sigs/sig-release/teams.yaml"
     allowedRepos:


### PR DESCRIPTION
#5640 put these teams in kubernetes-sigs, not kubernetes where the actual repo is. This PR fixes this issue.