### PR TITLE
etcd: Update release-etcd team for release window

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -169,7 +169,7 @@ teams:
     description: Granted permission to release etcd-io/etcd
     # The member list is intentionally empty. It should only include the release
     # lead during release windows.
-    members: []
+    members: [ivanvc]
     privacy: closed
     repos:
       etcd: maintain


### PR DESCRIPTION
Add ivanvc to the release-etcd team for release v3.6.5 and v3.5.23.

Link to https://github.com/etcd-io/etcd/issues/20501, https://github.com/etcd-io/etcd/issues/20546.

/cc @ahrtr @jmhbnz 