### PR TITLE
sig-apps: add gh teams for agent-sandbox repo

### DIFF
--- a/config/kubernetes-sigs/sig-apps/teams.yaml
+++ b/config/kubernetes-sigs/sig-apps/teams.yaml
@@ -1,4 +1,22 @@
 teams:
+  agent-sandbox-admins:
+    description: Admin access to agent-sandbox repo
+    members:
+    - janetkuo
+    - justinsb
+    - soltysh
+    privacy: closed
+    repos:
+      agent-sandbox: admin
+  agent-sandbox-maintainers:
+    description: Write access to agent-sandbox repo
+    members:
+    - janetkuo
+    - justinsb
+    - soltysh
+    privacy: closed
+    repos:
+      agent-sandbox: write
   execution-hook-admins:
     description: Admin access to execution-hook repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -150,6 +150,7 @@ restrictions:
     - "^yaml"
   - path: "kubernetes-sigs/sig-apps/teams.yaml"
     allowedRepos:
+    - "^agent-sandbox"
     - "^execution-hook"
     - "^jobset"
     - "^kjob"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5750

/assign @kubernetes/sig-apps-leads 

cc: @kubernetes/owners