### PR TITLE
Update admins for LWKD

### DIFF
--- a/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
+++ b/config/kubernetes-sigs/sig-contributor-experience/teams.yaml
@@ -21,10 +21,10 @@ teams:
     description: admin access to the lwkd repo
     members:
     - coderanger
+    - Hii-Arpit
     - jberkus
     - mfahlandt
     - sreeram-venkitesh
-    - Hii-Arpit
     privacy: closed
     repos:
       lwkd: admin


### PR DESCRIPTION
Two changes to the list of admins:

1. Remove @fykaa who is no longer active with LWKD
2. Add @Hii-Arpit who is a current editor.

/sig contributor-experience