### PR TITLE
Add v1.37 Release Comms Shadows to teams.yaml

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -110,8 +110,8 @@ teams:
     - sttts # API Machinery
     - SwathiR03 # v1.37 Comms Lead
     - tallclair # Auth
-    - TineoC #v1.37 Release Comms Shadow
     - thockin # Network
+    - TineoC #v1.37 Release Comms Shadow
     - towca # Autoscaling
     - troy0820 #v1.37 Release Comms Shadow
     - upodroid # K8s Infra
@@ -320,10 +320,10 @@ teams:
           release-team-comms:
             description: Members of the Comms team for the current release cycle.
             members:
-            - SwathiR03 # v1.37 Comms Lead
             - kirti763 #v1.37 Release Comms Shadow
             - RinkiyaKeDad # v1.37 Release Comms Shadow
             - SophiaUgo #v1.37 Release Comms Shadow
+            - SwathiR03 # v1.37 Comms Lead
             - TineoC #v1.37 Release Comms Shadow
             - troy0820 #v1.37 Release Comms Shadow
             privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -105,7 +105,7 @@ teams:
     - shu-mutou # UI
     - shyamjvs # Scalability
     - soltysh # CLI
-    - SophiaUgo #v1.37 Release Comms Shadow
+    - SophiaUgo # v1.37 Release Comms Shadow
     - spzala # IBM Cloud
     - sttts # API Machinery
     - SwathiR03 # v1.37 Comms Lead

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -120,7 +120,7 @@ teams:
     - wojtek-t # Scalability
     - xing-yang # Storage
     - xmudrii # Release Manager / K8s Infra
-    - zylxjtu # Windows       
+    - zylxjtu # Windows
     privacy: closed
     previously:
     - kubernetes-milestone-maintainers

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -297,7 +297,7 @@ teams:
         - saschagrunert # subproject owner / Chair
         - savitharaghunathan # subproject owner (1.22 RT Lead)
         - sayanchowdhury # v1.37 Release Lead Shadow
-        - SophiaUgo #v1.37 Release Comms Shadow
+        - SophiaUgo # v1.37 Release Comms Shadow
         - SwathiR03 # v1.37 Comms Lead
         - TineoC #v1.37 Release Comms Shadow
         - troy0820 #v1.37 Release Comms Shadow

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -322,7 +322,7 @@ teams:
             members:
             - kirti763 # v1.37 Release Comms Shadow
             - RinkiyaKeDad # v1.37 Release Comms Shadow
-            - SophiaUgo #v1.37 Release Comms Shadow
+            - SophiaUgo # v1.37 Release Comms Shadow
             - SwathiR03 # v1.37 Comms Lead
             - TineoC # v1.37 Release Comms Shadow
             - troy0820 # v1.37 Release Comms Shadow

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -64,7 +64,7 @@ teams:
     - k8s-release-robot # Release
     - kannon92 # wg-batch organizer
     - katcosgrove # v1.32 EA
-    - kirti763 #v1.37 Release Comms Shadow
+    - kirti763 # v1.37 Release Comms Shadow
     - kow3ns # Apps
     - liggitt # Auth / Release
     - luxas # Cluster Lifecycle

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -320,7 +320,7 @@ teams:
           release-team-comms:
             description: Members of the Comms team for the current release cycle.
             members:
-            - kirti763 #v1.37 Release Comms Shadow
+            - kirti763 # v1.37 Release Comms Shadow
             - RinkiyaKeDad # v1.37 Release Comms Shadow
             - SophiaUgo #v1.37 Release Comms Shadow
             - SwathiR03 # v1.37 Comms Lead

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -299,8 +299,8 @@ teams:
         - sayanchowdhury # v1.37 Release Lead Shadow
         - SophiaUgo # v1.37 Release Comms Shadow
         - SwathiR03 # v1.37 Comms Lead
-        - TineoC #v1.37 Release Comms Shadow
-        - troy0820 #v1.37 Release Comms Shadow
+        - TineoC # v1.37 Release Comms Shadow
+        - troy0820 # v1.37 Release Comms Shadow
         - Verolop # Release Manager
         - whtssub # v1.37 Enhancements Lead
         - xmudrii # Release Manager

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -64,6 +64,7 @@ teams:
     - k8s-release-robot # Release
     - kannon92 # wg-batch organizer
     - katcosgrove # v1.32 EA
+    - kirti763 #v1.37 Release Comms Shadow
     - kow3ns # Apps
     - liggitt # Auth / Release
     - luxas # Cluster Lifecycle
@@ -91,6 +92,7 @@ teams:
     - rayandas # v1.37 Release Lead Shadow
     - rexagod # Instrumentation
     - richabanker # Instrumentation
+    - RinkiyaKeDad # v1.37 Release Comms Shadow
     - ritazh # Auth
     - saad-ali # Storage
     - salaxander # Release Manager Associate / 1.29 RT EA
@@ -103,19 +105,22 @@ teams:
     - shu-mutou # UI
     - shyamjvs # Scalability
     - soltysh # CLI
+    - SophiaUgo #v1.37 Release Comms Shadow
     - spzala # IBM Cloud
     - sttts # API Machinery
     - SwathiR03 # v1.37 Comms Lead
     - tallclair # Auth
+    - TineoC #v1.37 Release Comms Shadow
     - thockin # Network
     - towca # Autoscaling
+    - troy0820 #v1.37 Release Comms Shadow
     - upodroid # K8s Infra
     - Verolop # Release Manager
     - whtssub # v1.37 Enhancements Lead
     - wojtek-t # Scalability
     - xing-yang # Storage
     - xmudrii # Release Manager / K8s Infra
-    - zylxjtu # Windows
+    - zylxjtu # Windows       
     privacy: closed
     previously:
     - kubernetes-milestone-maintainers
@@ -280,17 +285,22 @@ teams:
         - justaugustus # subproject owner / Chair
         - katcosgrove # 1.30 Lead / 1.32 EA
         - kernel-kun # v1.37 Docs Lead
+        - kirti763 #v1.37 Release Comms Shadow
         - mickeyboxell # 1.32 Release Manager Shadow
         - Prajyot-Parab  # v1.37 Release Lead Shadow
         - puerco # subproject owner / Technical Lead
         - rayandas # v1.37 Release Lead Shadow
         - reylejano # subproject owner (1.23 RT Lead)
+        - RinkiyaKeDad # v1.37 Release Comms Shadow
         - rytswd # v1.37 Release Branch Management Shadow
         - salaxander # subproject owner (1.27 RT Lead)
         - saschagrunert # subproject owner / Chair
         - savitharaghunathan # subproject owner (1.22 RT Lead)
         - sayanchowdhury # v1.37 Release Lead Shadow
+        - SophiaUgo #v1.37 Release Comms Shadow
         - SwathiR03 # v1.37 Comms Lead
+        - TineoC #v1.37 Release Comms Shadow
+        - troy0820 #v1.37 Release Comms Shadow
         - Verolop # Release Manager
         - whtssub # v1.37 Enhancements Lead
         - xmudrii # Release Manager
@@ -311,6 +321,11 @@ teams:
             description: Members of the Comms team for the current release cycle.
             members:
             - SwathiR03 # v1.37 Comms Lead
+            - kirti763 #v1.37 Release Comms Shadow
+            - RinkiyaKeDad # v1.37 Release Comms Shadow
+            - SophiaUgo #v1.37 Release Comms Shadow
+            - TineoC #v1.37 Release Comms Shadow
+            - troy0820 #v1.37 Release Comms Shadow
             privacy: closed
           release-team-enhancements:
             description: Members of the Enhancements team for the current release

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -324,8 +324,8 @@ teams:
             - RinkiyaKeDad # v1.37 Release Comms Shadow
             - SophiaUgo #v1.37 Release Comms Shadow
             - SwathiR03 # v1.37 Comms Lead
-            - TineoC #v1.37 Release Comms Shadow
-            - troy0820 #v1.37 Release Comms Shadow
+            - TineoC # v1.37 Release Comms Shadow
+            - troy0820 # v1.37 Release Comms Shadow
             privacy: closed
           release-team-enhancements:
             description: Members of the Enhancements team for the current release

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -111,7 +111,7 @@ teams:
     - SwathiR03 # v1.37 Comms Lead
     - tallclair # Auth
     - thockin # Network
-    - TineoC #v1.37 Release Comms Shadow
+    - TineoC # v1.37 Release Comms Shadow
     - towca # Autoscaling
     - troy0820 #v1.37 Release Comms Shadow
     - upodroid # K8s Infra

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -113,7 +113,7 @@ teams:
     - thockin # Network
     - TineoC # v1.37 Release Comms Shadow
     - towca # Autoscaling
-    - troy0820 #v1.37 Release Comms Shadow
+    - troy0820 # v1.37 Release Comms Shadow
     - upodroid # K8s Infra
     - Verolop # Release Manager
     - whtssub # v1.37 Enhancements Lead

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -285,7 +285,7 @@ teams:
         - justaugustus # subproject owner / Chair
         - katcosgrove # 1.30 Lead / 1.32 EA
         - kernel-kun # v1.37 Docs Lead
-        - kirti763 #v1.37 Release Comms Shadow
+        - kirti763 # v1.37 Release Comms Shadow
         - mickeyboxell # 1.32 Release Manager Shadow
         - Prajyot-Parab  # v1.37 Release Lead Shadow
         - puerco # subproject owner / Technical Lead


### PR DESCRIPTION
*Added Comms shadows under the release-team, release-comms and milestone-maintainers.

Ref: https://github.com/kubernetes/sig-release/issues/3027