### PR TITLE
sig-apps: update gh teams for mcp-lifecycle-operator

### DIFF
--- a/config/kubernetes-sigs/sig-apps/teams.yaml
+++ b/config/kubernetes-sigs/sig-apps/teams.yaml
@@ -90,7 +90,9 @@ teams:
   mcp-lifecycle-operator-admins:
     description: Admin access to mcp-lifecycle-operator repo
     members:
+    - aliok
     - ArangoGutierrez
+    - matzew
     - mikebrow
     - mrunalp
     - soltysh
@@ -100,7 +102,9 @@ teams:
   mcp-lifecycle-operator-maintainers:
     description: Write access to mcp-lifecycle-operator repo
     members:
+    - aliok
     - ArangoGutierrez
+    - matzew
     - mikebrow
     - mrunalp
     - soltysh


### PR DESCRIPTION
Add @aliok and @matzew to GH teams for https://github.com/kubernetes-sigs/mcp-lifecycle-operator.

Both are already in the owners file: https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/OWNERS

And both are in the org:
- https://github.com/kubernetes/org/issues/6169
- https://github.com/kubernetes/org/issues/6168

cc @Priyankasaggu11929 