### PR TITLE
sig-autoscaling: add gh teams for karpenter-provider-ibm-cloud repo

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -629,6 +629,7 @@ members:
 - PBundyra
 - pegasas
 - petr-muller
+- pfeifferj
 - Phaow
 - pierreprinetti
 - piosz

--- a/config/kubernetes-sigs/sig-autoscaling/teams.yaml
+++ b/config/kubernetes-sigs/sig-autoscaling/teams.yaml
@@ -39,6 +39,20 @@ teams:
     privacy: closed
     repos:
       karpenter: read
+  karpenter-provider-ibm-cloud-admins:
+    description: admin access to the karpenter-provider-ibm-cloud repo
+    members:
+    - pfeifferj
+    privacy: closed
+    repos:
+      karpenter-provider-ibm-cloud: admin
+  karpenter-provider-ibm-cloud-maintainers:
+    description: write access to the karpenter-provider-ibm-cloud repo
+    members:
+    - pfeifferj
+    privacy: closed
+    repos:
+      karpenter-provider-ibm-cloud: write
   sig-autoscaling-leads:
     description: "leads of the SIG Autoscaling"
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -175,6 +175,7 @@ restrictions:
   - path: "kubernetes-sigs/sig-autoscaling/teams.yaml"
     allowedRepos:
     - "^karpenter"
+    - "^karpenter-provider-ibm-cloud"
   - path: "kubernetes-sigs/sig-aws/teams.yaml"
     allowedRepos:
     - "^aws-ebs-csi-driver"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5836
Fix https://github.com/kubernetes/org/issues/5898

commit 1: b989bca26d96e1c93658f6023de23cdbab82a317, add github teams for karpenter-provider-ibm-cloud repo
commit 2: b133b868eab3af16edc2f3b58c8b3ceb7ade5ec2, add @pfeifferj to Kubernetes-sigs org



---

@pfeifferj - please note, I am unable to add `jirn073-76`, `viktoryatheone` to the GH teams atm because it requires Kubernetes-sigs org membership. Please feel free to open a PR to add them to the required GH teams after their org membership is in place as well.

/assign @kubernetes/sig-autoscaling-leads 

cc: @kubernetes/owners 