### PR TITLE
Revert "etcd: Update release-etcd team for release window"

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -169,7 +169,7 @@ teams:
     description: Granted permission to release etcd-io/etcd
     # The member list is intentionally empty. It should only include the release
     # lead during release windows.
-    members: [ivanvc]
+    members: []
     privacy: closed
     repos:
       etcd: maintain


### PR DESCRIPTION
Reverting to BAU after 3.5.24 and 3.4.38 releases.

/cc @ahrtr @jmhbnz 

This reverts commit 57f797c88ba89a2df9ed3933eb5e46cbf6495b28.