### PR TITLE
sig-scheduling: add gh teams for scheduler-library repo

### DIFF
--- a/config/kubernetes-sigs/sig-scheduling/teams.yaml
+++ b/config/kubernetes-sigs/sig-scheduling/teams.yaml
@@ -110,6 +110,24 @@ teams:
     privacy: closed
     repos:
       kwok: write
+  scheduler-library-admins:
+    description: Admin access to the scheduler-library repo
+    members:
+    - dom4ha
+    - macsko
+    - sanposhiho
+    privacy: closed
+    repos:
+      scheduler-library: admin
+  scheduler-library-maintainers:
+    description: Write access to the scheduler-library repo
+    members:
+    - dom4ha
+    - macsko
+    - sanposhiho
+    privacy: closed
+    repos:
+      scheduler-library: write
   scheduler-plugins-admins:
     description: Admin access to the scheduler-plugins repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -342,6 +342,7 @@ restrictions:
     - "^kube-scheduler-wasm-extension"
     - "^kueue"
     - "^kwok"
+    - "^scheduler-library"
     - "^scheduler-plugins"
   - path: "kubernetes-sigs/sig-storage/teams.yaml"
     allowedRepos:


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/6273

/assign @kubernetes/sig-scheduling-leads 

cc: @kubernetes/owners