### PR TITLE
adding khanhtc1202 & ntheanh201 as sig-docs-vi-owners/reviewers

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -254,16 +254,16 @@ teams:
   sig-docs-vi-owners:
     description: Admins for Vietnamese content
     members:
-    - truongnh1992
     - khanhtc1202
     - ntheanh201
+    - truongnh1992
     privacy: closed
   sig-docs-vi-reviews:
     description: PR reviews for Vietnamese content
     members:
-    - truongnh1992
     - khanhtc1202
     - ntheanh201
+    - truongnh1992
     privacy: closed
   sig-docs-uk-owners:
     description: Approvers for Ukrainian content

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -255,11 +255,15 @@ teams:
     description: Admins for Vietnamese content
     members:
     - truongnh1992
+    - khanhtc1202
+    - ntheanh201
     privacy: closed
   sig-docs-vi-reviews:
     description: PR reviews for Vietnamese content
     members:
     - truongnh1992
+    - khanhtc1202
+    - ntheanh201
     privacy: closed
   sig-docs-uk-owners:
     description: Approvers for Ukrainian content


### PR DESCRIPTION
Adding khanhtc1202 & ntheanh201 as sig-docs-vi-owners/reviewers

Ref: https://github.com/kubernetes/website/pull/52424#issuecomment-3314397607