### PR TITLE
Add 1.37 branch management shadows to milestone-maintainers

### DIFF
--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -54,6 +54,7 @@ teams:
     - janetkuo # Apps
     - jberkus # Etcd
     - jbpratt # Testing
+    - jenshu # v1.37 Release Branch Management Shadow
     - jeremyrickard # Release
     - jimangel # Docs / Release Manager Associate / 1.32 Release Branch Manager
     - joaquimrocha # UI
@@ -101,6 +102,7 @@ teams:
     - richabanker # Instrumentation
     - RinkiyaKeDad # v1.37 Release Comms Shadow
     - ritazh # Auth
+    - rytswd # v1.37 Release Branch Management Shadow
     - saad-ali # Storage
     - salaxander # Release Manager Associate / 1.29 RT EA
     - sanposhiho # Scheduling


### PR DESCRIPTION
Add the 1.37 Branch Management shadows to the `milestone-maintainers` team so that they can use the `/milestone` command on release cut issues (https://github.com/kubernetes/sig-release/issues/3053 for example)

cc @aibarbetta @dipesh-rawat 