### PR TITLE
Add Champbreed to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -178,6 +178,7 @@ members:
 - cemakd
 - chadmcrowell
 - chadswen
+- Champbreed
 - champtar
 - chandankumar4
 - changminbark


### PR DESCRIPTION
Adds @Champbreed to kubernetes-sigs because he's now working in slack-infra repo.

Simon is already a Kubernetes org member.