### PR TITLE
sig-ui: remove k/dashboard gh teams for repo archival

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1267,24 +1267,6 @@ teams:
     - jeremyrickard
     - stmcginnis
     privacy: closed
-  dashboard-admins:
-    description: Admins of the dashboard repo
-    members:
-    - floreks
-    - maciaszczykm
-    privacy: closed
-    repos:
-      dashboard: admin
-  dashboard-maintainers:
-    description: Write access to the dashboard repo
-    members:
-    - floreks
-    - jeefy
-    - maciaszczykm
-    - shu-mutou
-    privacy: closed
-    repos:
-      dashboard: write
   dep-approvers:
     description: People who can approve dependency changes in kubernetes/kubernetes
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -37,7 +37,6 @@ restrictions:
     - "^committee-security-response"
     - "^cloud-provider-gcp"
     - "^cloud-provider-vsphere"
-    - "^dashboard"
     - "^dns"
     - "^examples"
     - "^gengo"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/6046

Repo was already archived. 
Now migrated to https://github.com/kubernetes-retired/dashboard

PR cleans up the gh teams for the old repo location.

cc: @shu-mutou @joaquimrocha @floreks 