### PR TITLE
Add 1.35 Doc members to release-team-docs and website milestone maintainers 

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -328,6 +328,7 @@ teams:
     description: Contributors who can use `/milestone` in the website repo
     members:
     - a-mccarthy
+    - AnshumanTripathi
     - ArvindParekh
     - bene2k1
     - divya-mohan0209
@@ -335,12 +336,15 @@ teams:
     - huynguyennovem
     - inductor
     - jcjesus
+    - Jimmykhangnguyen
+    - kernel-kun
     - lmktfy
     - michellengnx
     - nasa9084
     - natalisucks
     - nate-double-u
     - onlydole
+    - OrlinVasilev
     - perriea
     - raelga
     - rashansmith
@@ -350,6 +354,7 @@ teams:
     - ryan-su-12
     - salaxander
     - SataQiu
+    - sayanchowdhury
     - seokho-son
     - shurup
     - tengqm

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -313,12 +313,12 @@ teams:
           release-team-docs:
             description: Members of the Docs team for the current release cycle.
             members:
-            - ArvindParekh # 1.34 Docs Shadow
-            - michellengnx # 1.34 Docs Lead
-            - rashansmith # 1.34 Docs Shadow
-            - ryan-su-12 # 1.34 Docs Shadow
-            - Urvashi0109 # 1.34 Docs Shadow
-            - yujen77300 # 1.34 Docs Shadow
+            - AnshumanTripathi # 1.35 Docs Shadow
+            - Jimmykhangnguyen # 1.35 Docs Shadow
+            - kernel-kun # 1.35 Docs Shadow
+            - OrlinVasilev # 1.35 Docs Lead
+            - sayanchowdhury # 1.35 Docs Shadow
+            - Urvashi0109 # 1.35 Docs Lead
             privacy: closed
           release-team-comms:
             description: Members of the Comms team for the current release cycle.


### PR DESCRIPTION
Update Release Docs team in release-team-docs in sig-release/teams.yaml and website-milestone-maintainers
cc @katcosgrove @drewhagen 