### PR TITLE
security-profiles-operator: sync maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-node/teams.yaml
+++ b/config/kubernetes-sigs/sig-node/teams.yaml
@@ -81,7 +81,9 @@ teams:
     members:
     - ccojocar
     - JAORMX
+    - ngopalak-redhat
     - saschagrunert
+    - Vincent056
     privacy: closed
     previously:
     - seccomp-operator-maintainers


### PR DESCRIPTION
Synchronizing the team with the actual OWNERS file.

cc @ngopalak-redhat @Vincent056