### PR TITLE
Add sayanchowdhury to the website-maintainers for v1.36 release

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -320,6 +320,7 @@ teams:
     - reylejano # L10n: English
     - salaxander # L10n: English
     - SataQiu # L10n: Chinese
+    - sayanchowdhury # v1.36 Release Docs Lead
     - seokho-son # L10n: Korean
     - shurup # L10n: Russian
     - t-inu # L10n: Japanese


### PR DESCRIPTION
Temporary adding myself (`sayanchowdhury`) to the website-maintainers team for write access to `k/website` repo in preparation to the v1.36 Release Day tasks.

/assign @reylejano 