### PR TITLE
Allow sig-auth-triage to edit comments

### DIFF
--- a/config/kubernetes/sig-auth/teams.yaml
+++ b/config/kubernetes/sig-auth/teams.yaml
@@ -76,4 +76,4 @@ teams:
     - stlaz
     privacy: closed
     repos:
-      enhancements: triage
+      enhancements: write


### PR DESCRIPTION
> Edit and delete anyone's comments on commits, pull requests, and issues

`write` is the minimum permission that allows this.