### PR TITLE
Add our mentees for the Etcd Docs mentorship as Etcd members.

### DIFF
--- a/config/etcd-io/org.yaml
+++ b/config/etcd-io/org.yaml
@@ -48,6 +48,7 @@ members:
 - nwnt
 - pav-kv
 - ptabor
+- ronaldngounou
 - serathius
 - siyuanfoundation
 - spzala
@@ -56,6 +57,7 @@ members:
 - tjungblu
 - victortrac
 - vorburger
+- wendy-ha18
 - wenjiaswe
 - wzshiming
 members_can_create_repositories: false


### PR DESCRIPTION
Ronald and Wendy are our mentees for the Etcd Docs contributor mentorship this season.  Asking to add them as Etcd members so that they can interact with the bots on etcd/website.

Both are Kubernetes members.

/sig etcd

attn: @jmhbnz @siyuanfoundation @nate-double-u 