### PR TITLE
add Tomy2e to kubernetes

### DIFF
--- a/config/kubernetes/org.yaml
+++ b/config/kubernetes/org.yaml
@@ -1149,6 +1149,7 @@ members:
 - tokt
 - tomasaschan
 - TommyStarK
+- Tomy2e
 - torredil
 - TortillaZHawaii
 - tosi3k


### PR DESCRIPTION
I'm already a member of the `kubernetes-sigs` org and I need to join `kubernetes` to be added as an OWNER on the Scaleway provider part of the autoscaler project (https://github.com/kubernetes/autoscaler/pull/10185).