### PR TITLE
Adds Dipesh Rawat as SIG Docs tech lead

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -165,6 +165,7 @@ teams:
   sig-docs-leads:
     description: Chairs and tech leads for SIG Docs
     members:
+    - dipesh-rawat
     - divya-mohan0209
     - katcosgrove
     - natalisucks


### PR DESCRIPTION
Add myself to the `sig-docs-leads` team as SIG Docs Tech Lead (missed in the initial PR).

cc @natalisucks @divya-mohan0209 @reylejano