### PR TITLE
Add tiny-li to sig-docs-zh-reviews

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -254,6 +254,7 @@ teams:
     - SataQiu
     - Sea-n
     - tengqm
+    - tiny-li
     - windsonsea
     - xichengliudui
     - ydFu


### PR DESCRIPTION
I want to join the sig-docs-zh-reviews team.

I have met the [requirements for reviewer](https://github.com/kubernetes/community/blob/master/community-membership.md#reviewer):

-  Member of Kubernetes for 3+ months
- 60+ PRs reviewed:https://github.com/kubernetes/website/pulls?q=is%3Apr+reviewed-by%3Atiny-li
- PRs merged: https://github.com/kubernetes/website/pulls?q=is%3Apr+is%3Amerged+author%3Atiny-li

Thanks