### PR TITLE
sig-cl: remove the general, outdated sig-cluster-lifecycle team

### DIFF
--- a/config/kubernetes/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes/sig-cluster-lifecycle/teams.yaml
@@ -64,21 +64,6 @@ teams:
     privacy: closed
     repos:
       minikube: write
-  sig-cluster-lifecycle:
-    description: For discussing SIG Cluster Lifecycle topics
-    members:
-    - cpanato
-    - detiber
-    - dixudx
-    - fabriziopandini
-    - kad
-    - luxas
-    - neolit123
-    - SataQiu
-    - stealthybox
-    - timothysc
-    - yagonobre
-    privacy: closed
   system-validators-admins:
     description: Admin access to system-validators repo
     members:


### PR DESCRIPTION
Historically this was a team with arbitrary membership. Majority of the users in this team are no longer active. Instead we should only maintain the [-leads team](https://github.com/kubernetes/org/pull/5690/files#diff-ce49e15ad0c55db9a5f2db9582f25d5fbc2fa9682d58cd12925cc527b6e76512R83) and we can be pinged from it.

/cc @fabriziopandini @justinsb @vincepri 