### PR TITLE
sig-cli: remove gh teams for krm-functions-registry for repo archival

### DIFF
--- a/config/kubernetes-sigs/sig-cli/teams.yaml
+++ b/config/kubernetes-sigs/sig-cli/teams.yaml
@@ -71,24 +71,6 @@ teams:
     privacy: closed
     repos:
       krew-index: write
-  krm-functions-registry-admins:
-    description: admin access to krm-functions-registry
-    members:
-    - eddiezane
-    - jeremyrickard
-    - soltysh
-    privacy: closed
-    repos:
-      krm-functions-registry: admin
-  krm-functions-registry-maintainers:
-    description: write access to krm-functions-registry
-    members:
-    - eddiezane
-    - jeremyrickard
-    - soltysh
-    privacy: closed
-    repos:
-      krm-functions-registry: write
   kubectl-validate-admins:
     description: admin access to kubectl-validate
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -188,7 +188,6 @@ restrictions:
     - "^cli-utils"
     - "^krew"
     - "^krew-index"
-    - "^krm-functions-registry"
     - "^kubectl-validate"
     - "^kustomize"
   - path: "kubernetes-sigs/sig-cloud-provider/teams.yaml"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5894

/assign @kubernetes/sig-cli-leads 

cc: @kubernetes/owners