### PR TITLE
Add new documentation approvers.  Remove retired approver.

### DIFF
--- a/config/etcd-io/sig-etcd/teams.yaml
+++ b/config/etcd-io/sig-etcd/teams.yaml
@@ -99,11 +99,12 @@ teams:
     - chalin
     - ivanvc
     - jberkus
-    - jmhbnz
     - nate-double-u
+    - ronaldngounou
     - serathius
     - siyuanfoundation
     - spzala
+    - wendy-ha18
     privacy: closed
     repos:
       website: admin


### PR DESCRIPTION
This syncs the list of maintainers with the [OWNERS file](https://github.com/etcd-io/website/blob/main/OWNERS).