### PR TITLE
Add v1.38 lead and  shadows from sig docs team

### DIFF
--- a/config/kubernetes/sig-docs/teams.yaml
+++ b/config/kubernetes/sig-docs/teams.yaml
@@ -21,7 +21,7 @@ teams:
   sig-docs-en-owners:
     description: Approvers for English content
     members:
-    - dipesh-rawat  
+    - dipesh-rawat
     - divya-mohan0209
     - katcosgrove
     - lmktfy
@@ -87,7 +87,7 @@ teams:
     description: PR reviews for Hindi content
     members:
     - bishal7679
-    - dipesh-rawat    
+    - dipesh-rawat
     - divya-mohan0209
     - jayeshmahajan
     - niranjandarshann
@@ -304,7 +304,8 @@ teams:
     members:
     - a-mccarthy # Localization subproject owner
     - bells17 # L10n: Japanese
-    - dipesh-rawat # L10n: English    
+    - Caesarsage # v1.38 Release Docs Lead
+    - dipesh-rawat # L10n: English
     - divya-mohan0209 # L10n: English
     - girikuncoro # L10n: Indonesian
     - huynguyennovem # L10n: Vietnamese # L10n: Korean
@@ -338,9 +339,12 @@ teams:
     description: Contributors who can use `/milestone` in the website repo
     members:
     - a-mccarthy
+    - abalso0 # v1.38 Release Docs Shadow
+    - AnshumanTripathi # v1.38 Release Docs Shadow
     - ArvindParekh
     - bene2k1
-    - Caesarsage
+    - Caesarsage # v1.38 Release Docs Lead
+    - ChieloChi # v1.38 Release Docs Shadow
     - dipesh-rawat
     - divya-mohan0209
     - girikuncoro
@@ -368,6 +372,8 @@ teams:
     - shurup
     - tengqm
     - truongnh1992
+    - whtssub # v1.38 Release Docs Shadow
     - xichengliudui
+    - yashasvimisra2798 # v1.38 Release Docs Shadow
     - yujen77300
     privacy: closed

--- a/config/kubernetes/sig-release/teams.yaml
+++ b/config/kubernetes/sig-release/teams.yaml
@@ -315,7 +315,12 @@ teams:
           release-team-docs:
             description: Members of the Docs team for the current release cycle.
             members:
+            - abalso0 # v1.38 Release Docs Shadow
+            - AnshumanTripathi # v1.38 Release Docs Shadow
             - Caesarsage # v1.38 Docs Lead
+            - ChieloChi # v1.38 Release Docs Shadow
+            - whtssub # v1.38 Release Docs Shadow
+            - yashasvimisra2798 # v1.38 Release Docs Shadow
             privacy: closed
           release-team-comms:
             description: Members of the Comms team for the current release cycle.


### PR DESCRIPTION
This PR adds 1.38 docs team lead and shadows to the appropriate groups i.e website-milestone-maintainers, release-team-docs.

/cc @sreeram-venkitesh @katcosgrove @fsmunoz 