### PR TITLE
update wg-ai-conformance to ai-conformance

### DIFF
--- a/config/kubernetes-sigs/sig-architecture/teams.yaml
+++ b/config/kubernetes-sigs/sig-architecture/teams.yaml
@@ -71,8 +71,8 @@ teams:
     privacy: closed
     repos:
       verify-conformance: admin
-  wg-ai-conformance-admins:
-    description: Admin access to wg-ai-conformance repo
+  ai-conformance-admins:
+    description: Admin access to ai-conformance repo
     members:
     - janetkuo
     - mfahlandt
@@ -80,9 +80,9 @@ teams:
     - terrytangyuan
     privacy: closed
     repos:
-      wg-ai-conformance: admin
-  wg-ai-conformance-maintainers:
-    description: Write access to wg-ai-conformance repo
+      ai-conformance: admin
+  ai-conformance-maintainers:
+    description: Write access to ai-conformance repo
     members:
     - janetkuo
     - mfahlandt
@@ -90,7 +90,7 @@ teams:
     - terrytangyuan
     privacy: closed
     repos:
-      wg-ai-conformance: write
+      ai-conformance: write
   wg-device-management-admins:
     description: Admin access to wg-device-management repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -165,7 +165,7 @@ restrictions:
     - "^depstat"
     - "^maintainer-tools"
     - "^verify-conformance"
-    - "^wg-ai-conformance"
+    - "^ai-conformance"
     - "^wg-device-management"
     - "^wg-serving"
   - path: "kubernetes-sigs/sig-auth/teams.yaml"


### PR DESCRIPTION
failing Prow job - https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-org-peribolos/2029447963259965440

```
{"component":"unset","level":"fatal","msg":"Configuration failed: failed to configure kubernetes-sigs team wg-ai-conformance-admins repos: failed to update team 14157272(wg-ai-conformance-admins) permissions on repo wg-ai-conformance to admin: status code 404 not one of [204], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/teams/teams#add-or-update-team-repository-permissions\",\"status\":\"404\"}","severity":"fatal","time":"2026-03-05T06:48:05Z"}
```