### PR TITLE
Add admin access for the work-api repo

### DIFF
--- a/config/kubernetes-sigs/sig-multicluster/teams.yaml
+++ b/config/kubernetes-sigs/sig-multicluster/teams.yaml
@@ -53,6 +53,8 @@ teams:
     description: Admin access for the work-api repo
     members:
     - jeremyot
+    - qiujian16
+    - RainbowMango
     - skitt
     privacy: closed
     repos:


### PR DESCRIPTION
## What

Add the current `work-api` approver to the `work-api-admins` team in `kubernetes-sigs`.

## Why

I am a maintainer of `kubernetes-sigs/work-api`, but I currently do not have sufficient repository permissions when handling PRs such as https://github.com/kubernetes-sigs/work-api/pull/63.


