### PR TITLE
Add kernel-kun to the website-maintainers for v1.37 release

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -310,6 +310,7 @@ teams:
     - inductor # L10n: Japanese
     - jcjesus # L10n: Portuguese
     - katcosgrove # L10n: English
+    - kernel-kun # v1.37 Release Docs Lead
     - kfess # L10n: Japanese
     - lmktfy # Emeritus tech lead
     - mfilocha # L10n: Polish


### PR DESCRIPTION
Temporarily adding myself (`kernel-kun`) to the website-maintainers team for write access to `k/website` repo in preparation to the v1.37 Release Day tasks.

/assign @reylejano