### PR TITLE
Add 1.37 docs team to website-milestone-maintainers, release-team-docs

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -337,12 +337,15 @@ teams:
     - a-mccarthy
     - ArvindParekh
     - bene2k1
-    - dipesh-rawat    
+    - Caesarsage
+    - chadmcrowell
+    - dipesh-rawat
     - divya-mohan0209
     - girikuncoro
     - huynguyennovem
     - inductor
     - jcjesus
+    - jmickey
     - kernel-kun
     - lmktfy
     - michellengnx
@@ -362,8 +365,10 @@ teams:
     - sayanchowdhury
     - seokho-son
     - shurup
+    - singh1203
     - tengqm
     - truongnh1992
     - xichengliudui
+    - yashasvimisra2798
     - yujen77300
     privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -305,7 +305,12 @@ teams:
           release-team-docs:
             description: Members of the Docs team for the current release cycle.
             members:
+            - Caesarsage # v1.37 Docs Shadow
+            - chadmcrowell # v1.37 Docs Shadow
+            - jmickey # v1.37 Docs Shadow
             - kernel-kun # v1.37 Docs Lead
+            - singh1203 # v1.37 Docs Shadow
+            - yashasvimisra2798 # v1.37 Docs Shadow
             privacy: closed
           release-team-comms:
             description: Members of the Comms team for the current release cycle.


### PR DESCRIPTION
This PR adds 1.37 docs team shadows to the appropriate groups i.e website-milestone-maintainers, release-team-docs.

/cc @katcosgrove @fsmunoz @dipesh-rawat 