### PR TITLE
sig-arch: add gh teams for admission-policies repo

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -834,6 +834,7 @@ members:
 - vdkotkar
 - Verolop
 - vignesh-goutham
+- vinayakankugoyal
 - Vincent056
 - vincepri
 - vishalanarase

--- a/config/kubernetes-sigs/sig-architecture/teams.yaml
+++ b/config/kubernetes-sigs/sig-architecture/teams.yaml
@@ -9,6 +9,22 @@ teams:
     privacy: closed
     repos:
       depstat: admin
+  admission-policies-admins:
+    description: Admin access to admission-policies repo
+    members:
+    - BenTheElder
+    - vinayakankugoyal
+    privacy: closed
+    repos:
+      admission-policies: admin
+  admission-policies-maintainers:
+    description: Write access to admission-policies repo
+    members:
+    - BenTheElder
+    - vinayakankugoyal
+    privacy: closed
+    repos:
+      admission-policies: write
   apisnoop-admins:
     description: Admin access to apisnoop repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -159,6 +159,7 @@ restrictions:
   - path: "kubernetes-sigs/sig-architecture/teams.yaml"
     allowedRepos:
     - "^apisnoop"
+    - "^admission-policies"
     - "^depstat"
     - "^maintainer-tools"
     - "^verify-conformance"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5408

/assign @kubernetes/sig-architecture-leads 

cc: @kubernetes/owners 

---

Note: This PR also adds `vinayakankugoyal` to `kubernetes-sigs` org,  to satisy org membership requirements for creating gh teams.