### PR TITLE
Remove v1.37 shadows from sig docs team

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -363,7 +363,6 @@ teams:
     - ryan-su-12
     - salaxander
     - SataQiu
-    - sayanchowdhury
     - seokho-son
     - shurup
     - tengqm

--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -310,7 +310,6 @@ teams:
     - inductor # L10n: Japanese
     - jcjesus # L10n: Portuguese
     - katcosgrove # L10n: English
-    - kernel-kun # v1.37 Release Docs Lead
     - kfess # L10n: Japanese
     - lmktfy # Emeritus tech lead
     - mfilocha # L10n: Polish
@@ -341,14 +340,12 @@ teams:
     - ArvindParekh
     - bene2k1
     - Caesarsage
-    - chadmcrowell
     - dipesh-rawat
     - divya-mohan0209
     - girikuncoro
     - huynguyennovem
     - inductor
     - jcjesus
-    - jmickey
     - katcosgrove
     - kernel-kun
     - lmktfy
@@ -369,10 +366,8 @@ teams:
     - sayanchowdhury
     - seokho-son
     - shurup
-    - singh1203
     - tengqm
     - truongnh1992
     - xichengliudui
-    - yashasvimisra2798
     - yujen77300
     privacy: closed


### PR DESCRIPTION
- Remove me from `website-maintainers`
- Remove v1.37 shadows except for Destiny (v1.38 release docs lead) from `website-milestone-maintainers`

cc @kubernetes/sig-docs-leads @Caesarsage 