### PR TITLE
Add ekam-walia to Kubernetes Org

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -333,6 +333,7 @@ members:
 - eduartua
 - Edwinhr716
 - ehashman
+- ekam-walia
 - Elbehery
 - electrocucaracha
 - elevran


### PR DESCRIPTION
I want to become Kubernetes member to self test https://github.com/kubernetes/test-infra for https://github.com/kubernetes-sigs/kueue

I am already Kubernetes-sigs org member

https://github.com/kubernetes/org/blob/96d44c144f6593eb79f590dc7414b0e802a95208/config/kubernetes-sigs/org.yaml#L293