### PR TITLE
add wonyongg to sig docs ko reviews

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -159,6 +159,7 @@ teams:
     - jihoon-seo
     - jongwooo
     - seokho-son
+    - wonyongg
     privacy: closed
   sig-docs-leads:
     description: Chairs and tech leads for SIG Docs


### PR DESCRIPTION
Add @wonyongg to sig-docs-ko-reviewes. (Reviewer for Korean l10n contents)