### PR TITLE
sig-arch: add gh teams for wg-ai-conformance repo

### DIFF
--- a/config/kubernetes-sigs/sig-architecture/teams.yaml
+++ b/config/kubernetes-sigs/sig-architecture/teams.yaml
@@ -71,6 +71,26 @@ teams:
     privacy: closed
     repos:
       verify-conformance: admin
+  wg-ai-conformance-admins:
+    description: Admin access to wg-ai-conformance repo
+    members:
+    - janetkuo
+    - mfahlandt
+    - ritazh
+    - terrytangyuan
+    privacy: closed
+    repos:
+      wg-ai-conformance: admin
+  wg-ai-conformance-maintainers:
+    description: Write access to wg-ai-conformance repo
+    members:
+    - janetkuo
+    - mfahlandt
+    - ritazh
+    - terrytangyuan
+    privacy: closed
+    repos:
+      wg-ai-conformance: write
   wg-device-management-admins:
     description: Admin access to wg-device-management repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -163,6 +163,7 @@ restrictions:
     - "^depstat"
     - "^maintainer-tools"
     - "^verify-conformance"
+    - "^wg-ai-conformance"
     - "^wg-device-management"
     - "^wg-serving"
   - path: "kubernetes-sigs/sig-auth/teams.yaml"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5809

/assign @kubernetes/sig-architecture-leads 

cc: @kubernetes/owners