### PR TITLE
add nirrozenbaum to kubernetes org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -839,6 +839,7 @@ members:
 - nilo19
 - nimbinatus
 - niranjandarshann
+- nirrozenbaum
 - nitishfy
 - niuzhenguo
 - nixpanic


### PR DESCRIPTION
This is a membership join request. 
I’m a member of k8s-sigs (joined in https://github.com/kubernetes/org/issues/5439).
I’m requesting to join also to Kubernetes org.
my contributions can be seen in https://github.com/kubernetes-sigs/gateway-api-inference-extension (ranked second in contributions and a code reviewer in OWNERS file).