### PR TITLE
add gh team for k-sigs/owners

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -1069,3 +1069,14 @@ teams:
     privacy: closed
     repos:
       node-feature-discovery: write
+  owners:
+    description: Kubernetes GitHub Owners
+    maintainers:
+    - cblecker
+    - jasonbraganza
+    - MadhavJivrajani
+    - mrbobbytables
+    - nikhita
+    - palnabarun
+    - Priyankasaggu11929
+    privacy: closed


### PR DESCRIPTION
We don't have a GH team for tagging all GH admins in Kubernetes-sigs org.

Fixing that.



cc: @kubernetes/owners 