### PR TITLE
Add yuzhiquan to kubernetes-sigs org

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -1108,6 +1108,7 @@ members:
 - yuluo-yx
 - yussufsh
 - yuwenma
+- yuzhiquan
 - z1cheng
 - zac-nixon
 - zetxqx


### PR DESCRIPTION
Existing kubernetes org member: https://github.com/kubernetes/org/blob/e9e3d83261aa81f48a3c89a7daf3f6cc5c6b5fbf/config/kubernetes/org.yaml#L1250

Per the [community membership guidelines](https://github.com/kubernetes/community/blob/master/community-membership.md#kubernetes-github-organizations), members of one Kubernetes GitHub organization are implicitly eligible for the others and may request access via a direct PR.

I am currently working on [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox), where I have authored:

- kubernetes-sigs/agent-sandbox#1339 — `feat(mcp): add /healthz and /readyz probe endpoints`
- kubernetes-sigs/agent-sandbox#1329 — `feat(mcp): add list_files and file_exists tools`
- kubernetes-sigs/agent-sandbox#1291 — `feat(api): mirror backing pod's PodScheduled condition into Sandbox status`
- kubernetes-sigs/agent-sandbox#1290 — `feat(warmpool): configurable readiness grace period and unschedulable re-check interval`
- kubernetes-sigs/agent-sandbox#1293 — issue: `SandboxWarmPool: per-pool spec override for readiness grace period and unschedulable re-check interval`

Membership in the kubernetes-sigs org would let me participate more directly in the repo, including having tests run on my PRs without needing `/ok-to-test` each time.