### PR TITLE
sig-cl: sync system-validators admins/maintainers

### DIFF
--- a/config/kubernetes/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes/sig-cluster-lifecycle/teams.yaml
@@ -25,7 +25,6 @@ teams:
     description: Admin access to the kubeadm repo
     members:
     - carlory
-    - fabriziopandini
     - HirazawaUi
     - neolit123
     - pacoxu
@@ -37,7 +36,6 @@ teams:
     description: Write access to the kubeadm repo
     members:
     - carlory
-    - fabriziopandini
     - HirazawaUi
     - neolit123
     - pacoxu
@@ -67,14 +65,22 @@ teams:
   system-validators-admins:
     description: Admin access to system-validators repo
     members:
+    - carlory
+    - HirazawaUi
     - neolit123
+    - pacoxu
+    - SataQiu
     privacy: closed
     repos:
       system-validators: admin
   system-validators-maintainers:
     description: Write access to system-validators repo
     members:
+    - carlory
+    - HirazawaUi
     - neolit123
+    - pacoxu
+    - SataQiu
     privacy: closed
     repos:
       system-validators: write


### PR DESCRIPTION
sync with the k/kubeadm OWNERS file, so that anyone can cut system-validators releases.
also remove Fabrizio from k/kubeadm admins, but can be re-added if he wishes.

/cc @pacoxu @SataQiu 
