### PR TITLE
Add yankay to kubespray-admins in kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
+++ b/config/kubernetes-sigs/sig-cluster-lifecycle/teams.yaml
@@ -361,6 +361,7 @@ teams:
     - ant31
     - chadswen
     - floryut
+    - yankay
     privacy: closed
     repos:
       kubespray: admin


### PR DESCRIPTION
## Summary

Add `yankay` to `kubespray-admins` team in `kubernetes-sigs`.

Slack discussion: https://kubernetes.slack.com/archives/C01672LSZL0/p1773315543465089?thread_ts=1773307901.107919&cid=C01672LSZL0

---

I wanted to ask whether we can enable GitHub Copilot capabilities for @kubernetes-sigs/kubespray:

1) Enable "Automatically request Copilot code review" in the repository rules (Rulesets / Branch rules) so that new PRs automatically request a Copilot review.
2) Also, can we enable/allow Copilot to work directly from issues—i.e., have a Copilot agent propose a fix and open a PR for the issue?

I noticed that some other projects (e.g., @kubernetes-sigs/headlamp) seem to have already enabled and are using similar capabilities, so I'd like to confirm the process for enabling this in kubespray and what prerequisites are required (e.g., org-level Copilot settings, licensing, and any repo-admin configuration).

If you need a concrete PR example or details about my current permissions, I can provide them. Thanks!