### PR TITLE
Update provider-aws owners aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -193,8 +193,9 @@ aliases:
 ## BEGIN CUSTOM CONTENT
   provider-aws:
     - justinsb
-    - nckturner
-    - wongma7
+    - DavidXU12345
+    - YangjinanHu
+    - samuhale
   provider-azure:
     - craiglpeters
     - feiskyer


### PR DESCRIPTION
@nckturner and @wongma7 are no long in AWS. Remove them and add active owners (@DavidXU12345, @YangjinanHu and @samuhale) in AWS