### PR TITLE
sig-scalability: add Bslabe123, jjk-g, lenadankin to inference-perf-maintainers

### DIFF
--- a/config/kubernetes-sigs/sig-scalability/teams.yaml
+++ b/config/kubernetes-sigs/sig-scalability/teams.yaml
@@ -13,6 +13,9 @@ teams:
     description: Write access to the inference-perf repo
     members:
     - achandrasekar
+    - Bslabe123
+    - jjk-g
+    - lenadankin
     - SachinVarghese
     - terrytangyuan
     - wangchen615


### PR DESCRIPTION
Brings kubernetes/org in line with inference-perf's [OWNERS_ALIASES](https://github.com/kubernetes-sigs/inference-perf/blob/main/OWNERS_ALIASES), which already lists these three under `inference-perf-maintainers`.

/cc @achandrasekar @SachinVarghese @wangchen615 @terrytangyuan @jjk-g @lenadankin
/area github-management
