### PR TITLE
Add v1.36 Release Team members

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -320,7 +320,7 @@ teams:
           release-team-docs:
             description: Members of the Docs team for the current release cycle.
             members:
-            - sayanchowdhury # 1.65 Docs Lead
+            - sayanchowdhury # 1.36 Docs Lead
             privacy: closed
           release-team-comms:
             description: Members of the Comms team for the current release cycle.


### PR DESCRIPTION
This only updates the Release Lead, Release Lead Shadows, and Subteam Leads entries, as well as subteam members.

As I saw many names from v1.34 or before in the `milestone-maintainers`, I kept the list as is, and will probably look to clean up in a separate PR.