### PR TITLE
sig-network: add gh teams for wg-ai-gateway repo

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -355,3 +355,27 @@ teams:
     privacy: closed
     repos:
       node-ipam-controller: write
+  wg-ai-gateway-admins:
+    description: Admin access to the wg-ai-gateway repo
+    members:
+    - keithmattix
+    - kflynn
+    - kfswain
+    - nirrozenbaum
+    - shaneutt
+    - xunzhuo
+    privacy: closed
+    repos:
+      wg-ai-gateway: admin
+  wg-ai-gateway-maintainers:
+    description: Write access to the wg-ai-gateway repo
+    members:
+    - keithmattix
+    - kflynn
+    - kfswain
+    - nirrozenbaum
+    - shaneutt
+    - xunzhuo
+    privacy: closed
+    repos:
+      wg-ai-gateway: write

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -290,6 +290,7 @@ restrictions:
     - "^network-policy-api"
     - "^network-policy-finalizer"
     - "^node-ipam-controller"
+    - "^wg-ai-gateway"
   - path: "kubernetes-sigs/sig-node/teams.yaml"
     allowedRepos:
     - "^dra-driver-cpu"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5848

/assign @kubernetes/sig-network-leads 

cc: @kubernetes/owners