### PR TITLE
sig-instrumentation: add gh teams for resource-state-metrics repo

### DIFF
--- a/config/kubernetes-sigs/sig-instrumentation/teams.yaml
+++ b/config/kubernetes-sigs/sig-instrumentation/teams.yaml
@@ -104,6 +104,24 @@ teams:
     privacy: closed
     repos:
       prometheus-adapter: write
+  resource-state-metrics-admins:
+    description: Admin access to the resource-state-metrics repo
+    members:
+    - dgrisonnet
+    - mrueg
+    - rexagod
+    privacy: closed
+    repos:
+      resource-state-metrics: admin
+  resource-state-metrics-maintainers:
+    description: Write access to the resource-state-metrics repo
+    members:
+    - dgrisonnet
+    - mrueg
+    - rexagod
+    privacy: closed
+    repos:
+      resource-state-metrics: write
   usage-metrics-collector-admins:
     description: Admin access to the usage-metrics-collector repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -249,6 +249,7 @@ restrictions:
     - "^logtools"
     - "^metrics-server"
     - "^prometheus-adapter"
+    - "^resource-state-metrics"
     - "^usage-metrics-collector"
   - path: "kubernetes-sigs/sig-k8s-infra/teams.yaml"
     allowedRepos:


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5740

/assign @kubernetes/sig-instrumentation-leads 

cc: @kubernetes/owners