### PR TITLE
kubernete-sigs: add teams for gateway-api-conformance-images

### DIFF
--- a/config/kubernetes-sigs/sig-network/teams.yaml
+++ b/config/kubernetes-sigs/sig-network/teams.yaml
@@ -238,6 +238,27 @@ teams:
     - service-apis-amintainers
     repos:
       gateway-api: write
+  gateway-api-conformance-images-admins:
+    description: Admin access to the gateway-api-conformance-images repo
+    members:
+    - rikatz
+    - robscott
+    - youngnick
+    privacy: closed
+    repos:
+      gateway-api-conformance-images: admin
+  gateway-api-conformance-images-maintainers:
+    description: Write access to the gateway-api-conformance-images repo
+    members:
+    - bexxmodd
+    - davidjumani
+    - kflynn
+    - rikatz
+    - robscott
+    - youngnick
+    privacy: closed
+    repos:
+      gateway-api-conformance-images: write
   gateway-api-release-team:
     description: Gateway API Release Team
     members:


### PR DESCRIPTION
Part of #6454 

/assign @kubernetes/owners @kubernetes/sig-network-leads 