### PR TITLE
Remove michellengnx from website-maintainers after 1.34 release

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -300,7 +300,6 @@ teams:
     - katcosgrove # L10n: English
     - lmktfy # Emeritus tech lead
     - mfilocha # L10n: Polish
-    - michellengnx
     - nasa9084 # L10n: Japanese
     - natalisucks # L10n: English
     - nate-double-u # L10n: English


### PR DESCRIPTION
1.34 was released yesterday, this PR removes the 1.34 release docs lead, michellengnx, from website-maintainers as part of the post release tasks
This is a follow-up PR to https://github.com/kubernetes/org/pull/5794
