### PR TITLE
Add pablo-ruth to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -678,6 +678,7 @@ members:
 - oomichi
 - OrlinVasilev
 - orsenthil
+- pablo-ruth
 - pacoxu
 - pajakd
 - parispittman


### PR DESCRIPTION
I'm already a member of the kubernetes org and I need to join kubernetes-sigs to be added as an OWNER on the Scaleway provider part of the image-builder project (https://github.com/kubernetes-sigs/image-builder/pull/1967).