### PR TITLE
CAPO: Sync owners from repo

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -20,7 +20,7 @@ teams:
     repos:
       cluster-addons: write
   cluster-api-addon-provider-helm-admins:
-    description:  Admin access to cluster-api-addon-provider-helm repo
+    description: Admin access to cluster-api-addon-provider-helm repo
     members:
     - fabriziopandini
     - jackfrancis
@@ -258,16 +258,20 @@ teams:
   cluster-api-provider-openstack-admins:
     description: admin access to cluster-api-provider-openstack
     members:
-    - EmilienM
+    - emilienm
     - lentzi90
+    - mandre
+    - stephenfin
     privacy: closed
     repos:
       cluster-api-provider-openstack: admin
   cluster-api-provider-openstack-maintainers:
     description: write access to cluster-api-provider-openstack
     members:
-    - EmilienM
+    - emilienm
     - lentzi90
+    - mandre
+    - stephenfin
     privacy: closed
     repos:
       cluster-api-provider-openstack: write


### PR DESCRIPTION
For reference, the owners and aliases in CAPO:

- https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/main/OWNERS
- https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/main/OWNERS_ALIASES

