### PR TITLE
Remove year from copyright header boilerplate

### DIFF
--- a/hack/boilerplate/boilerplate.Dockerfile.txt
+++ b/hack/boilerplate/boilerplate.Dockerfile.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.Makefile.txt
+++ b/hack/boilerplate/boilerplate.Makefile.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.go.txt
+++ b/hack/boilerplate/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright YEAR The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.py.txt
+++ b/hack/boilerplate/boilerplate.py.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.sh.txt
+++ b/hack/boilerplate/boilerplate.sh.txt
@@ -1,4 +1,4 @@
-# Copyright YEAR The Kubernetes Authors.
+# Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.tf.txt
+++ b/hack/boilerplate/boilerplate.tf.txt
@@ -1,5 +1,5 @@
 /*
-Copyright YEAR The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/boilerplate/verify_boilerplate.py
+++ b/hack/boilerplate/verify_boilerplate.py
@@ -135,15 +135,10 @@ def file_passes(filename, refs, regexs):  # pylint: disable=too-many-locals
     # trim our file to the same number of lines as the reference file
     data = data[:len(ref)]
 
-    year = regexs["year"]
-    for datum in data:
-        if year.search(datum):
-            return False
-
-    # Replace all occurrences of the regex "2017|2016|2015|2014" with "YEAR"
+    # Remove all occurrences of the year (regex "Copyright (2014|2015|2016|2017|2018) ")
     when = regexs["date"]
     for idx, datum in enumerate(data):
-        (data[idx], found) = when.subn('YEAR', datum)
+        (data[idx], found) = when.subn('Copyright ', datum)
         if found != 0:
             break
 
@@ -218,16 +213,18 @@ def get_files(extensions):
 
 
 def get_dates():
-    years = datetime.datetime.now().year
-    return '(%s)' % '|'.join((str(year) for year in range(2014, years + 1)))
+    # After 2025, we no longer allow new files to include the year in the copyright header.
+    final_year = 2025
+    return ' (%s) ' % '|'.join((str(year) for year in range(2014, final_year + 1)))
 
 
 def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile('YEAR')
-    # dates can be any year between 2014 and the current year, company holder names can be anything
-    regexs["date"] = re.compile(get_dates())
+    # get_dates return 2014, 2015, 2016, 2017, ..., 2025
+    # as a regex like: "(2014|2015|2016|2017|2018|...|2025)";
+    regexs["date"] = re.compile('Copyright' + get_dates())
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(
         r"^(// \+build.*\n)+\n", re.MULTILINE)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Per kubernetes/steering#299, we no longer need to include the year in the
copyright header. This PR removes the requirement from
`hack/boilerplate/verify_boilerplate.py` and updates the boilerplate
templates to drop the `YEAR` placeholder, mirroring
kubernetes/kubernetes#134835.

This also caps the allowed years at 2025, so new files can no longer be
added with a year (or a year >= 2026) in the copyright header.

#### Which issue(s) this PR is related to:

Related to kubernetes/steering#299

#### Does this PR introduce a user-facing change?

```release-note
NONE
```