### PR TITLE
sig-release: add gh teams for new repo - signalhound

### DIFF
--- a/config/kubernetes-sigs/sig-release/teams.yaml
+++ b/config/kubernetes-sigs/sig-release/teams.yaml
@@ -243,6 +243,30 @@ teams:
     privacy: closed
     repos:
       release-utils: write
+  signalhound-admins:
+    description: admin access to the signalhound repo
+    members:
+    - cpanato
+    - drewhagen
+    - jeremyrickard
+    - justaugustus
+    - knabben
+    - puerco
+    - saschagrunert
+    - tico88612
+    - Verolop
+    privacy: closed
+    repos:
+      signalhound: admin
+  signalhound-maintainers:
+    description: write access to the signalhound repo
+    members:
+    - drewhagen
+    - knabben
+    - tico88612
+    privacy: closed
+    repos:
+      signalhound: write      
   tejolote-admins:
     description: admin access to tejolote
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -316,6 +316,7 @@ restrictions:
     - "^release-sdk"
     - "^release-team-shadow-stats"
     - "^release-utils"
+    - "^signalhound"
     - "^tejolote"
     - "^testgrid-json-exporter"
     - "^zeitgeist"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/5960

/assign @kubernetes/sig-release-leads 

cc: @kubernetes/owners