### PR TITLE
Update PRR shadows for 1.37 cycle

### DIFF
--- a/config/kubernetes/sig-architecture/teams.yaml
+++ b/config/kubernetes/sig-architecture/teams.yaml
@@ -94,13 +94,20 @@ teams:
       prod-readiness-reviewers:
         description: Production Readiness Reviewers
         members:
-        - aramase       # shadow
-        - deads2k       # approver
-        - johnbelamaric # approver
-        - jpbetz        # approver
-        - kannon92      # approver
-        - sohankunkerkar # shadow
-        - soltysh       # approver
-        - stlaz         # shadow
-        - wojtek-t      # approver
+        - ameukam            # shadow
+        - champbreed         # shadow
+        - deads2k            # approver
+        - jefftree           # shadow
+        - johnbelamaric      # approver
+        - jpbetz             # approver
+        - jyotimahapatra     # shadow
+        - kannon92           # approver
+        - kfess              # shadow
+        - omerap12           # shadow
+        - ShaanveerS         # shadow
+        - sohankunkerkar     # shadow
+        - soltysh            # approver
+        - stlaz              # shadow
+        - wojtek-t           # approver
+        - x0rw               # shadow
         privacy: closed


### PR DESCRIPTION
Following May 27th PRR call (https://docs.google.com/document/d/10QkXwiZfBL7wBKHHFslooXvGDKHA75jkkgiIXuKFryM/edit?tab=t.0) this updates the PRR shadows for 1.37 cycle. 

/assign @johnbelamaric 