### PR TITLE
Add nmn3m to sig-instrumentation-members

### DIFF
--- a/config/kubernetes/sig-instrumentation/teams.yaml
+++ b/config/kubernetes/sig-instrumentation/teams.yaml
@@ -32,6 +32,7 @@ teams:
     - ehashman
     - lilic
     - mrueg
+    - nmn3m
     - pohly
     - RainbowMango
     - rexagod


### PR DESCRIPTION
Syncing sig-instrumentation-members with current reviewers list
Fixes https://github.com/kubernetes/org/issues/6206