### PR TITLE
Sync `config/kubernetes-sigs/sig-apps/teams.yaml` to https://github.com/kubernetes-sigs/jobset/blob/main/OWNERS

### DIFF
--- a/config/kubernetes-sigs/sig-apps/teams.yaml
+++ b/config/kubernetes-sigs/sig-apps/teams.yaml
@@ -38,7 +38,7 @@ teams:
     members:
     - ahg-g
     - andreyvelich
-    - danielvegamyhre
+    - GiuseppeTT
     - kannon92
     privacy: closed
     repos:
@@ -48,6 +48,7 @@ teams:
     members:
     - ahg-g
     - andreyvelich
+    - GiuseppeTT
     - kannon92
     privacy: closed
     repos:


### PR DESCRIPTION
Sync `config/kubernetes-sigs/sig-apps/teams.yaml` to https://github.com/kubernetes-sigs/jobset/blob/main/OWNERS

In practice, this means:

- Add @GiuseppeTT (myself) to `jobset-admins` and `jobset-maintainers`
- Remove @danielvegamyhre from `jobset-admins`

This is a follow up to https://github.com/kubernetes-sigs/jobset/pull/1122 and https://github.com/kubernetes-sigs/jobset/pull/1123 .

cc @ahg-g @kannon92 @andreyvelich @danielvegamyhre 
