### PR TITLE
Add gambtho to headlamp-reviewers team

### DIFF
--- a/config/kubernetes-sigs/sig-ui/teams.yaml
+++ b/config/kubernetes-sigs/sig-ui/teams.yaml
@@ -19,6 +19,7 @@ teams:
     description: Triage access to the headlamp repo
     members:
     - ashu8912
+    - gambtho
     - knrt10
     - skoeva
     - vyncent-t


### PR DESCRIPTION
Adds `gambtho` to the `headlamp-reviewers` team for `kubernetes-sigs/headlamp`.

I've been a reviewer in the headlamp repo's `OWNERS_ALIASES` since kubernetes-sigs/headlamp#6406 (merged 2026-07-06), but I'm not a member of any headlamp GitHub team, so I currently have no permissions on the repo — not even triage.

Existing kubernetes-sigs org member.

/sig ui
/assign @joaquimrocha
