### PR TITLE
Add kahirokunn to kubernetes org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -537,6 +537,7 @@ members:
 - k8s-publishing-bot
 - k8s-release-robot
 - kad
+- kahirokunn
 - kaisoz
 - kakts
 - kamarabbas99


### PR DESCRIPTION
I'm already a member of kubernetes-sigs (https://github.com/kubernetes/org/issues/5325, added via https://github.com/kubernetes/org/pull/5350).
Per the [community membership doc](https://github.com/kubernetes/community/blob/main/community-membership.md#kubernetes-ecosystem):
> If you are a member of one of these Orgs, you are implicitly eligible for membership in related orgs
The doc also says this can be requested directly by PR when it becomes relevant.

This will help move kubernetes/k8s.io#9499 forward.