### PR TITLE
Remove SubhasmitaSw from org configurations

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -806,7 +806,6 @@ members:
 - stormqueen1990
 - strongjz
 - sttts
-- SubhasmitaSw
 - sudermanjr
 - sunjayBhatia
 - Sunnatillo

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -929,7 +929,6 @@ members:
 - stp-ip
 - strongjz
 - sttts
-- SubhasmitaSw
 - sudermanjr
 - sunjayBhatia
 - Sunnatillo

--- a/config/kubernetes/sig-architecture/teams.yaml
+++ b/config/kubernetes/sig-architecture/teams.yaml
@@ -52,7 +52,6 @@ teams:
     - kikisdeliveryservice # subproject owner
     - rayandas # 1.35 Enhancements Lead
     - salehsedghpour # 1.30 RT Enhancements Lead
-    - SubhasmitaSw # 1.35 Enhancements Shadow
     privacy: closed
     teams:
       enhancements-admins:

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -118,7 +118,6 @@ teams:
     - sreeram-venkitesh # 1.34 Release Lead Shadow
     - stmcginnis # 1.34 Enhancements Shadow
     - sttts # API Machinery
-    - SubhasmitaSw # 1.35 Enhancements Shadow
     - tallclair # Auth
     - thockin # Network
     - tico88612 # 1.35 Release Signal Lead
@@ -302,7 +301,6 @@ teams:
         - saschagrunert # subproject owner / Chair
         - savitharaghunathan # subproject owner (1.22 RT Lead)
         - stmcginnis # 1.34 Enhancements Shadow
-        - SubhasmitaSw # 1.35 Enhancements Shadow
         - Verolop # Release Manager
         - xmudrii # Release Manager
         privacy: closed
@@ -347,7 +345,6 @@ teams:
             - fykaa # 1.35 Enhancements Shadow
             - jmickey # 1.35 Enhancements Shadow
             - rayandas # 1.35 Enhancements Lead
-            - SubhasmitaSw # 1.35 Enhancements Shadow
             privacy: closed
           release-team-leads:
             description: Release Team Leads for the current Kubernetes release


### PR DESCRIPTION
## Summary
Remove SubhasmitaSw from all org and team configurations.

## Reason
The GitHub user SubhasmitaSw no longer exists. CI failure: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-org-peribolos/1976339465773256704

🤖 Generated with [Claude Code](https://claude.com/claude-code)