### PR TITLE
Add porridge to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -689,6 +689,7 @@ members:
 - pmalek
 - pohly
 - poonam-lamba
+- porridge
 - Pradumnasaraf
 - Prajyot-Parab
 - prankulmahajan


### PR DESCRIPTION
I'm already member of the kubernetes org, and the [request form](https://github.com/kubernetes/org/issues/new?assignees=&labels=area%2Fgithub-membership&template=membership.yml&title=REQUEST%3A+New+membership+for+%3Cyour-GH-handle%3E) says I can add myself directly to other orgs:

> Please note, if you are already part of any Kubernetes GitHub organization like kubernetes-sigs and you are filing this request to be added to kubernetes, you do not need to open this request and can add yourself directly! The org memberships are now equivalent and sponsorship is not needed to join additional Kubernetes GitHub orgs. 