### PR TITLE
Sync repo-infra teams with OWNERS

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -181,7 +181,6 @@ teams:
   repo-infra-admins:
     description: Admin access to the repo-infra repo
     members:
-    - BenTheElder
     - cpanato
     - justaugustus
     - puerco
@@ -191,11 +190,18 @@ teams:
       repo-infra: admin
   repo-infra-maintainers:
     description: Write access to the repo-infra repo
+    maintainers:
+    - palnabarun
     members:
-    - BenTheElder
+    - ameukam
+    - cici37
     - cpanato
+    - jeremyrickard
+    - jimangel
+    - jrsapi
     - justaugustus
     - puerco
+    - salaxander
     - saschagrunert
     - Verolop
     - xmudrii


### PR DESCRIPTION
Remove BenTheElder from repo-infra-admins and repo-infra-maintainers after moving to emeritus in kubernetes/repo-infra#253.

Add active release-engineering approvers and reviewers to repo-infra-maintainers to match the current OWNERS_ALIASES.

/cc @BenTheElder