### PR TITLE
Add AwesomePatrol to kubernetes

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -135,6 +135,7 @@ members:
 - AutuSnow
 - AverageMarcus
 - avni-mahajan
+- AwesomePatrol
 - AxeZhan
 - azaynul10
 - azylinski


### PR DESCRIPTION
I am already a member of `etcd-io`: https://github.com/kubernetes/org/issues/5824

Per the guideline adding myself to the org directly so I can continue work on kubernetes side.