### PR TITLE
sig-apps: add gh teams for kube-agents & devops-bench repo

### DIFF
--- a/config/kubernetes-sigs/sig-apps/teams.yaml
+++ b/config/kubernetes-sigs/sig-apps/teams.yaml
@@ -17,6 +17,24 @@ teams:
     privacy: closed
     repos:
       agent-sandbox: write
+  devops-bench-admins:
+    description: Admin access to devops-bench repo
+    members:
+    - janetkuo
+    - kow3ns
+    - soltysh
+    privacy: closed
+    repos:
+      devops-bench: admin
+  devops-bench-maintainers:
+    description: Write access to devops-bench repo
+    members:
+    - janetkuo
+    - kow3ns
+    - soltysh
+    privacy: closed
+    repos:
+      devops-bench: write
   execution-hook-admins:
     description: Admin access to execution-hook repo
     members:

--- a/config/kubernetes-sigs/sig-apps/teams.yaml
+++ b/config/kubernetes-sigs/sig-apps/teams.yaml
@@ -69,6 +69,24 @@ teams:
     privacy: closed
     repos:
       kjob: write
+  kube-agents-admins:
+    description: Admin access to kube-agents repo
+    members:
+    - janetkuo
+    - kow3ns
+    - soltysh
+    privacy: closed
+    repos:
+      kube-agents: admin
+  kube-agents-maintainers:
+    description: Write access to kube-agents repo
+    members:
+    - janetkuo
+    - kow3ns
+    - soltysh
+    privacy: closed
+    repos:
+      kube-agents: write
   lws-admins:
     description: Admin access to lws repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -161,6 +161,7 @@ restrictions:
     - "^execution-hook"
     - "^jobset"
     - "^kjob"
+    - "^kube-agents"
     - "^llm-instance-gateway$"
     - "^lws"
     - "^mcp-lifecycle-operator"

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -158,6 +158,7 @@ restrictions:
   - path: "kubernetes-sigs/sig-apps/teams.yaml"
     allowedRepos:
     - "^agent-sandbox"
+    - "^devops-bench"
     - "^execution-hook"
     - "^jobset"
     - "^kjob"


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/6367

cc: @kubernetes/owners

/assign @kubernetes/sig-apps-leads