### PR TITLE
sig-network: remove teams related to kubernetes-sigs/ingate

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -139,21 +139,6 @@ teams:
     - maintainers-external-dns
     repos:
       external-dns: write
-  ingate-admins:
-    description: Admin access to the ingate repo
-    members:
-    - strongjz
-    privacy: closed
-    repos:
-      ingate: admin
-  ingate-maintainers:
-    description: Write access to the ingate repo
-    members:
-    - strongjz
-    - tao12345666333
-    privacy: closed
-    repos:
-      ingate: write
   ingress2gateway-admins:
     description: Admin access to the ingress2gateway repo
     members:

--- a/config/restrictions.yaml
+++ b/config/restrictions.yaml
@@ -290,7 +290,6 @@ restrictions:
     - "^gwctl"
     - "^ip-masq-agent"
     - "^external-dns"
-    - "^ingate"
     - "^ingress2gateway"
     - "^ingress-controller-conformance"
     - "^iptables-wrappers"


### PR DESCRIPTION
Part of #6230

/assign @kubernetes/owners @kubernetes/sig-network-leads 