### PR TITLE
chore: CAPA maintainer team changes

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -97,7 +97,7 @@ teams:
     description: maintain access to cluster-api-provider-aws
     members:
     - AndiDog
-    - Ankitasw
+    - damdo
     - dlipovetsky
     - nrb
     - richardcase


### PR DESCRIPTION
Contains changes to the CAPA maintainers team.

Relates: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5760