### PR TITLE
Add sohankunkerkar to kueue-maintainers team

### DIFF
--- a/config/kubernetes-sigs/sig-scheduling/teams.yaml
+++ b/config/kubernetes-sigs/sig-scheduling/teams.yaml
@@ -88,8 +88,8 @@ teams:
   kueue-maintainers:
     description: Write access to the kueue repo
     members:
-    - gabesaba
     - mimowo
+    - sohankunkerkar
     - tenzen-y
     privacy: closed
     repos:


### PR DESCRIPTION
Add sohankunkerkar to the kueue-maintainers team (write access) following full approver nomination in kubernetes-sigs/kueue#13927.

/sig scheduling