### PR TITLE
Add yankay to lws teams in kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/sig-apps/teams.yaml
+++ b/config/kubernetes-sigs/sig-apps/teams.yaml
@@ -111,6 +111,7 @@ teams:
     - ahg-g
     - edwinhr716
     - kerthcet
+    - yankay
     privacy: closed
     repos:
       lws: admin
@@ -120,6 +121,7 @@ teams:
     - ahg-g
     - edwinhr716
     - kerthcet
+    - yankay
     privacy: closed
     repos:
       lws: write


### PR DESCRIPTION
## Summary

Add `yankay` to the `lws-admins` and `lws-maintainers` teams in `kubernetes-sigs`.

I am listed as an approver in the LWS [OWNERS](https://github.com/kubernetes-sigs/lws/blob/main/OWNERS) file.

I would also like to ask whether we can enable GitHub Copilot capabilities for `kubernetes-sigs/lws`, including automatic Copilot code review requests for new PRs like https://github.com/kubernetes-sigs/jobset .