### PR TITLE
Add new teams in k8s and k8s-sigs orgs for WG WAS leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -167,6 +167,11 @@ aliases:
   wg-structured-logging-leads:
     - pohly
     - serathius
+  wg-workload-aware-scheduling-leads:
+    - andreyvelich
+    - helayoty
+    - kannon92
+    - mm4tt
   committee-code-of-conduct:
     - AnaMMedina21
     - endocrimes

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -639,6 +639,7 @@ members:
 - mlavacca
 - mloiseleur
 - mloskot
+- mm4tt
 - mmerkes
 - mnaser
 - mneverov

--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -380,6 +380,7 @@ members:
 - harshanarayana
 - HarshithaMS005
 - hectorj2f
+- helayoty
 - helen-frank
 - Henrywu573
 - heyste

--- a/config/kubernetes-sigs/wg-workload-aware-scheduling/OWNERS
+++ b/config/kubernetes-sigs/wg-workload-aware-scheduling/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - wg-workload-aware-scheduling-leads
+approvers:
+  - wg-workload-aware-scheduling-leads
+labels:
+  - wg/workload-aware-scheduling

--- a/config/kubernetes-sigs/wg-workload-aware-scheduling/teams.yaml
+++ b/config/kubernetes-sigs/wg-workload-aware-scheduling/teams.yaml
@@ -1,0 +1,9 @@
+teams:
+  wg-workload-aware-scheduling-leads:
+    description: ""
+    members:
+    - andreyvelich
+    - helayoty
+    - kannon92
+    - mm4tt
+    privacy: closed

--- a/config/kubernetes/wg-workload-aware-scheduling/OWNERS
+++ b/config/kubernetes/wg-workload-aware-scheduling/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - wg-workload-aware-scheduling-leads
+approvers:
+  - wg-workload-aware-scheduling-leads
+labels:
+  - wg/workload-aware-scheduling

--- a/config/kubernetes/wg-workload-aware-scheduling/teams.yaml
+++ b/config/kubernetes/wg-workload-aware-scheduling/teams.yaml
@@ -1,0 +1,9 @@
+teams:
+  wg-workload-aware-scheduling-leads:
+    description: ""
+    members:
+    - andreyvelich
+    - helayoty
+    - kannon92
+    - mm4tt
+    privacy: closed


### PR DESCRIPTION
- Add new GitHub team `wg-workload-aware-scheduling-leads` to kubernetes and kubernetes-sigs orgs.
- Add each of @helayoty and @mm4tt as members to the kubernetes-sigs org since both are existing members of Kubernetes org.

/wg workload-aware-scheduling