### PR TITLE
Add jasonbraganza as GitHub admin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ SHELL := /usr/bin/env bash
 GITHUB_TOKEN_PATH ?=
 
 # intentionally hardcoded list to ensure it's high friction to remove someone
-ADMINS = cblecker MadhavJivrajani mrbobbytables nikhita palnabarun Priyankasaggu11929
+ADMINS = cblecker jasonbraganza MadhavJivrajani mrbobbytables nikhita palnabarun Priyankasaggu11929
 ORGS = $(shell find ./config -type d -mindepth 1 -maxdepth 1 | cut -d/ -f3)
 
 # use absolute path to ./_output, which is .gitignored

--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@
 
 reviewers:
   - cblecker
+  - jasonbraganza
   - MadhavJivrajani
   - mrbobbytables
   - nikhita
@@ -9,6 +10,7 @@ reviewers:
   - Priyankasaggu11929
 approvers:
   - cblecker
+  - jasonbraganza
   - MadhavJivrajani
   - mrbobbytables
   - nikhita

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -11,6 +11,7 @@
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
 cblecker
+jasonbraganza
 MadhavJivrajani
 mrbobbytables
 nikhita

--- a/admin/update.sh
+++ b/admin/update.sh
@@ -23,6 +23,7 @@ readonly REPO_ROOT
 
 readonly admins=(
   cblecker
+  jasonbraganza
   MadhavJivrajani
   mrbobbytables
   nikhita

--- a/config/etcd-io/org.yaml
+++ b/config/etcd-io/org.yaml
@@ -1,5 +1,6 @@
 admins:
 - cblecker
+- jasonbraganza
 - k8s-ci-robot
 - k8s-github-robot
 - MadhavJivrajani
@@ -32,7 +33,6 @@ members:
 - hwdef
 - idvoretskyi
 - ivanvc
-- jasonbraganza
 - jberkus
 - jmhbnz
 - joshjms

--- a/config/kubernetes-client/org.yaml
+++ b/config/kubernetes-client/org.yaml
@@ -1,5 +1,6 @@
 admins:
 - cblecker
+- jasonbraganza
 - k8s-ci-robot
 - k8s-github-robot
 - MadhavJivrajani
@@ -33,7 +34,6 @@ members:
 - idvoretskyi
 - irvifa
 - ityuhui
-- jasonbraganza
 - jonschoning
 - justaugustus
 - k8s-infra-cherrypick-robot

--- a/config/kubernetes-csi/org.yaml
+++ b/config/kubernetes-csi/org.yaml
@@ -1,5 +1,6 @@
 admins:
 - cblecker
+- jasonbraganza
 - k8s-ci-robot
 - k8s-github-robot
 - MadhavJivrajani
@@ -47,7 +48,6 @@ members:
 - huntergregory
 - idvoretskyi
 - irvifa
-- jasonbraganza
 - jingxu97
 - jsafrane
 - justaugustus

--- a/config/kubernetes-incubator/OWNERS
+++ b/config/kubernetes-incubator/OWNERS
@@ -2,6 +2,7 @@
 
 approvers:
   - cblecker
+  - jasonbraganza
   - MadhavJivrajani
   - mrbobbytables
   - nikhita

--- a/config/kubernetes-incubator/org.yaml
+++ b/config/kubernetes-incubator/org.yaml
@@ -7,6 +7,7 @@ members_can_create_repositories: false
 billing_email: github@kubernetes.io
 admins:
 - cblecker
+- jasonbraganza
 - k8s-ci-robot
 - k8s-github-robot
 - MadhavJivrajani

--- a/config/kubernetes-nightly/OWNERS
+++ b/config/kubernetes-nightly/OWNERS
@@ -1,12 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+  - jasonbraganza
   - MadhavJivrajani
   - palnabarun
   - Priyankasaggu11929
   - savitharaghunathan
 approvers:
   - cblecker
+  - jasonbraganza
   - MadhavJivrajani
   - mrbobbytables
   - nikhita

--- a/config/kubernetes-nightly/org.yaml
+++ b/config/kubernetes-nightly/org.yaml
@@ -9,6 +9,7 @@ admins:
 - cblecker
 - cpanato
 - dims
+- jasonbraganza
 - jeremyrickard
 - justaugustus
 - k8s-ci-robot

--- a/config/kubernetes-retired/OWNERS
+++ b/config/kubernetes-retired/OWNERS
@@ -2,6 +2,7 @@
 
 approvers:
   - cblecker
+  - jasonbraganza
   - MadhavJivrajani
   - mrbobbytables
   - nikhita

--- a/config/kubernetes-retired/org.yaml
+++ b/config/kubernetes-retired/org.yaml
@@ -7,6 +7,7 @@ members_can_create_repositories: false
 billing_email: github@kubernetes.io
 admins:
 - cblecker
+- jasonbraganza
 - k8s-ci-robot
 - k8s-github-robot
 - MadhavJivrajani

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -1,5 +1,6 @@
 admins:
 - cblecker
+- jasonbraganza
 - k8s-ci-robot
 - k8s-github-robot
 - MadhavJivrajani
@@ -361,7 +362,6 @@ members:
 - JaneLiuL
 - janetkuo
 - JAORMX
-- jasonbraganza
 - javadoors
 - jayesh-srivastava
 - jaypipes

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1,5 +1,6 @@
 admins:
 - cblecker
+- jasonbraganza
 - k8s-ci-robot
 - k8s-github-robot
 - MadhavJivrajani
@@ -416,7 +417,6 @@ members:
 - JamesLaverack
 - janetkuo
 - JAORMX
-- jasonbraganza
 - javadoors
 - jayesh-srivastava
 - jayeshmahajan


### PR DESCRIPTION
Ref: [Issue: #8622, sig-contribex announcement for nomination ](https://github.com/kubernetes/community/pull/8622)

**Commit 1**

`add jasonbraganza as admin (scripts and security)`

Change root OWNERS and ADMIN variables in scripts.

**Commit 2**

`add or promote jasonbraganza as admin (OWNERS and org.yaml files)`

Add jasonbraganza as admin in all orgs.
Add jasonbraganza as reviewer and approver in OWNERS of all orgs.

/cc @kubernetes/owners 
/assign @Priyankasaggu11929 