### PR TITLE
sig-cluster-lifecycle: add gh teams for minikube-os/preloads repos

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -416,3 +416,31 @@ teams:
     privacy: closed
     repos:
       minikube-gui: write
+  minikube-os-admins:
+    description: Admin access to the minikube-os repo
+    members:
+    - medyagh
+    privacy: closed
+    repos:
+      minikube-os: admin
+  minikube-os-maintainers:
+    description: Write access to the minikube-os repo
+    members:
+    - medyagh
+    privacy: closed
+    repos:
+      minikube-os: write
+  minikube-preloads-admins:
+    description: Admin access to the minikube-preloads repo
+    members:
+    - medyagh
+    privacy: closed
+    repos:
+      minikube-preloads: admin
+  minikube-preloads-maintainers:
+    description: Write access to the minikube-preloads repo
+    members:
+    - medyagh
+    privacy: closed
+    repos:
+      minikube-preloads: write

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -227,6 +227,8 @@ restrictions:
     - "^kubespray"
     - "^logical-cluster"
     - "^minikube-gui"
+    - "^minikube-os"
+    - "^minikube-preloads"
   - path: "kubernetes-sigs/sig-contributor-experience/teams.yaml"
     allowedRepos:
     - "^contributor-tweets"


### PR DESCRIPTION
ref: github.com/kubernetes/org/issues/5772, https://github.com/kubernetes/org/issues/5762

/assign @kubernetes/sig-cluster-lifecycle-leads 

cc: @kubernetes/owners