### PR TITLE
Move mrbobbytables out of blog owners

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -1,8 +1,6 @@
 teams:
   sig-docs-blog-owners:
     description: Approvers for blog content
-    maintainers:
-    - mrbobbytables
     members:
     - Gauravpadam
     - graz-dev


### PR DESCRIPTION
Remove @mrbobbytables from our source of truth for @kubernetes/sig-docs-blog-owners. This change is OK because:
- we have other folks happy to help here
- Bob / @mrbobbytables has plenty of other things going on

Also see https://github.com/kubernetes/website/pull/54074

@mrbobbytables if you would LGTM this one, I'd appreciate it, just so we have on record that you're happy to step away.

