### PR TITLE
sig-network: add gh teams for kindnet repo

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -236,6 +236,26 @@ teams:
     - keithmattix
     - mikemorris
     privacy: closed
+  kindnet-admins:
+    description: Admin access to the kindnet repo
+    members:
+    - aojea
+    - bentheelder
+    - danwinship
+    - thockin
+    privacy: closed
+    repos:
+      kindnet: admin
+  kindnet-maintainers:
+    description: Write access to the kindnet repo
+    members:
+    - aojea
+    - bentheelder
+    - danwinship
+    - thockin
+    privacy: closed
+    repos:
+      kindnet: write
   knftables-admins:
     description: Admin access to the knftables repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -283,6 +283,7 @@ restrictions:
     - "^ingress-controller-conformance"
     - "^iptables-wrappers"
     - "^gateway-api"
+    - "^kindnet"
     - "^knftables"
     - "^kube-network-policies"
     - "^multi-network"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5801

/assign @kubernetes/sig-network-leads 

cc: @kubernetes/owners 