### PR TITLE
Add graz-dev as blog owner

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -6,6 +6,7 @@ teams:
     members:
     - nate-double-u
     - onlydole
+    - graz-dev
     privacy: closed
   sig-docs-de-owners:
     description: Approvers for German content

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -4,9 +4,9 @@ teams:
     maintainers:
     - mrbobbytables
     members:
+    - graz-dev
     - nate-double-u
     - onlydole
-    - graz-dev
     privacy: closed
   sig-docs-de-owners:
     description: Approvers for German content


### PR DESCRIPTION
Here is the English translation:

Hi, following up on PR https://github.com/kubernetes/website/pull/51410, I would like to be added to the blog owners' group here as well.

I would also need edit access to the https://github.com/orgs/kubernetes/projects/93 board. Is joining the blog owners' group sufficient, or is another permission required? If so, could you please let me know how to gain access?

Thanks a lot;
Graziano