### PR TITLE
Add joaquimrocha as a Kubernetes org and SIG UI member

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -558,6 +558,7 @@ members:
 - jmhbnz
 - jmickey
 - jmyung
+- joaquimrocha
 - joekr
 - joelanford
 - joelsmith


### PR DESCRIPTION
The membership is mainly sparked from my attempt to get an image build/test dashboard for Headlamp. I am in the kubernetes-sigs org only, and according to this discussion I'd need to be in kubernetes and SIG UI as well.
https://github.com/kubernetes/test-infra/pull/35028#discussion_r2167208048

Happy to get any further guidance if needed here.

cc/ @floreks , @maciaszczykm 