### PR TITLE
Add kfess to sig-docs-ja-reviewer

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -141,10 +141,10 @@ teams:
     - bells17
     - inductor
     - kakts
+    - kfess
     - nasa9084
     - Okabe-Junya
     - t-inu
-    - kfess
     privacy: closed
   sig-docs-ko-owners:
     description: Approvers for Korean content


### PR DESCRIPTION
### Feature Description
- Add @kfess to `sig-docs-ja-reviewer`

### FYI
- Merged PRs (kubernetes/website): https://github.com/pulls?q=is%3Amerged+is%3Apr+author%3Akfess+archived%3Afalse+repo%3Akubernetes%2Fwebsite
- Reviewed PRs (kubernetes/website): https://github.com/pulls?q=is%3Apr+reviewed-by%3Akfess+repo%3Akubernetes%2Fwebsite+

### Additional
https://github.com/kubernetes/website/pull/53618