### PR TITLE
add YangjinanHu as member to kubernetes

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1177,6 +1177,7 @@ members:
 - yagikota
 - yagonobre
 - YamasouA
+- YangjinanHu
 - yangjunmyfm192085
 - yankay
 - YanzhaoLi


### PR DESCRIPTION
I'm already a member of kubernetes-sigs (https://github.com/kubernetes/org/issues/6039). 

Per the [community membership doc](https://github.com/kubernetes/community/blob/main/community-membership.md#kubernetes-ecosystem): > If you are a member of one of these Orgs, you are implicitly eligible for membership in related orgs, and can request membership when it becomes relevant, by creating a PR directly. Adding myself to the kubernetes org. So this https://github.com/kubernetes/org/pull/6375 can automatically ok-to-test my PRs.