### PR TITLE
Add sig-k8s-infra-dns-admins team

### DIFF
--- a/config/kubernetes/sig-k8s-infra/teams.yaml
+++ b/config/kubernetes/sig-k8s-infra/teams.yaml
@@ -53,6 +53,13 @@ teams:
           - upodroid
           - xmudrii
         privacy: closed
+      sig-k8s-infra-dns-admins:
+        description: sig-k8s-infra dns admins
+        maintainers:
+          - cblecker
+        members:
+          - BenTheElder
+        privacy: closed
       registry.k8s.io-admins:
         description: Admin access to kubernetes/registry.k8s.io
         members:


### PR DESCRIPTION
## Summary

Create a new GitHub team `sig-k8s-infra-dns-admins` nested under the `sig-k8s-infra` parent team.

## Changes

- Add `sig-k8s-infra-dns-admins` team to `config/kubernetes/sig-k8s-infra/teams.yaml`
- Team members: BenTheElder and cblecker
- Privacy: closed
- No repository permissions (membership-only team)

## Verification

- YAML syntax validated successfully
- Team added in alphabetical order with other sub-teams