### PR TITLE
Add damikag to kubernetes-sigs

### DIFF
--- a/config/kubernetes-sigs/org.yaml
+++ b/config/kubernetes-sigs/org.yaml
@@ -233,6 +233,7 @@ members:
 - damdo
 - damemi
 - DamianSawicki
+- damikag
 - damsien
 - danehans
 - danielvegamyhre


### PR DESCRIPTION
I'm a member of Kubernetes org in https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler. We're migrating to a separate repository in kubernetes-sigs org (https://github.com/kubernetes-sigs/cluster-autoscaler), so I need to propagate my membership.