### PR TITLE
dra-example-driver: add nojnhuh as maintainer

### DIFF
--- a/config/kubernetes-sigs/sig-node/teams.yaml
+++ b/config/kubernetes-sigs/sig-node/teams.yaml
@@ -29,6 +29,7 @@ teams:
     description: Write access to dra-example-driver repo
     members:
     - bart0sh
+    - nojnhuh
     privacy: closed
     repos:
       dra-example-driver: write


### PR DESCRIPTION
This PR adds myself to the group with write access to the dra-example-driver repo where I'm already an approver: https://github.com/kubernetes-sigs/dra-example-driver/blob/ba82bf55dad820297b124b64cb4487958bb17466/OWNERS#L9

With write access to the repo I'll be able to do things like run GitHub Actions workflows on PRs and push tags during the release process without having to bother @pohly or @klueska or @bart0sh.