### PR TITLE
Adding kro maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
+++ b/config/kubernetes-sigs/sig-cloud-provider/teams.yaml
@@ -179,7 +179,9 @@ teams:
     - barney-s
     - bridgetkromhout
     - cheftako
+    - jlbutler
     - justinsb
+    - nicslatts
     privacy: closed
     repos:
       kro: admin


### PR DESCRIPTION
In https://github.com/kubernetes/org/issues/5789#issuecomment-3286751958 @mrbobbytables noted that he added the people he could add at the time he created the team. "team has been created with members that are currently members of k-sigs: https://github.com/kubernetes/org/pull/5837" 

Now that @Priyankasaggu11929 updated the members in https://github.com/kubernetes/org/pull/5839, it's possible to add two more of the kro admins who couldn't be added initially until their membership in k-sigs was processed. (A third one should be coming next week; I'll add that after https://github.com/kubernetes/org/issues/5842 is complete.)