### PR TITLE
Add stlaz to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -941,6 +941,7 @@ members:
 - steve-hardman
 - stevehipwell
 - stevekuznetsov
+- stlaz
 - stmcginnis
 - stormqueen1990
 - strongjz


### PR DESCRIPTION
I am already a member of the kubernetes org, I need basic privileges to be able to help with https://github.com/kubernetes-sigs/secrets-store-csi-driver releases.

/cc aramase enj