### PR TITLE
sig-network: add gh teams for kube-agentic-networking repo

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -266,6 +266,22 @@ teams:
     privacy: closed
     repos:
       knftables: admin
+  kube-agentic-networking-admins:
+    description: Admin access to the kube-agentic-networking repo
+    members:
+    - guicassolato
+    - LiorLieberman
+    privacy: closed
+    repos:
+      kube-agentic-networking: admin
+  kube-agentic-networking-maintainers:
+    description: Write access to the kube-agentic-networking repo
+    members:
+    - guicassolato
+    - LiorLieberman
+    privacy: closed
+    repos:
+      kube-agentic-networking: write
   kube-network-policies-admins:
     description: Admin access to the kube-network-policies repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -285,6 +285,7 @@ restrictions:
     - "^gateway-api"
     - "^kindnet"
     - "^knftables"
+    - "^kube-agentic-networking"
     - "^kube-network-policies"
     - "^multi-network"
     - "^multi-network-api"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5939

/assign @kubernetes/sig-network-leads

cc: @kubernetes/owners