### PR TITLE
Add nerdeveloper to kubernetes and kubernetes-sigs orgs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -616,6 +616,7 @@ members:
 - ndipebot
 - nearora-msft
 - neolit123
+- nerdeveloper
 - ngopalak-redhat
 - nicslatts
 - nilekhc

--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -711,6 +711,7 @@ members:
 - negz
 - neoaggelos
 - neolit123
+- nerdeveloper
 - network-charles
 - nilekhc
 - nilo19


### PR DESCRIPTION
## Membership Request

**GitHub Username:** @nerdeveloper

**Organizations:** kubernetes, kubernetes-sigs

**Sponsors:**
- @camilamacedo86 (Kubebuilder maintainer)
- @mimowo (Kueue maintainer)

## Contributions

### Kubebuilder (kubernetes-sigs/kubebuilder)
- https://github.com/kubernetes-sigs/kubebuilder/pull/5116 - Refactor sampleexternalplugin to be a valid reference implementation *(open)*
- https://github.com/kubernetes-sigs/kubebuilder/pull/5107 - Add docs for custom markers
- https://github.com/kubernetes-sigs/kubebuilder/pull/5087 - Update tutorials with Status Conditions
- https://github.com/kubernetes-sigs/kubebuilder/pull/5042 - Fix empty CRD directory handling

### Kueue (kubernetes-sigs/kueue)
- https://github.com/kubernetes-sigs/kueue/pull/7490 - Remove deprecated AdmissionChecks field
- https://github.com/kubernetes-sigs/kueue/pull/7407 - Remove deprecated retryDelayMinutes field
- https://github.com/kubernetes-sigs/kueue/pull/7406 - Remove deprecated PodIntegrationOptions API

## Checklist
- [x] Reviewed community membership guidelines
- [x] Enabled 2FA on GitHub
- [x] Actively contributing to Kubernetes subprojects
- [x] Have two sponsors from different companies
- [x] Sponsors are reviewers/approvers in OWNERS files
- [x] Spoken to sponsors ahead of this application

/cc @camilamacedo86 @mimowo