### PR TITLE
sig-network: add gh teams for new node-local-dns repo

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -420,6 +420,26 @@ teams:
     privacy: closed
     repos:
       network-policy-finalizer: write
+  node-local-dns-admins:
+    description: Admin access to the node-local-dns repo
+    members:
+    - aojea
+    - bowei
+    - danwinship
+    - thockin
+    privacy: closed
+    repos:
+      node-local-dns: admin
+  node-local-dns-maintainers:
+    description: Write access to the node-local-dns repo
+    members:
+    - aojea
+    - bowei
+    - danwinship
+    - thockin
+    privacy: closed
+    repos:
+      node-local-dns: write
   node-ipam-controller-admins:
     description: Admin access to the node-ipam-controller repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -301,6 +301,7 @@ restrictions:
     - "^nat64"
     - "^network-policy-api"
     - "^network-policy-finalizer"
+    - "^node-local-dns"
     - "^node-ipam-controller"
     - "^wg-ai-gateway"
   - path: "kubernetes-sigs/sig-node/teams.yaml"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/6192

/assign @kubernetes/sig-network-leads

cc: @kubernetes/owners