### PR TITLE
Add vitorfloriano to kubernetes

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1037,6 +1037,7 @@ members:
 - vincepri
 - vishalanarase
 - vishesh92
+- vitorfloriano
 - vladikkuzn
 - vladimirvivien
 - voelzmo


### PR DESCRIPTION
@vitorfloriano (myself) is already a member of kubernetes-sigs.

https://github.com/kubernetes/org/blob/30001ac74915cb78693cd7c8a59307214f633ca6/config/kubernetes-sigs/org.yaml#L901

Need to be added to kubernetes to be accepted in kubernetes/test-infra OWNER_ALIASES.

Ref. kubernetes/test-infra#36152

