### PR TITLE
sig-node: add gh teams for dra-driver-google-tpu repo

### DIFF
--- a/config/kubernetes-sigs/sig-node/teams.yaml
+++ b/config/kubernetes-sigs/sig-node/teams.yaml
@@ -93,6 +93,24 @@ teams:
     privacy: closed
     repos:
       noderesourcetopology-api: write
+  dra-driver-google-tpu-admins:
+    description: Admin access to dra-driver-google-tpu repo
+    members:
+    - johnbelamaric
+    - mortent
+    - troychiu
+    privacy: closed
+    repos:
+      dra-driver-google-tpu: admin
+  dra-driver-google-tpu-maintainers:
+    description: Write access to dra-driver-google-tpu repo
+    members:
+    - johnbelamaric
+    - mortent
+    - troychiu
+    privacy: closed
+    repos:
+      dra-driver-google-tpu: write
   dra-driver-nvidia-gpu-admins:
     description: Admin access to dra-driver-nvidia-gpu repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -313,6 +313,7 @@ restrictions:
     - "^noderesourcetopology-api"
     - "^node-feature-discovery-operator"
     - "^node-readiness-controller"
+    - "^dra-driver-google-tpu"
     - "^dra-driver-nvidia-gpu"
     - "^security-profiles-operator"
   - path: "kubernetes-sigs/sig-release/teams.yaml"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/6285

cc: @kubernetes/owners 

/assign @kubernetes/sig-node-leads 