### PR TITLE
Add ronaldngounou to kubernetes-sigs member

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -737,6 +737,7 @@ members:
 - robscott
 - rolfedh
 - RomanBednar
+- ronaldngounou
 - rostislavbobo
 - roycaihw
 - rschalo


### PR DESCRIPTION
I am already member of kubernetes org.

Add ronaldngounou to kubernetes-sigs member

```
We are currently working on automation that would transfer membership in the Kubernetes organization to any related orgs automatically, but such is not the case currently.
```


Issue https://github.com/kubernetes/org/issues/6109#issuecomment-3815619143

cc @jasonbraganza 