### PR TITLE
etcd: Restore release-etcd team members

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -168,7 +168,7 @@ teams:
     description: Granted permission to release etcd-io/etcd
     # The member list is intentionally empty. It should only include the release
     # lead during release windows.
-    members: [ivanvc]
+    members: []
     privacy: closed
     repos:
       etcd: maintain


### PR DESCRIPTION
v3.6.4 was released last Friday. Return the release-etcd team members to BAU.

/cc @ahrtr @jmhbnz 

This reverts commit f5117b4252f3cf2b4ea83495ae4fdc9675b0aff9.