### PR TITLE
add pfeifferj to main kubernetes org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -810,6 +810,7 @@ members:
 - pegasas
 - perriea
 - petr-muller
+- pfeifferj
 - Phaow
 - pierluigilenoci
 - pierreprinetti


### PR DESCRIPTION
already a member of kubernetes-sigs via SIG Autoscaling. adding myself to the kubernetes org per the equivalent-org-membership policy.