### PR TITLE
Update Steering members following annual election cycle

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -183,9 +183,9 @@ aliases:
   committee-steering:
     - aojea
     - BenTheElder
-    - justaugustus
+    - katcosgrove
     - pacoxu
-    - pohly
+    - ritazh
     - saschagrunert
     - soltysh
 ## BEGIN CUSTOM CONTENT

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1551,9 +1551,9 @@ teams:
     members:
     - aojea
     - BenTheElder
-    - justaugustus
+    - katcosgrove
     - pacoxu
-    - pohly
+    - ritazh
     - saschagrunert
     - soltysh
     privacy: closed


### PR DESCRIPTION
(Part of https://github.com/kubernetes/steering/issues/300.)

Add:

* Kat Cosgrove - @katcosgrove
* Rita Zhang - @ritazh

Now Emeritus:

* Patrick Ohly - @pohly 
* Stephen Augustus - @justaugustus 

Thanks to all of the Emeritus members for your service and welcome to the new Steering Committee members!

/assign @BenTheElder @aojea @saschagrunert 
/cc @kubernetes/steering-committee
/hold