### PR TITLE
sig-autoscaler: add gh teams for new cluster-autoscaler repo

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -134,6 +134,7 @@ members:
 - bgrant0607
 - Bharadwajshivam28
 - bhope
+- BigDarkClown
 - binacs
 - bishal7679
 - BlaineEXE

--- a/config/kubernetes-sigs/sig-autoscaling/teams.yaml
+++ b/config/kubernetes-sigs/sig-autoscaling/teams.yaml
@@ -1,4 +1,28 @@
 teams:
+  cluster-autoscaler-admins:
+    description: admin access to the cluster-autoscaler repo
+    members:
+    - adrianmoisey
+    - BigDarkClown
+    - gjtempleton
+    - jackfrancis
+    - towca
+    - x13n
+    privacy: closed
+    repos:
+      cluster-autoscaler: admin
+  cluster-autoscaler-maintainers:
+    description: write access to the cluster-autoscaler repo
+    members:
+    - adrianmoisey
+    - BigDarkClown
+    - gjtempleton
+    - jackfrancis
+    - towca
+    - x13n
+    privacy: closed
+    repos:
+      cluster-autoscaler: write
   karpenter-admins:
     description: admin access to the karpenter repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -182,6 +182,7 @@ restrictions:
     - "^sig-auth-tools"
   - path: "kubernetes-sigs/sig-autoscaling/teams.yaml"
     allowedRepos:
+    - "^cluster-autoscaler"
     - "^karpenter"
     - "^karpenter-provider-ibm-cloud"
   - path: "kubernetes-sigs/sig-aws/teams.yaml"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/6221

/assign @kubernetes/sig-autoscaling-leads 

cc: @kubernetes/owners

---

Please note: PR adds @BigDarkClown to the kubernetes-sigs org, as they are an [existing member of the kubernetes org](https://github.com/kubernetes/org/blob/4ecb20cca1ca3716e2d01d68d98f90d6bef45ae2/config/kubernetes/org.yaml#L158)